### PR TITLE
Merge pull request #47 from jellydn/openai-adapter-zai

### DIFF
--- a/src/providers/zai.ts
+++ b/src/providers/zai.ts
@@ -1,208 +1,40 @@
-import OpenAI from "openai";
 import type { ModelCapabilities } from "./capabilities.js";
 import { supportsThinking as modelRegistrySupportsThinking } from "./model-registry.js";
 import { getModelCapabilitiesFromCatalog } from "./models-dev.js";
-import type { ChatOptions, ChatResponse, LLMClient, Message, StreamChunk, ToolCall, ToolDefinition } from "./types.js";
+import type { OpenAIProviderConfig } from "./openai.js";
+import { OpenAIProvider } from "./openai.js";
 
 export interface ZaiProviderConfig {
 	apiKey?: string;
 	baseUrl?: string;
 }
 
-type OpenAIMessage = OpenAI.Chat.ChatCompletionMessageParam;
-type OpenAITool = OpenAI.Chat.ChatCompletionTool;
+const ZAI_BASE_URL = "https://api.z.ai/api/paas/v4/";
 
-function convertMessages(messages: Message[]): OpenAIMessage[] {
-	return messages.map((msg): OpenAIMessage => {
-		if (msg.role === "tool") {
-			return {
-				role: "tool",
-				content: msg.content,
-				tool_call_id: msg.toolCallId ?? "",
-			};
-		}
-
-		if (msg.role === "assistant" && msg.toolCalls?.length) {
-			return {
-				role: "assistant",
-				content: msg.content || null,
-				tool_calls: msg.toolCalls.map((tc) => ({
-					id: tc.id,
-					type: "function" as const,
-					function: {
-						name: tc.name,
-						arguments: JSON.stringify(tc.arguments),
-					},
-				})),
-			};
-		}
-
-		return {
-			role: msg.role as "system" | "user" | "assistant",
-			content: msg.content,
-		};
-	});
-}
-
-function convertTools(tools: ToolDefinition[]): OpenAITool[] {
-	return tools.map((tool) => ({
-		type: "function" as const,
-		function: {
-			name: tool.name,
-			description: tool.description,
-			parameters: tool.parameters,
-		},
-	}));
-}
-
-function parseToolCalls(toolCalls?: OpenAI.Chat.ChatCompletionMessageToolCall[]): ToolCall[] | undefined {
-	if (!toolCalls?.length) return undefined;
-
-	return toolCalls
-		.filter((tc): tc is OpenAI.Chat.ChatCompletionMessageToolCall & { type: "function" } => tc.type === "function")
-		.map((tc) => {
-			try {
-				return {
-					id: tc.id,
-					name: tc.function.name,
-					arguments: JSON.parse(tc.function.arguments || "{}"),
-				};
-			} catch (err) {
-				console.warn(`[ZaiProvider] Failed to parse tool arguments for ${tc.function.name}: ${err}`);
-				return {
-					id: tc.id,
-					name: tc.function.name,
-					arguments: {},
-				};
-			}
-		});
-}
-
-function mapFinishReason(reason: string | null): ChatResponse["finishReason"] {
-	switch (reason) {
-		case "stop":
-			return "stop";
-		case "tool_calls":
-			return "tool_calls";
-		case "length":
-			return "length";
-		default:
-			return "stop";
-	}
-}
-
-export class ZaiProvider implements LLMClient {
-	private _client: OpenAI;
-	private _capabilitiesCache = new Map<string, ModelCapabilities>();
+/**
+ * Zai (z.ai / Zhipu) is an OpenAI-compatible endpoint with a different base
+ * URL and its own per-model context-window fallback. Inherits chat(), stream()
+ * and the tool-call buffering from `OpenAIProvider`; only `getCapabilities`
+ * carries zai-specific behavior (catalog lookup keyed under "zai", then a
+ * hardcoded GLM-4.x context-window map as a final fallback).
+ */
+export class ZaiProvider extends OpenAIProvider {
+	private _zaiCapabilitiesCache = new Map<string, ModelCapabilities>();
 
 	constructor(config: ZaiProviderConfig) {
-		this._client = new OpenAI({
-			apiKey: config.apiKey,
-			baseURL: config.baseUrl ?? "https://api.z.ai/api/paas/v4/",
-		});
+		super({
+			apiKey: config.apiKey ?? "",
+			baseUrl: config.baseUrl ?? ZAI_BASE_URL,
+		} satisfies OpenAIProviderConfig);
 	}
 
-	async chat(options: ChatOptions): Promise<ChatResponse> {
-		const requestBody = {
-			model: options.model,
-			messages: convertMessages(options.messages),
-			tools: options.tools?.length ? convertTools(options.tools) : undefined,
-			temperature: options.temperature,
-			max_tokens: options.maxTokens,
-			reasoning_effort: options.thinking?.effort,
-		} as Record<string, unknown>;
-		const response = await this._client.chat.completions.create(
-			requestBody as unknown as OpenAI.Chat.ChatCompletionCreateParamsNonStreaming,
-			{ signal: options.signal }
-		);
-
-		const choice = response.choices[0];
-		const message = choice?.message;
-
-		return {
-			content: message?.content ?? "",
-			toolCalls: parseToolCalls(message?.tool_calls),
-			finishReason: mapFinishReason(choice?.finish_reason ?? null),
-		};
-	}
-
-	async *stream(options: ChatOptions): AsyncGenerator<StreamChunk, void, unknown> {
-		const requestBody = {
-			model: options.model,
-			messages: convertMessages(options.messages),
-			tools: options.tools?.length ? convertTools(options.tools) : undefined,
-			temperature: options.temperature,
-			max_tokens: options.maxTokens,
-			stream: true,
-			reasoning_effort: options.thinking?.effort,
-		} as Record<string, unknown>;
-		const stream = await this._client.chat.completions.create(
-			requestBody as unknown as OpenAI.Chat.ChatCompletionCreateParamsStreaming,
-			{ signal: options.signal }
-		);
-
-		const toolCallsBuffer: Map<number, { id: string; name: string; args: string }> = new Map();
-
-		for await (const chunk of stream) {
-			const delta = chunk.choices[0]?.delta;
-			const finishReason = chunk.choices[0]?.finish_reason;
-
-			if (delta?.tool_calls) {
-				for (const tc of delta.tool_calls) {
-					const existing = toolCallsBuffer.get(tc.index) ?? { id: "", name: "", args: "" };
-					if (tc.id) existing.id = tc.id;
-					if (tc.function?.name) existing.name = tc.function.name;
-					if (tc.function?.arguments) existing.args += tc.function.arguments;
-					toolCallsBuffer.set(tc.index, existing);
-				}
-			}
-
-			if (delta?.content) {
-				yield {
-					content: delta.content,
-					done: false,
-				};
-			}
-
-			if (finishReason) {
-				const toolCalls: ToolCall[] | undefined =
-					toolCallsBuffer.size > 0
-						? Array.from(toolCallsBuffer.values()).map((tc) => {
-								try {
-									return {
-										id: tc.id,
-										name: tc.name,
-										arguments: JSON.parse(tc.args || "{}"),
-									};
-								} catch (err) {
-									console.warn(`[ZaiProvider] Failed to parse streamed tool arguments for ${tc.name}: ${err}`);
-									return {
-										id: tc.id,
-										name: tc.name,
-										arguments: {},
-									};
-								}
-							})
-						: undefined;
-
-				yield {
-					toolCalls,
-					done: true,
-				};
-				return;
-			}
-		}
-
-		yield { done: true };
-	}
-
-	async getCapabilities(model: string): Promise<ModelCapabilities> {
-		const cached = this._capabilitiesCache.get(model);
+	override async getCapabilities(model: string): Promise<ModelCapabilities> {
+		const cached = this._zaiCapabilitiesCache.get(model);
 		if (cached) return cached;
 
 		const catalogCapabilities = getModelCapabilitiesFromCatalog(model, "zai");
 		if (catalogCapabilities) {
-			this._capabilitiesCache.set(model, catalogCapabilities);
+			this._zaiCapabilitiesCache.set(model, catalogCapabilities);
 			return catalogCapabilities;
 		}
 
@@ -233,7 +65,7 @@ export class ZaiProvider implements LLMClient {
 			source: "fallback",
 		};
 
-		this._capabilitiesCache.set(model, capabilities);
+		this._zaiCapabilitiesCache.set(model, capabilities);
 		return capabilities;
 	}
 }


### PR DESCRIPTION
The previous zai.ts duplicated convertMessages / convertTools / parseToolCalls /
mapFinishReason and the tool-call-buffering loop from openai.ts (~225 lines).
With the OpenAIProtocol deep module landed on Layer 1, ZaiProvider extends
OpenAIProvider with the z.ai base URL and overrides only getCapabilities
(zai-specific catalog lookup + GLM-4.x hardcoded context-window fallback).

File shrinks ~73% (280 → 75 lines). No public-surface change to factory.ts.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>