### PR TITLE
feat(tools): add dryRun mode and delete_file tool to registry/file-tools

### DIFF
--- a/src/tools/file-tools.ts
+++ b/src/tools/file-tools.ts
@@ -33,6 +33,10 @@ const editFileArgsSchema = z.object({
 	replace_all: z.boolean().optional(),
 });
 
+const deleteFileArgsSchema = z.object({
+	path: z.string(),
+});
+
 const listDirectoryArgsSchema = z.object({
 	path: z.string(),
 	recursive: z.boolean().optional(),
@@ -401,4 +405,45 @@ async function listDir(dirPath: string, recursive: boolean, prefix = ""): Promis
 	return results;
 }
 
-export const fileTools: Tool[] = [readFileTool, writeFileTool, editFileTool, listDirectoryTool];
+export const deleteFileTool: Tool = {
+	name: "delete_file",
+	description:
+		"Delete a file. Refuses to remove sensitive files or paths outside the project root. Returns success if the file was deleted, or failure with a descriptive error otherwise.",
+	dangerous: "Will delete file",
+	parameters: {
+		type: "object",
+		properties: {
+			path: {
+				type: "string",
+				description: "The absolute or relative path to the file to delete",
+			},
+		},
+		required: ["path"],
+	},
+	async execute(args: Record<string, unknown>): Promise<ToolResult> {
+		const parsed = deleteFileArgsSchema.safeParse(args);
+		if (!parsed.success) {
+			return { success: false, error: `Invalid arguments: ${parsed.error.message}` };
+		}
+
+		const filePath = parsed.data.path;
+
+		const pathValidation = await validatePath(filePath, true);
+		if (!pathValidation.valid) {
+			return { success: false, error: pathValidation.error };
+		}
+
+		if (isSensitiveFile(filePath)) {
+			return { success: false, error: `Cannot delete sensitive file: ${filePath}` };
+		}
+
+		try {
+			await fs.unlink(filePath);
+			return { success: true, output: `Deleted ${filePath}` };
+		} catch (err) {
+			return handleFileError(filePath, err, "Failed to delete file");
+		}
+	},
+};
+
+export const fileTools: Tool[] = [readFileTool, writeFileTool, editFileTool, listDirectoryTool, deleteFileTool];

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -3,6 +3,25 @@ import type { AnthropicToolDef, OpenAIFunctionDef, Tool } from "./types.js";
 
 export class ToolRegistry {
 	private _tools: Map<string, Tool> = new Map();
+	private _dryRun: boolean = false;
+
+	/**
+	 * Enable or disable dry-run mode. When enabled, `execute` returns a synthetic
+	 * result for any tool flagged as `dangerous`, leaving the rest of the registry's
+	 * behavior (including non-dangerous tools like read_file/list_directory) intact.
+	 *
+	 * Why only dangerous tools: a dry-run that still runs `bash { command: "git status" }`
+	 * or `read_file` is the most useful agent shape — the user wants to see what the
+	 * plan would do, but exploration must continue to work. Mutating ops (write/edit/
+	 * delete/bash-destructive) are the ones that truly need to be simulated.
+	 */
+	setDryRun(enabled: boolean): void {
+		this._dryRun = enabled;
+	}
+
+	isDryRun(): boolean {
+		return this._dryRun;
+	}
 
 	register(tool: Tool): void {
 		if (this._tools.has(tool.name)) {
@@ -138,10 +157,33 @@ export class ToolRegistry {
 			return { success: false, error: `Tool "${name}" not found` };
 		}
 
+		if (this._dryRun && this.isDangerous(name, args)) {
+			const dangerLevel = this.getDangerLevel(name, args) ?? `Execute ${name}`;
+			const argsSummary = formatArgsSummary(args);
+			return {
+				success: true,
+				output: `[DRY-RUN] Would execute: ${dangerLevel} (tool=${name}, args=${argsSummary})`,
+			};
+		}
+
 		try {
 			return await tool.execute(args);
 		} catch (err) {
 			return { success: false, error: err instanceof Error ? err.message : String(err) };
 		}
 	}
+}
+
+function formatArgsSummary(args: Record<string, unknown>): string {
+	const entries = Object.entries(args);
+	if (entries.length === 0) return "{}";
+	const maxLen = 80;
+	const rendered = entries
+		.map(([k, v]) => {
+			const valueStr = typeof v === "string" ? v : JSON.stringify(v);
+			const truncated = valueStr.length > maxLen ? `${valueStr.slice(0, maxLen)}…` : valueStr;
+			return `${k}=${truncated}`;
+		})
+		.join(", ");
+	return `{ ${rendered} }`;
 }


### PR DESCRIPTION
Layer 1 of architecture-review Candidate 2 ("push tool execution into the
registry"). Two small additions:

- ToolRegistry.setDryRun(enabled) gates `execute`'s dangerous-tool path:
  when dryRun is true and the tool is `dangerous`, returns a synthetic
  "[DRY-RUN] Would execute: <danger> (tool=<name>, args={...})" result
  without invoking the underlying tool. Non-dangerous ops (read_file,
  list_directory, git status) still run so exploration continues to
  work in dry-run mode.

- New `deleteFileTool` (dangerous: "Will delete file") joins fileTools.
  Validates path with symlink check (parity with writeFileTool's
  defense and rejects sensitive targets before fs.unlink.

executeBatch, the agent-loop confirmation funnel, is intentionally
untouched at this layer to avoid scope creep; build-agent's
confirmation path will reuse the registry in Layer 2.
EOF
)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>