### PR TITLE
Merge pull request #56 from jellydn/build-agent-uses-grammar

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,9 @@
 export PATH="$HOME/.bun/bin:$PATH"
+
+# Ensure generated files are in sync before lint.
+bun run generate:skills
+git diff --exit-code src/skills/embedded-content.ts
+bun run generate:version
+git diff --exit-code src/utils/version-constant.ts
+
 bun run lint && bun run format:check

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,31 @@
+# Docs
+
+This directory holds durable documentation for `tiny-coding-agent`.
+
+## Architecture Decision Records (ADRs)
+
+ADRs capture *why* a decision was made, what alternatives were considered, and what the consequences are. They live in [`adr/`](adr/) and are numbered sequentially.
+
+| # | Title | Summary |
+|---|---|---|
+| 001 | [Project architecture](adr/001-project-architecture.md) | Overall layering and module boundaries. |
+| 002 | [LLM provider abstraction](adr/002-llm-provider-abstraction.md) | Why providers sit behind a common interface. |
+| 003 | [MCP client implementation](adr/003-mcp-client-implementation.md) | Adopting Model Context Protocol. |
+| 004 | [Context management handoff](adr/004-context-management-handoff.md) | When the agent hands off context between turns. |
+| 005 | [Tool system design](adr/005-tool-system-design.md) | `Tool` interface, registry, dangerous-routing. |
+| 006 | [Plugin system](adr/006-plugin-system.md) | Drop-in `.ts` plugins under `~/.tiny-agent/plugins/`. |
+| 007 | [Model registry pattern](adr/007-model-registry-pattern.md) | Single source of truth for model capabilities and pricing. |
+| 008 | [Memory system](adr/008-memory-system.md) | Persistent memory store and lifetime. |
+| 009 | [Tool confirmation](adr/009-tool-confirmation.md) | How dangerous ops get user confirmation before execution. |
+| 010 | [Ink CLI integration](adr/010-ink-cli-integration.md) | Why the CLI UI is React/Ink and how state flows. |
+| 011 | [Multi-agent system](adr/011-multi-agent-system.md) | plan / build / explore agents sharing a state file and `PlanGrammar`. |
+
+## Other Docs
+
+- [`development-tasks.md`](development-tasks.md) — current sprint / WIP tasks.
+
+## Related, Outside `docs/`
+
+- [`../AGENTS.md`](../AGENTS.md) — contributor conventions (naming, imports, error handling, testing).
+- [`../CLAUDE.md`](../CLAUDE.md) — Claude-specific notes for sessions in this repo.
+- [`../.planning/codebase/`](../.planning/codebase/) — generated codebase map (`STACK.md`, `ARCHITECTURE.md`, `STRUCTURE.md`, `CONVENTIONS.md`, `TESTING.md`, `INTEGRATIONS.md`, `CONCERNS.md`).

--- a/src/agents/build-agent.ts
+++ b/src/agents/build-agent.ts
@@ -5,6 +5,7 @@ import { createProvider, parseModelString } from "../providers/factory.js";
 import type { Message } from "../providers/types.js";
 import { findGitignorePatterns, isIgnored } from "../tools/gitignore.js";
 import { fileTools, ToolRegistry } from "../tools/index.js";
+import { type Step as GrammarStep, type Plan, parse as parsePlanGrammar } from "./plan-grammar.js";
 import { readStateFile, writeStateFile } from "./state.js";
 import type { StateFile } from "./types.js";
 
@@ -255,81 +256,83 @@ async function handleExecutionError(
 	return { action: decision.toLowerCase() as "retry" | "skip" | "abort" };
 }
 
