### PR TITLE
Merge pull request #48 from jellydn/openai-adapter-opencode

### DIFF
--- a/src/providers/opencode.ts
+++ b/src/providers/opencode.ts
@@ -1,6 +1,6 @@
 import type { ModelCapabilities } from "./capabilities.js";
 import { OpenAIProvider } from "./openai.js";
-import type { ChatOptions, ChatResponse, LLMClient, StreamChunk } from "./types.js";
+import type { ChatOptions, ChatResponse, StreamChunk } from "./types.js";
 
 export interface OpenCodeProviderConfig {
 	apiKey: string;
@@ -11,31 +11,29 @@ function stripPrefix(model: string): string {
 	return model.replace(/^opencode\//, "");
 }
 
-export class OpenCodeProvider implements LLMClient {
-	private _delegate: OpenAIProvider;
-
+/**
+ * OpenCode (opencode.ai) is an OpenAI-compatible endpoint whose model names
+ * are prefixed with `opencode/`. Inherits chat(), stream(), and tool-call
+ * buffering from `OpenAIProvider`; overrides each method to strip the
+ * prefix before delegating to super.
+ */
+export class OpenCodeProvider extends OpenAIProvider {
 	constructor(config: OpenCodeProviderConfig) {
-		this._delegate = new OpenAIProvider({
+		super({
 			apiKey: config.apiKey,
 			baseUrl: config.baseUrl || "https://opencode.ai/zen/v1",
 		});
 	}
 
-	async chat(options: ChatOptions): Promise<ChatResponse> {
-		return this._delegate.chat({
-			...options,
-			model: stripPrefix(options.model),
-		});
+	override async chat(options: ChatOptions): Promise<ChatResponse> {
+		return super.chat({ ...options, model: stripPrefix(options.model) });
 	}
 
-	async *stream(options: ChatOptions): AsyncGenerator<StreamChunk, void, unknown> {
-		yield* this._delegate.stream({
-			...options,
-			model: stripPrefix(options.model),
-		});
+	override async *stream(options: ChatOptions): AsyncGenerator<StreamChunk, void, unknown> {
+		yield* super.stream({ ...options, model: stripPrefix(options.model) });
 	}
 
-	async getCapabilities(model: string): Promise<ModelCapabilities> {
-		return this._delegate.getCapabilities(stripPrefix(model));
+	override async getCapabilities(model: string): Promise<ModelCapabilities> {
+		return super.getCapabilities(stripPrefix(model));
 	}
 }


### PR DESCRIPTION
The previous opencode.ts implemented the LLMClient interface via composition:
a `private _delegate: OpenAIProvider` member plus three methods that called
the delegate and applied stripPrefix. With the OpenAIProtocol deep module on
Layer 1, OpenCode can extend OpenAIProvider directly and inherit chat(),
stream(), and the tool-call buffering. Each override applies stripPrefix
before delegating to super, so `opencode/<id>` model names resolve to the
underlying OpenAI-compatible endpoint without a separate client instance.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>