### PR TITLE
fix(providers): make openrouter.ts look up capabilities from models.dev

### DIFF
--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -1,3 +1,5 @@
+import type { ModelCapabilities } from "./capabilities.js";
+import { getModelCapabilitiesFromCatalog } from "./models-dev.js";
 import { OpenAIProvider } from "./openai.js";
 
 export interface OpenRouterProviderConfig {
@@ -5,11 +7,38 @@ export interface OpenRouterProviderConfig {
 	baseUrl?: string;
 }
 
+/**
+ * OpenRouter is an OpenAI-compatible routing layer that fronts models from
+ * many underlying providers (anthropic, google, meta, mistralai, deepseek,
+ * etc.). Inherits chat(), stream(), and tool-call buffering from
+ * `OpenAIProvider` with the OpenRouter base URL.
+ *
+ * `getCapabilities` is overridden to look up entries from the models.dev
+ * catalog under the "openrouter" key, which carries proxied-upstream
+ * capabilities. Falls back to the inherited openai defaults for unknown
+ * models so callers still get sensible numbers (rather than 16k
+ * fallbacks) when the catalog does not know a particular id.
+ */
 export class OpenRouterProvider extends OpenAIProvider {
+	private _openrouterCapabilitiesCache = new Map<string, ModelCapabilities>();
+
 	constructor(config: OpenRouterProviderConfig) {
 		super({
 			apiKey: config.apiKey,
 			baseUrl: config.baseUrl || "https://openrouter.ai/api/v1",
 		});
+	}
+
+	override async getCapabilities(model: string): Promise<ModelCapabilities> {
+		const cached = this._openrouterCapabilitiesCache.get(model);
+		if (cached) return cached;
+
+		const catalogCapabilities = getModelCapabilitiesFromCatalog(model, "openrouter");
+		if (catalogCapabilities) {
+			this._openrouterCapabilitiesCache.set(model, catalogCapabilities);
+			return catalogCapabilities;
+		}
+
+		return super.getCapabilities(model);
 	}
 }


### PR DESCRIPTION
OpenRouter fronts models from many underlying providers (anthropic, google,
meta, mistralai, deepseek). Each entry is keyed in the models.dev catalog under
the "openrouter" provider, with proxied-upstream capabilities populated by
the catalog maintainers.

Before this layer, an OpenRouter-hosted model name (e.g.
"openrouter/anthropic/claude-3-5-sonnet") fell through to inherited
OpenAIProvider capabilities: it would not match any openai catalog entry,
not match the GPT hardcoded map, and resolve to a 16385 context-window
fallback. Override getCapabilities on this branch to look up the "openrouter"
catalog key first, cache the hit, and only fall back to super.getCapabilities
when the catalog does not know the model id.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>