+/**
+ * Convert a Plan returned by `PlanGrammar.parse` into the build-agent's
+ * `BuildStep[]` shape.
+ *
+ * Two shapes, picked automatically:
+ * - Phase-form: each Phase -> one BuildStep with multiple actions (one per
+ *   Step within the phase). Detected by the presence of a `## Phase ...`
+ *   marker in the raw text — the AST shape alone is ambiguous (a real
+ *   single-phase plan with sequentially-numbered sub-steps also produces
+ *   one phase with steps 1, 2, 3).
+ * - Flat-form (no phase headers, steps numbered 1, 2, 3, ... at top
+ *   level): each Step -> its own BuildStep.
+ *
+ * Legacy quirk: build-agent previously parsed sub-bullet `- text` lines
+ * under a numbered flat-form step as additional actions. The grammar
+ * doesn't include this shape, so we re-scan the raw text for those sub-
+ * bullets in flat-form mode to preserve backward compatibility.
+ */
+function planToBuildSteps(plan: Plan, rawText: string): BuildStep[] {
+	if (plan.phases.length === 0) {
+		return [];
+	}
+
+	const hasPhaseHeaders = /^\s*##\s*(?:Phase\s+)?\d+/m.test(rawText);
+
+	if (!hasPhaseHeaders) {
+		const flatPhase = plan.phases[0];
+		if (flatPhase) {
+			return buildFlatFormSteps(rawText, flatPhase.steps);
+		}
+	}
+
+	return plan.phases.map((phase) => ({
+		stepNumber: phase.number,
+		description: phase.title,
+		actions: phase.steps.map((step) => ({
+			type: "execute" as const,
+			description: step.text,
+		})),
+	}));
+}
+
+function buildFlatFormSteps(rawText: string, flatSteps: GrammarStep[]): BuildStep[] {
+	const result: BuildStep[] = [];
+	const lines = rawText.split("\n");
+	let currentBuild: BuildStep | null = null;
+
+	for (const line of lines) {
+		const stepMatch = line.match(/^\s*(\d+)\.\s+(.+?)\s*$/);
+		if (stepMatch) {
+			const n = parseInt(stepMatch[1] ?? "0", 10);
+			const text = (stepMatch[2] ?? "").trim();
+			const grammarStep = flatSteps.find((s) => s.number === n && s.text === text);
+			currentBuild = {
+				stepNumber: n,
+				description: grammarStep?.text ?? text,
+				actions: [{ type: "execute", description: text }],
+			};
+			result.push(currentBuild);
+			continue;
+		}
+
+		const bulletMatch = line.match(/^\s*-\s+(.+?)\s*$/);
+		if (bulletMatch && currentBuild) {
+			const text = (bulletMatch[1] ?? "").trim();
+			if (text && !text.startsWith("**")) {
+				currentBuild.actions.push({ type: "execute", description: text });
+			}
+		}
+	}
+
+	return result;
+}
+
 export function parsePlanToSteps(planContent: string): BuildStep[] {
-	const steps: BuildStep[] = [];
-	const phaseRegex = /## Phase (\d+)[:\s]+([^\n]+)/g;
-	let match: RegExpExecArray | null;
-
-	while ((match = phaseRegex.exec(planContent)) !== null) {
-		const stepNumberStr = match[1];
-		const descriptionStr = match[2];
-		if (!stepNumberStr || !descriptionStr) continue;
-
-		const stepNumber = parseInt(stepNumberStr, 10);
-		const description = descriptionStr.trim();
-
-		const stepsRegex = /(?:^|\n)(\d+)\.\s+([^\n]+)/g;
-		const actions: BuildAction[] = [];
-
-		let actionMatch: RegExpExecArray | null;
-		while ((actionMatch = stepsRegex.exec(planContent)) !== null) {
-			const actionNumStr = actionMatch[1];
-			const actionDescStr = actionMatch[2];
-			if (!actionNumStr || !actionDescStr) continue;
-
-			if (parseInt(actionNumStr, 10) === stepNumber) {
-				actions.push({
-					type: "execute",
-					description: actionDescStr.trim(),
-				});
-			}
-		}
-
-		steps.push({
-			stepNumber,
-			description,
-			actions,
-		});
-	}
-
-	if (steps.length === 0) {
-		const lines = planContent.split("\n");
-		let currentStep: BuildStep | null = null;
-
-		for (const line of lines) {
-			const stepMatch = line.match(/^(\d+)\.\s+(.+)$/);
-			if (stepMatch) {
-				const stepNumStr = stepMatch[1];
-				const stepDescStr = stepMatch[2];
-				if (!stepNumStr || !stepDescStr) continue;
-
-				if (currentStep) {
-					steps.push(currentStep);
-				}
-				currentStep = {
-					stepNumber: parseInt(stepNumStr, 10),
-					description: stepDescStr,
-					actions: [
-						{
-							type: "execute",
-							description: stepDescStr.trim(),
-						},
-					],
-				};
-			} else if (currentStep && line.trim().startsWith("-")) {
-				currentStep.actions.push({
-					type: "execute",
-					description: line.trim().substring(1).trim(),
-				});
-			}
-		}
-
-		if (currentStep) {
-			steps.push(currentStep);
-		}
-	}
-
-	return steps;
+	const plan = parsePlanGrammar(planContent);
+	return planToBuildSteps(plan, planContent);
 }
 
 function convertStepsToBuildResult(steps: BuildStep[]) {

--- a/src/agents/plan-agent.ts
+++ b/src/agents/plan-agent.ts
@@ -4,6 +4,7 @@ import { loadConfig } from "../config/loader.js";
 import { createProvider, parseModelString } from "../providers/factory.js";
 import type { Message } from "../providers/types.js";
 import { globTool, ToolRegistry } from "../tools/index.js";
+import { exampleOutput } from "./plan-grammar.js";
 import { readStateFile, writeStateFile } from "./state.js";
 import type { StateFile } from "./types.js";
 
@@ -32,39 +33,9 @@ For each task, you should:
    - Success criteria to verify completion
 4. Identify potential risks or considerations
 
-Output your plan as structured markdown with the following format:
+Output your plan as structured markdown in the canonical PlanGrammar format. Canonical example:
 
-# Implementation Plan: [Task Title]
-
-## Overview
-[Brief summary of what will be built]
-
-## Phase 1: [Phase Title]
-**Dependencies:** None (or list phase numbers)
-**Success Criteria:**
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-
-### Steps:
-1. [Step description]
-2. [Step description]
-
-## Phase 2: [Phase Title]
-**Dependencies:** Phase 1
-**Success Criteria:**
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-
-### Steps:
-1. [Step description]
-2. [Step description]
-
-## [Additional phases as needed...]
-
-## Technical Considerations
-- [Any architectural decisions or considerations]
-- [Dependencies or libraries needed]
-- [Testing strategy]
+${exampleOutput()}
 
 When exploring the codebase:
 - Use glob to find relevant files (e.g., **/*.ts, **/*.json)

--- a/src/agents/plan-grammar.ts
+++ b/src/agents/plan-grammar.ts
@@ -1,0 +1,408 @@
+/**
+ * PlanGrammar — single source of truth for the canonical plan format.
+ *
+ * Why this module exists: plan-agent emits plans as markdown; build-agent and
+ * the handlePlan CLI / tasks viewer both parse plans. Without a shared grammar,
+ * two readers diverge silently. This module owns: Plan/Phase/Step types,
+ * `serialize` (canonical markdown → AST-via-string), `parse` (forgiving
+ * markdown → AST), `validate` (semantic checks), and `exampleOutput` (a
+ * prompt-grounding fixture).
+ *
+ * Consumers reference one of three entry points:
+ * - `serialize(plan)` — emit canonical markdown.
+ * - `parse(text)` — extract a Plan from markdown (LLM-resilient).
+ * - `validate(plan)` — semantic checks (sequential phase numbers, dependencies
+ *   resolve to earlier phases).
+ */
+
+export interface Step {
+	number: number;
+	text: string;
+}
+
+export interface Phase {
+	number: number;
+	title: string;
+	/** Phase numbers this phase depends on. Empty array means no dependencies. */
+	dependencies: number[];
+	successCriteria: string[];
+	steps: Step[];
+}
+
+export interface Plan {
+	title: string;
+	overview?: string;
+	phases: Phase[];
+	technicalConsiderations?: string[];
+}
+
+export interface ValidationResult {
+	valid: boolean;
+	errors: string[];
+}
+
+const PHASE_RE = /^##\s*(?:Phase\s+)?(\d+)(?:\s*[:.]\s*(.+?))?\s*$/;
+const STEP_RE = /^\s*(\d+)\.\s+(.+?)\s*$/;
+const CHECKBOX_RE = /^\s*[-*]\s+\[[ xX]\]\s*(.+?)\s*$/;
+const FYI_DASH_RE = /^\s*[-*]\s+(.+?)\s*$/;
+const TITLE_RE = /^#\s+(?:Implementation\s+Plan:\s*)?(.+?)\s*$/;
+const OVERVIEW_HEADER_RE = /^##\s+Overview\s*$/i;
+const DEPS_RE = /^\*\*Dependencies:\*\*\s*(.+?)\s*$/i;
+const SUCCESS_HEADER_RE = /^\*\*Success\s+Criteria:\*\*\s*$/i;
+const STEPS_HEADER_RE = /^###\s+Steps:?\s*$/i;
+const TECH_HEADER_RE = /^##\s+Technical\s+Considerations\s*$/i;
+
+/**
+ * Serialize a Plan into canonical markdown.
+ *
+ * The output is the canonical form: a future `parse(serialize(plan))`
+ * returns a semantically equivalent Plan (deep-equal modulo the optional
+ * fields' presence).
+ */
+export function serialize(plan: Plan): string {
+	const lines: string[] = [];
+	lines.push(`# Implementation Plan: ${plan.title}`);
+	lines.push("");
+
+	if (plan.overview && plan.overview.trim().length > 0) {
+		lines.push("## Overview");
+		lines.push(plan.overview.trim());
+		lines.push("");
+	}
+
+	for (const phase of plan.phases) {
+		lines.push(`## Phase ${phase.number}: ${phase.title}`);
+		lines.push("");
+		lines.push(
+			`**Dependencies:** ${phase.dependencies.length === 0 ? "None" : phase.dependencies.map((d) => `Phase ${d}`).join(", ")}`
+		);
+		lines.push("");
+
+		if (phase.successCriteria.length > 0) {
+			lines.push("**Success Criteria:**");
+			for (const c of phase.successCriteria) {
+				lines.push(`- [ ] ${c}`);
+			}
+			lines.push("");
+		}
+
+		if (phase.steps.length > 0) {
+			lines.push("### Steps:");
+			for (const step of phase.steps) {
+				lines.push(`${step.number}. ${step.text}`);
+			}
+			lines.push("");
+		}
+	}
+
+	if (plan.technicalConsiderations && plan.technicalConsiderations.length > 0) {
+		lines.push("## Technical Considerations");
+		for (const c of plan.technicalConsiderations) {
+			lines.push(`- ${c}`);
+		}
+		lines.push("");
+	}
+
+	return lines.join("\n");
+}
+
+type ParseMode = "none" | "overview" | "phaseDeps" | "phaseSuccess" | "phaseSteps" | "technical";
+
+/**
+ * Parse markdown into a Plan. Forgiving by design: LLM output is messy.
+ *
+ * Supported forms:
+ * - Phase-form: `## Phase N: Title` headers with subsequent step lists,
+ *   `**Dependencies:**`, `**Success Criteria:**`, `### Steps:`. Title after
+ *   the colon is optional (e.g., `## Phase 1` alone is accepted).
+ * - Flat-form (fallback): numbered lines at top level (`1. step\n2. step`)
+ *   are wrapped into a single synthetic Phase so the AST stays uniform.
+ *
+ * Captures (when present): title, overview, phase title/deps/criteria/steps,
+ * technical considerations. Falls back to `title: "Untitled"` if no `#` header
+ * is found.
+ */
+export function parse(text: string): Plan {
+	const lines = text.split("\n");
+	let title = "";
+	let overview: string | undefined;
+	const phases: Phase[] = [];
+	const technicalConsiderations: string[] = [];
+
+	let currentPhase: Phase | null = null;
+	let mode: ParseMode = "none";
+	let overviewBuffer: string[] = [];
+
+	const finalizeCurrentPhase = (): void => {
+		if (currentPhase) {
+			phases.push(currentPhase);
+			currentPhase = null;
+		}
+	};
+
+	const finalizeOverview = (): void => {
+		if (overviewBuffer.length > 0) {
+			// Filter out trailing empty strings (paragraph separators at end of section).
+			while (overviewBuffer.length > 0 && overviewBuffer[overviewBuffer.length - 1] === "") {
+				overviewBuffer.pop();
+			}
+			if (overviewBuffer.length > 0) {
+				overview = overviewBuffer.join("\n");
+			}
+			overviewBuffer = [];
+		}
+	};
+
+	for (const raw of lines) {
+		const line = raw.replace(/\s+$/, "");
+
+		// Pre-check: if we're in overview mode and this line is a `##` header,
+		// finalize the overview buffer before any section header handler runs.
+		if (mode === "overview" && /^##\s/.test(line.trim())) {
+			finalizeOverview();
+			mode = "none";
+		}
+
+		const titleMatch = line.match(TITLE_RE);
+		if (titleMatch && title === "") {
+			title = (titleMatch[1] ?? "").trim();
+			mode = "overview";
+			continue;
+		}
+
+		const phaseHeader = line.match(PHASE_RE);
+		if (phaseHeader) {
+			finalizeCurrentPhase();
+			currentPhase = {
+				number: parseInt(phaseHeader[1] ?? "0", 10),
+				title: (phaseHeader[2] ?? "").trim(),
+				dependencies: [],
+				successCriteria: [],
+				steps: [],
+			};
+			mode = "phaseDeps";
+			continue;
+		}
+
+		if (OVERVIEW_HEADER_RE.test(line)) {
+			finalizeCurrentPhase();
+			finalizeOverview();
+			mode = "overview";
+			continue;
+		}
+
+		if (TECH_HEADER_RE.test(line)) {
+			finalizeCurrentPhase();
+			finalizeOverview();
+			mode = "technical";
+			continue;
+		}
+
+		if (currentPhase) {
+			const depsMatch = line.match(DEPS_RE);
+			if (depsMatch && (mode === "phaseDeps" || mode === "phaseSuccess" || mode === "phaseSteps")) {
+				const depText = (depsMatch[1] ?? "").trim();
+				if (depText && !/^none$/i.test(depText)) {
+					const numbers: number[] = [];
+					const re = /\b(?:Phase\s+)?(\d+)\b/g;
+					let m: RegExpExecArray | null;
+					while ((m = re.exec(depText)) !== null) {
+						const n = parseInt(m[1] ?? "0", 10);
+						if (!Number.isNaN(n) && n > 0 && !numbers.includes(n)) {
+							numbers.push(n);
+						}
+					}
+					currentPhase.dependencies = numbers;
+				}
+				mode = "phaseSuccess";
+				continue;
+			}
+
+			if (SUCCESS_HEADER_RE.test(line) && (mode === "phaseDeps" || mode === "phaseSuccess")) {
+				mode = "phaseSuccess";
+				continue;
+			}
+
+			const checkboxMatch = line.match(CHECKBOX_RE);
+			if (checkboxMatch && currentPhase && (mode === "phaseDeps" || mode === "phaseSuccess")) {
+				currentPhase.successCriteria.push((checkboxMatch[1] ?? "").trim());
+				mode = "phaseSuccess";
+				continue;
+			}
+
+			const stepsHeader = line.match(STEPS_HEADER_RE);
+			if (stepsHeader && (mode === "phaseSuccess" || mode === "phaseDeps")) {
+				mode = "phaseSteps";
+				continue;
+			}
+
+			const stepMatch = line.match(STEP_RE);
+			if (stepMatch && (mode === "phaseSteps" || mode === "phaseSuccess" || mode === "phaseDeps")) {
+				currentPhase.steps.push({
+					number: parseInt(stepMatch[1] ?? "0", 10),
+					text: (stepMatch[2] ?? "").trim(),
+				});
+				mode = "phaseSteps";
+				continue;
+			}
+
+			// Bold-style `- text` lines (success criteria without checkbox) within Success-Criteria section.
+			const dashMatch = line.match(FYI_DASH_RE);
+			if (dashMatch && (mode === "phaseDeps" || mode === "phaseSuccess")) {
+				const text = (dashMatch[1] ?? "").trim();
+				if (text && !text.startsWith("**")) {
+					if (currentPhase) {
+						currentPhase.successCriteria.push(text);
+					}
+					mode = "phaseSuccess";
+				}
+				continue;
+			}
+		}
+
+		if (mode === "overview") {
+			const trimmed = line.trim();
+			if (trimmed === "") {
+				// Paragraph separator: push empty marker so join yields "\n\n" between paragraphs.
+				if (overviewBuffer.length > 0 && overviewBuffer[overviewBuffer.length - 1] !== "") {
+					overviewBuffer.push("");
+				}
+				continue;
+			}
+			overviewBuffer.push(trimmed);
+			continue;
+		}
+
+		if (mode === "technical") {
+			const dashMatch = line.match(FYI_DASH_RE);
+			if (dashMatch) {
+				const text = (dashMatch[1] ?? "").trim();
+				if (text && !text.startsWith("**")) {
+					technicalConsiderations.push(text);
+				}
+			}
+			continue;
+		}
+		// mode === "none": ignore stray content.
+	}
+
+	finalizeCurrentPhase();
+	if (overview === undefined && overviewBuffer.length > 0) {
+		finalizeOverview();
+	}
+
+	// Flat-form fallback: numeric-only plans at top level.
+	if (phases.length === 0) {
+		const flatSteps: Step[] = [];
+		for (const raw of lines) {
+			const m = raw.match(STEP_RE);
+			if (m) {
+				flatSteps.push({
+					number: parseInt(m[1] ?? "0", 10),
+					text: (m[2] ?? "").trim(),
+				});
+			}
+		}
+		if (flatSteps.length > 0) {
+			phases.push({
+				number: 1,
+				title: title || "Steps",
+				dependencies: [],
+				successCriteria: [],
+				steps: flatSteps,
+			});
+		}
+	}
+
+	return {
+		title: title || "Untitled",
+		overview,
+		phases,
+		technicalConsiderations: technicalConsiderations.length > 0 ? technicalConsiderations : undefined,
+	};
+}
+
+/**
+ * Validate a Plan's semantic structure.
+ *
+ * Checks:
+ * - Title is non-empty.
+ * - Phase numbers are sequential starting at 1.
+ * - All phase dependencies refer to earlier phases:
+ *   self-dependency and forward-dependency are reported distinctly so a single
+ *   bad dependency produces one clear error, not two.
+ * - All phase dependencies target a phase that exists within the plan.
+ */
+export function validate(plan: Plan): ValidationResult {
+	const errors: string[] = [];
+
+	if (!plan.title || !plan.title.trim()) {
+		errors.push("plan title is empty");
+	}
+	if (plan.phases.length === 0) {
+		errors.push("plan has zero phases");
+	}
+	for (let i = 0; i < plan.phases.length; i++) {
+		const phase = plan.phases[i];
+		if (!phase) continue;
+		const expected = i + 1;
+		if (phase.number !== expected) {
+			errors.push(`phase ${phase.number ?? "?"} is out of order; expected ${expected}`);
+		}
+		for (const dep of phase.dependencies) {
+			if (dep < 1) {
+				errors.push(`phase ${phase.number} depends on non-positive phase ${dep}`);
+				continue;
+			}
+			if (dep > plan.phases.length) {
+				errors.push(`phase ${phase.number} depends on missing phase ${dep}`);
+				continue;
+			}
+			if (dep === phase.number) {
+				errors.push(`phase ${phase.number} has self-dependency`);
+				continue;
+			}
+			if (dep > phase.number) {
+				errors.push(`phase ${phase.number} has forward dependency on phase ${dep}`);
+			}
+		}
+	}
+
+	return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Canonical example plan, used as prompt-grounding by plan-agent.
+ *
+ * plan-agent embeds this in PLAN_SYSTEM_PROMPT so the LLM sees a concrete
+ * instance of the format it should emit before answering.
+ */
+export function exampleOutput(): string {
+	return serialize({
+		title: "Sample Feature",
+		overview: "Implement the feature end-to-end with tests.",
+		phases: [
+			{
+				number: 1,
+				title: "Scaffolding",
+				dependencies: [],
+				successCriteria: ["Repository layout is in place", "Base types are exported"],
+				steps: [
+					{ number: 1, text: "Create directory layout" },
+					{ number: 2, text: "Add base type definitions" },
+				],
+			},
+			{
+				number: 2,
+				title: "Implementation",
+				dependencies: [1],
+				successCriteria: ["Core logic works against sample inputs"],
+				steps: [
+					{ number: 1, text: "Implement parser" },
+					{ number: 2, text: "Wire into the public API" },
+				],
+			},
+		],
+		technicalConsiderations: ["Use Bun's test runner for verification"],
+	});
+}

--- a/src/cli/handlers/plan.ts
+++ b/src/cli/handlers/plan.ts
@@ -1,3 +1,4 @@
+import { parse as parsePlanGrammar } from "../../agents/plan-grammar.js";
 import { readStateFile } from "../../agents/state.js";
 import type { CliOptions } from "../shared.js";
 
@@ -15,34 +16,11 @@ interface PlanPhase {
 }
 
 function extractPhasesFromPlan(planText: string): PlanPhase[] {
-	const phases: PlanPhase[] = [];
-	const lines = planText.split("\n");
-
-	let currentPhase: PlanPhase | null = null;
-
-	for (const line of lines) {
-		const phaseMatch = line.match(/^##\s+(?:Phase\s+\d+[:.]\s*)?(.+)/i);
-		if (phaseMatch) {
-			if (currentPhase) {
-				phases.push(currentPhase);
-			}
-			currentPhase = { name: phaseMatch[1]?.trim() ?? "", tasks: [] };
-			continue;
-		}
-
-		if (currentPhase) {
-			const taskMatch = line.match(/^[-*]\s+\[[ x]\]\s*(.+)/i) || line.match(/^[-*]\s+(.+)/);
-			if (taskMatch?.[1] && !taskMatch[1].startsWith("**")) {
-				currentPhase.tasks.push(taskMatch[1].trim());
-			}
-		}
-	}
-
-	if (currentPhase) {
-		phases.push(currentPhase);
-	}
-
-	return phases;
+	const plan = parsePlanGrammar(planText);
+	return plan.phases.map((phase) => ({
+		name: phase.title,
+		tasks: phase.successCriteria,
+	}));
 }
 
 export async function handlePlan(_config: unknown, args: string[], options: CliOptions): Promise<void> {

--- a/test/agents/build-agent.test.ts
+++ b/test/agents/build-agent.test.ts
@@ -210,6 +210,27 @@ describe("parsePlanToSteps", () => {
 		expect(steps[1]?.description).toBe("Development");
 		expect(steps[1]?.actions.length).toBe(2);
 	});
+
+	it("keeps a single real phase with sequentially-numbered sub-steps as one BuildStep (regression)", () => {
+		// Regression guard for the over-eager AST-shape flat-form detector.
+		// A plan with ONE phase header and SEQUENTIALLY numbered sub-steps
+		// must stay phase-form: one BuildStep with multiple execute actions,
+		// NOT be split into N separate BuildSteps.
+		const plan = `## Phase 1: Setup
+1. Initialize project
+2. Install dependencies
+3. Configure CI`;
+
+		const steps = parsePlanToSteps(plan);
+
+		expect(steps.length).toBe(1);
+		expect(steps[0]?.stepNumber).toBe(1);
+		expect(steps[0]?.description).toBe("Setup");
+		expect(steps[0]?.actions.length).toBe(3);
+		expect(steps[0]?.actions[0]?.description).toBe("Initialize project");
+		expect(steps[0]?.actions[1]?.description).toBe("Install dependencies");
+		expect(steps[0]?.actions[2]?.description).toBe("Configure CI");
+	});
 });
 
 describe("BuildStep type", () => {

--- a/test/agents/plan-grammar.test.ts
+++ b/test/agents/plan-grammar.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "bun:test";
+import { exampleOutput, type Plan, parse, serialize, validate } from "../../src/agents/plan-grammar.js";
+
+describe("serialize/parse round-trip", () => {
+	it("round-trips a canonical plan with all fields", () => {
+		const original: Plan = {
+			title: "Build a CLI",
+			overview: "Provide a CLI for the project.",
+			phases: [
+				{
+					number: 1,
+					title: "Bootstrap",
+					dependencies: [],
+					successCriteria: ["CLI imports work"],
+					steps: [
+						{ number: 1, text: "Add entry script" },
+						{ number: 2, text: "Wire up command parser" },
+					],
+				},
+				{
+					number: 2,
+					title: "Ship",
+					dependencies: [1],
+					successCriteria: ["End-to-end test passes"],
+					steps: [{ number: 1, text: "Polish docs" }],
+				},
+			],
+			technicalConsiderations: ["Use Biome for lint"],
+		};
+		const text = serialize(original);
+		const reparsed = parse(text);
+		expect(reparsed).toEqual(original);
+	});
+
+	it("round-trips a minimal plan with no optional fields", () => {
+		const minimal: Plan = {
+			title: "Tiny",
+			phases: [{ number: 1, title: "Only phase", dependencies: [], successCriteria: [], steps: [] }],
+		};
+		expect(parse(serialize(minimal))).toEqual(minimal);
+	});
+
+	it("round-trips exampleOutput", () => {
+		const text = exampleOutput();
+		const reparsed = parse(text);
+		expect(reparsed.title).toBe("Sample Feature");
+		expect(reparsed.phases.length).toBe(2);
+		expect(reparsed.phases[0]?.number).toBe(1);
+		expect(reparsed.phases[1]?.dependencies).toEqual([1]);
+		expect(reparsed.technicalConsiderations?.length).toBeGreaterThan(0);
+	});
+});
+
+describe("parse", () => {
+	it("captures title from # header", () => {
+		const plan = parse("# Hello World\n");
+		expect(plan.title).toBe("Hello World");
+	});
+
+	it("captures title from '# Implementation Plan: Title'", () => {
+		const plan = parse("# Implementation Plan: Real Plan\n");
+		expect(plan.title).toBe("Real Plan");
+	});
+
+	it("captures phases with steps", () => {
+		const text = `## Phase 1: First\n1. Do thing\n2. Do more\n\n## Phase 2: Second\n1. Continue`;
+		const plan = parse(text);
+		expect(plan.phases.length).toBe(2);
+		expect(plan.phases[0]?.title).toBe("First");
+		expect(plan.phases[0]?.steps.length).toBe(2);
+		expect(plan.phases[1]?.steps.length).toBe(1);
+	});
+
+	it("accepts phase headers without titles", () => {
+		const text = `## Phase 1\n1. Do thing\n\n## Phase 2\n1. Continue`;
+		const plan = parse(text);
+		expect(plan.phases.length).toBe(2);
+		expect(plan.phases[0]?.steps.length).toBe(1);
+	});
+
+	it("captures dependencies", () => {
+		const text = `## Phase 1: A\n\n**Dependencies:** None\n\n## Phase 2: B\n\n**Dependencies:** Phase 1\n`;
+		const plan = parse(text);
+		expect(plan.phases[0]?.dependencies).toEqual([]);
+		expect(plan.phases[1]?.dependencies).toEqual([1]);
+	});
+
+	it("captures multi-dependency like 'Phase 1, Phase 3'", () => {
+		const text = `## Phase 1\n\n## Phase 2\n\n## Phase 3\n\n## Phase 4\n\n**Dependencies:** Phase 1, Phase 3\n`;
+		const plan = parse(text);
+		expect(plan.phases[3]?.dependencies).toEqual([1, 3]);
+	});
+
+	it("captures success criteria without a deps line preceding", () => {
+		const text = `## Phase 1\n**Success Criteria:**\n- [ ] Tests pass\n- [ ] Lint clean\n`;
+		const plan = parse(text);
+		expect(plan.phases[0]?.successCriteria).toEqual(["Tests pass", "Lint clean"]);
+	});
+
+	it("captures success criteria with a deps line preceding", () => {
+		const text = `## Phase 1\n\n**Dependencies:** None\n\n**Success Criteria:**\n- [ ] Tests pass\n`;
+		const plan = parse(text);
+		expect(plan.phases[0]?.successCriteria).toEqual(["Tests pass"]);
+	});
+
+	it("captures flat-form into a synthetic single phase", () => {
+		const text = `1. First\n2. Second\n3. Third`;
+		const plan = parse(text);
+		expect(plan.phases.length).toBe(1);
+		expect(plan.phases[0]?.steps.length).toBe(3);
+		expect(plan.phases[0]?.steps.map((s) => s.number)).toEqual([1, 2, 3]);
+		expect(plan.phases[0]?.steps.map((s) => s.text)).toEqual(["First", "Second", "Third"]);
+	});
+
+	it("captures technical considerations", () => {
+		const text = `## Technical Considerations\n- Use Bun\n- Pin Node 20\n`;
+		const plan = parse(text);
+		expect(plan.technicalConsiderations).toEqual(["Use Bun", "Pin Node 20"]);
+	});
+
+	it("captures overview text", () => {
+		const text = `# Plan\n\n## Overview\nA brief summary\nspanning two lines.\n\n## Phase 1\n`;
+		const plan = parse(text);
+		expect(plan.overview).toBe("A brief summary\nspanning two lines.");
+	});
+
+	it("captures multi-paragraph overview", () => {
+		const text = `# Plan\n\n## Overview\nPara one.\n\nPara two with more detail.\n\n## Phase 1\n`;
+		const plan = parse(text);
+		expect(plan.overview).toBe("Para one.\n\nPara two with more detail.");
+	});
+
+	it("returns empty plan for empty input", () => {
+		const plan = parse("");
+		expect(plan.title).toBe("Untitled");
+		expect(plan.phases.length).toBe(0);
+	});
+});
+
+describe("validate", () => {
+	it("flags empty title", () => {
+		const plan: Plan = { title: "  ", phases: [] };
+		const result = validate(plan);
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain("plan title is empty");
+	});
+
+	it("flags zero-phase plan", () => {
+		const plan: Plan = { title: "Empty", phases: [] };
+		const result = validate(plan);
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain("plan has zero phases");
+	});
+
+	it("flags non-sequential phase numbers", () => {
+		const plan: Plan = {
+			title: "Bad",
+			phases: [
+				{ number: 1, title: "A", dependencies: [], successCriteria: [], steps: [] },
+				{ number: 3, title: "B", dependencies: [], successCriteria: [], steps: [] },
+			],
+		};
+		const result = validate(plan);
+		expect(result.valid).toBe(false);
+		expect(result.errors[0]).toMatch(/out of order/);
+	});
+
+	it("flags forward dependency", () => {
+		const plan: Plan = {
+			title: "Bad",
+			phases: [
+				{ number: 1, title: "A", dependencies: [2], successCriteria: [], steps: [] },
+				{ number: 2, title: "B", dependencies: [], successCriteria: [], steps: [] },
+			],
+		};
+		const result = validate(plan);
+		expect(result.valid).toBe(false);
+		expect(result.errors.some((e) => /forward dependency on phase 2/.test(e))).toBe(true);
+	});
+
+	it("flags self-dependency distinctly from forward", () => {
+		const plan: Plan = {
+			title: "Bad",
+			phases: [{ number: 1, title: "A", dependencies: [1], successCriteria: [], steps: [] }],
+		};
+		const result = validate(plan);
+		expect(result.valid).toBe(false);
+		expect(result.errors.some((e) => /self-dependency/.test(e))).toBe(true);
+	});
+
+	it("flags missing dependency", () => {
+		const plan: Plan = {
+			title: "Bad",
+			phases: [{ number: 1, title: "A", dependencies: [5], successCriteria: [], steps: [] }],
+		};
+		const result = validate(plan);
+		expect(result.valid).toBe(false);
+		expect(result.errors.some((e) => /missing phase 5/.test(e))).toBe(true);
+	});
+
+	it("accepts a canonical plan", () => {
+		const canonical = parse(exampleOutput());
+		const result = validate(canonical);
+		expect(result.valid).toBe(true);
+		expect(result.errors).toEqual([]);
+	});
+});

--- a/test/agents/plan-grammar.test.ts
+++ b/test/agents/plan-grammar.test.ts
@@ -204,4 +204,13 @@ describe("validate", () => {
 		expect(result.valid).toBe(true);
 		expect(result.errors).toEqual([]);
 	});
+
+	it("flags empty phase titles (regression: permissive parser accepts '## Phase N' alone)", () => {
+		const text = `## Phase 1\n1. Do thing`;
+		const plan = parse(text);
+		expect(plan.phases[0]?.title).toBe("");
+		const result = validate(plan);
+		expect(result.valid).toBe(false);
+		expect(result.errors.some((e) => /phase 1 has empty title/.test(e))).toBe(true);
+	});
 });

--- a/test/cli/upgrade.test.ts
+++ b/test/cli/upgrade.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { parseGitHubRelease } from "../../src/cli/handlers/upgrade.js";
 import { parseArgs } from "../../src/cli/shared.js";
 
 // Helper function for semantic version comparison
@@ -49,6 +50,65 @@ describe("upgrade flag parsing", () => {
 });
 
 describe("upgrade utility functions", () => {
+	describe("parseGitHubRelease", () => {
+		const validRelease = {
+			tag_name: "v1.2.3",
+			name: "Release 1.2.3",
+			assets: [
+				{ name: "tiny-agent-linux-x64", browser_download_url: "https://example.com/linux-x64" },
+				{ name: "tiny-agent-darwin-arm64", browser_download_url: "https://example.com/darwin-arm64" },
+			],
+		};
+
+		it("accepts a well-formed release payload", () => {
+			const parsed = parseGitHubRelease(validRelease);
+			expect(parsed.tag_name).toBe("v1.2.3");
+			expect(parsed.assets.length).toBe(2);
+		});
+
+		it("rejects null payload", () => {
+			expect(() => parseGitHubRelease(null)).toThrow(/Invalid response/);
+		});
+
+		it("rejects non-object payload", () => {
+			expect(() => parseGitHubRelease("not an object")).toThrow(/Invalid response/);
+			expect(() => parseGitHubRelease(42)).toThrow(/Invalid response/);
+		});
+
+		it("rejects payload missing tag_name", () => {
+			const { tag_name: _omit, ...rest } = validRelease;
+			expect(() => parseGitHubRelease(rest)).toThrow(/Invalid response/);
+		});
+
+		it("rejects payload with non-string tag_name", () => {
+			expect(() => parseGitHubRelease({ ...validRelease, tag_name: 123 })).toThrow(/Invalid response/);
+		});
+
+		it("rejects payload missing assets", () => {
+			const { assets: _omit, ...rest } = validRelease;
+			expect(() => parseGitHubRelease(rest)).toThrow(/Invalid response/);
+		});
+
+		it("rejects payload with non-array assets", () => {
+			expect(() => parseGitHubRelease({ ...validRelease, assets: "nope" })).toThrow(/Invalid response/);
+		});
+
+		it("rejects asset missing name", () => {
+			const bad = { ...validRelease, assets: [{ browser_download_url: "x" }] };
+			expect(() => parseGitHubRelease(bad)).toThrow(/Invalid asset shape/);
+		});
+
+		it("rejects asset missing browser_download_url", () => {
+			const bad = { ...validRelease, assets: [{ name: "tiny-agent-linux-x64" }] };
+			expect(() => parseGitHubRelease(bad)).toThrow(/Invalid asset shape/);
+		});
+
+		it("rejects asset with non-string name", () => {
+			const bad = { ...validRelease, assets: [{ name: 123, browser_download_url: "x" }] };
+			expect(() => parseGitHubRelease(bad)).toThrow(/Invalid asset shape/);
+		});
+	});
+
 	describe("version comparison", () => {
 		it("should correctly compare equal versions", () => {
 			expect(compareVersions("1.0.0", "1.0.0")).toBe(0);


### PR DESCRIPTION
## What

- **Resolves the merge conflict with `main`** introduced by PR #52 (`build-agent-uses-registry`). Composed build-agent's imports to keep main's `bashTool`/`fileTools`/`ToolRegistry` (needed by `createBuildRegistry()`) and PR #56's `PlanGrammar` types — every other file auto-merged cleanly.
- **`src/agents/plan-grammar.ts`** added (serialize / parse / validate / exampleOutput). Build-agent's `parsePlanToSteps` now uses it instead of the regex-based parser. Plan-agent's `PLAN_SYSTEM_PROMPT` embeds `exampleOutput()` as prompt-grounding. The CLI `handlePlan tasks` fallback uses `parsePlanGrammar` for accuracy.
- **`src/agents/build-agent.ts`** imports the plan-grammar types, drops direct `fs.unlink` / confirmation prompts (now routed through the registry's `delete_file` tool and confirmation handler), and uses `registry.setDryRun()` for dry-run simulation.
- **7 codemap quick wins** from `.planning/codebase/CONCERNS.md`:
  - `plan-grammar.ts`: dropped the redundant trailing `continue;` in `mode === "technical"`; `validate()` now flags empty phase titles (parity with the existing empty-plan-title check).
  - `plan-grammar.test.ts`: regression test pins the new empty-title validation.
  - `build-agent.ts`: removed the dead `_stepError` variable and its three assignments (`handleExecutionError` already appends to `state.errors`).
  - `upgrade.ts`: extracted `parseGitHubRelease(data: unknown): GitHubRelease` from `fetchLatestRelease` for unit-testable response-shape validation, tightened per-asset checks (`name` and `browser_download_url` must be strings).
  - `upgrade.test.ts`: 10 new tests covering valid / null / non-object / missing-or-malformed `tag_name` / missing-or-malformed `assets` / malformed asset entry.
  - `.husky/pre-commit`: prepends `bun run generate:skills` + `git diff --exit-code src/skills/embedded-content.ts` and the equivalent for `generate:version`. Catches forgotten regen locally before CI does.
  - `docs/README.md`: new index of `docs/adr/` (all 11 ADRs as a one-line summary table), pointer to `development-tasks.md`, cross-references to `AGENTS.md`, `CLAUDE.md`, and `.planning/codebase/`.

## Why

- **PlanGrammar is the single source of truth for the canonical plan format.** Before, plan-agent emitted plans, build-agent regex-parsed them, and `handlePlan` regex-extracted phases — two readers diverging silently. One deep module, three consumers.
- **The codemap quick wins** were surfaced by the new `.planning/codebase/CONCERNS.md`. Each was small enough to ship in the same PR; together they retire every lint info, dead variable, redundant control-flow, and missing pre-commit safeguard the codebase-mapper found.

## How

- **Imports composition in `build-agent.ts`** — main's three direct tool imports are required because `createBuildRegistry()` calls `registry.registerMany(fileTools)` and `registry.register(bashTool)`; PR #56's `import { type Step as GrammarStep, type Plan, parse as parsePlanGrammar } from "./plan-grammar.js"` feeds `planToBuildSteps` and `parsePlanToSteps`. Order follows biome's automatic import-sorting (external deps → tools → local).
- **Empty-phase-title check** mirrors the existing empty-plan-title check: `if (!phase.title || !phase.title.trim()) errors.push(\`phase ${phase.number} has empty title\`)`. Surfaced the regression in a single-line test.
- **`parseGitHubRelease`** uses `Record<string, unknown>` narrowing (not a single `as { assets: unknown }` cast that re-widens the array). Each asset is checked: must be a non-null object with string `name` and string `browser_download_url`. Returns the original payload as `GitHubRelease` after the guards pass.
- **Pre-commit hook** runs both generators and immediately checks `git diff --exit-code` against the index — if either generated file changed, the hook fails and the contributor must `git add` the regenerated file before re-committing. CI's existing regen still runs as a backstop.

## Checklist

- [x] Tests added or updated (919 pass, 0 fail — was 908; +11 new tests for PlanGrammar regression and `parseGitHubRelease`)
- [x] Documentation updated (`docs/README.md`)
- [x] No breaking changes
