### PR TITLE
feat(cli): add /login command for provider onboarding

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -55,7 +55,7 @@ Layered, dependency-inverted architecture. The CLI is the outermost layer; every
 
 ### 2. CLI Dispatcher (`src/cli/`, `src/cli/handlers/`)
 - `src/cli/main.tsx` mounts the Ink UI.
-- `src/cli/chat-commands.ts` and the per-feature handlers (`plan.ts`, `agent.ts`, `state.ts`, `memory.ts`, `config.ts`, `mcp.ts`, `skill.ts`, `trace.ts`, `status.ts`, `upgrade.ts`) implement each subcommand.
+- `src/cli/chat-commands.ts` and the per-feature handlers (`plan.ts`, `agent.ts`, `state.ts`, `memory.ts`, `config.ts`, `mcp.ts`, `skill.ts`, `trace.ts`, `status.ts`, `upgrade.ts`, `login.ts`) implement each subcommand.
 - Handlers return structured results; the CLI layer never throws to the user.
 
 ### 3. Agent Loop (`src/core/agent.ts`)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A lightweight, extensible coding agent built in TypeScript that helps developers
 
 - **Rich Terminal UI**: Ink-powered CLI with components for messages, spinners, and tool output
 - **TTY Detection**: Automatically adapts to terminal capabilities with plain text fallback
-- **Multi-Provider LLM Support**: Works with OpenAI, Anthropic, Ollama, OpenRouter, and OpenCode
+- **Multi-Provider LLM Support**: Works with OpenAI, Anthropic, Ollama, OpenRouter, OpenCode, Z.AI, and ClinePass
 - **MCP Client Integration**: Connect to Model Context Protocol servers for extended capabilities
 - **Built-in Tools**: File operations, bash execution, grep, glob, and web search
 - **Memory System**: User-initiated persistent storage with relevance-based retrieval
@@ -64,6 +64,39 @@ bun run build
 | Linux        | glibc 2.28+     |
 | Architecture | x64 or arm64    |
 
+## Provider Login (Onboarding)
+
+Connect an LLM provider so you can start chatting. The `login` command walks you through picking a provider and entering your API key — no manual config editing required.
+
+```bash
+tiny-agent login            # Interactive provider picker (recommended for first run)
+tiny-agent login openai     # Connect OpenAI directly
+tiny-agent login anthropic  # Connect Anthropic directly
+tiny-agent login ollama     # Configure local Ollama (no API key needed)
+tiny-agent login status     # Show which providers are connected
+```
+
+**What it does:**
+
+1. Shows your current provider connection status.
+2. Lets you pick a provider (OpenAI, Anthropic, Ollama, OpenRouter, OpenCode, Z.AI, ClinePass).
+3. Prompts for your API key with **masked input** (typed characters show as `*`).
+4. Saves the key to `~/.tiny-agent/config.yaml` and suggests a default model for that provider.
+
+Get an API key from your provider:
+
+| Provider   | Where to get an API key                          |
+| ---------- | ------------------------------------------------ |
+| OpenAI     | <https://platform.openai.com/api-keys>           |
+| Anthropic  | <https://console.anthropic.com/settings/keys>    |
+| OpenRouter | <https://openrouter.ai/keys>                     |
+| OpenCode   | <https://opencode.ai>                            |
+| Z.AI       | <https://open.bigmodel.cn/usercenter/apikeys>    |
+| ClinePass  | <https://cline.bot>                              |
+| Ollama     | No key needed — runs locally. Install from <https://ollama.com> |
+
+> **Tip:** For better security, store the key in an environment variable instead of the config file. After running `login`, replace `apiKey: sk-...` with `apiKey: ${OPENAI_API_KEY}` and `export OPENAI_API_KEY=your-key` in your shell profile.
+
 ## Troubleshooting
 
 ### "command not found: tiny-agent"
@@ -80,7 +113,14 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
 
 ### API key errors
 
-Set your API key as an environment variable:
+The quickest fix is to run the login command, which prompts for your key with masked input and writes it to the config file:
+
+```bash
+tiny-agent login        # Interactive picker
+tiny-agent login openai # Or connect a specific provider directly
+```
+
+Alternatively, set your API key as an environment variable:
 
 ```bash
 export OPENAI_API_KEY="your-key"
@@ -95,6 +135,8 @@ providers:
   openai:
     apiKey: ${OPENAI_API_KEY}
 ```
+
+Check which providers are connected at any time with `tiny-agent login status`.
 
 ## Uninstallation
 
@@ -288,15 +330,17 @@ tiny-agent --provider opencode --model opencode/gpt-5.2-codex "write a function"
 
 ## CLI Commands
 
-| Command                   | Description               |
-| ------------------------- | ------------------------- |
-| `tiny-agent chat`         | Interactive chat session  |
-| `tiny-agent run "prompt"` | Single prompt, then exit  |
-| `tiny-agent config`       | Show current config       |
-| `tiny-agent status`       | Show provider, MCP, tools |
-| `tiny-agent mcp`          | Manage MCP servers        |
-| `tiny-agent memory`       | Manage memories           |
-| `tiny-agent skill`        | Manage skills             |
+| Command                     | Description                          |
+| --------------------------- | ------------------------------------ |
+| `tiny-agent chat`           | Interactive chat session             |
+| `tiny-agent run "prompt"`   | Single prompt, then exit             |
+| `tiny-agent login`          | Connect a provider (onboarding)      |
+| `tiny-agent login status`   | Show provider connection status      |
+| `tiny-agent config`         | Show current config                  |
+| `tiny-agent status`         | Show provider, MCP, tools            |
+| `tiny-agent mcp`            | Manage MCP servers                   |
+| `tiny-agent memory`         | Manage memories                      |
+| `tiny-agent skill`          | Manage skills                        |
 
 ### MCP Server Management
 
@@ -432,17 +476,18 @@ Skills are automatically discovered from `SKILL.md` files in your configured ski
 
 ### Chat Commands
 
-| Command         | Description                               |
-| --------------- | ----------------------------------------- |
-| `/help`         | Show available commands                   |
-| `/clear`        | Clear conversation history                |
-| `/model <name>` | Switch model                              |
-| `/tools`        | View tool execution history               |
-| `/mcp`          | Show MCP server status                    |
-| `/memory`       | List stored memories                      |
-| `/skill [name]` | List all skills, or load a specific skill |
-| `@<skill-name>` | Load a skill (type @ to see picker)       |
-| `/exit`         | Exit chat (Ctrl+D also works)             |
+| Command         | Description                                            |
+| --------------- | ------------------------------------------------------ |
+| `/help`         | Show available commands                                |
+| `/clear`        | Clear conversation history                             |
+| `/model <name>` | Switch model                                           |
+| `/login`        | Show provider connection status + onboarding guidance  |
+| `/tools`        | View tool execution history                            |
+| `/mcp`          | Show MCP server status                                 |
+| `/memory`       | List stored memories                                   |
+| `/skill [name]` | List all skills, or load a specific skill              |
+| `@<skill-name>` | Load a skill (type @ to see picker)                    |
+| `/exit`         | Exit chat (Ctrl+D also works)                          |
 
 ## Custom Plugins
 

--- a/bun.lock
+++ b/bun.lock
@@ -438,7 +438,7 @@
 
     "string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
 
-    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "strip-eof": ["strip-eof@1.0.0", "", {}, "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q=="],
 
@@ -515,8 +515,6 @@
     "bumpp/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "execa/cross-spawn": ["cross-spawn@5.1.0", "", { "dependencies": { "lru-cache": "^4.0.1", "shebang-command": "^1.2.0", "which": "^1.2.9" } }, "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A=="],
-
-    "is-fullwidth-code-point/get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
     "npm-run-path/path-key": ["path-key@2.0.1", "", {}, "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="],
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,9 @@ ADRs capture *why* a decision was made, what alternatives were considered, and w
 | 009 | [Tool confirmation](adr/009-tool-confirmation.md) | How dangerous ops get user confirmation before execution. |
 | 010 | [Ink CLI integration](adr/010-ink-cli-integration.md) | Why the CLI UI is React/Ink and how state flows. |
 | 011 | [Multi-agent system](adr/011-multi-agent-system.md) | plan / build / explore agents sharing a state file and `PlanGrammar`. |
+| 012 | [GatewayOpenAIProvider base class](adr/012-gateway-openai-provider-base.md) | Held back by the 30% duplication threshold — keep providers inline. |
+| 013 | [ClinePass live model lookup](adr/013-clinepass-live-model-lookup.md) | Replace baked capability table with a live `GET /api/v1/models` fetch. |
+| 014 | [Login command onboarding design](adr/014-login-command.md) | Top-level command before `loadConfig`; chat `/login` status-only; literal key storage with env-var tip. |
 
 ## Other Docs
 

--- a/docs/adr/014-login-command.md
+++ b/docs/adr/014-login-command.md
@@ -1,0 +1,125 @@
+# ADR-014: Login Command — Onboarding Design
+
+**Status:** Accepted
+**Date:** 2026-07-26
+**Deciders:** huynhdung
+
+## Context
+
+New users must connect an LLM provider before `tiny-agent chat` works — the agent loop calls `createProvider()`, which throws `X provider requires apiKey in config` when no key is present. The only onboarding path was to hand-edit `~/.tiny-agent/config.yaml`, which is friction for a first-run experience.
+
+The `login` command (added in commit `a494add`) provides an interactive onboarding flow: a provider picker, masked API key entry, and a `status` subcommand. Three design decisions in that implementation are non-obvious enough to warrant an ADR.
+
+## Decisions
+
+### 1. Top-level CLI command, dispatched before `loadConfig()`
+
+The `login` command is dispatched in `main.tsx` **before** the `loadConfig()` call that every other command depends on:
+
+```typescript
+// main.tsx — login runs before loadConfig()
+if (command === "login") {
+  await handleLogin(args);
+  return;
+}
+
+const config = loadConfig();
+// ... all other commands use `config`
+```
+
+**Rationale:** Onboarding is the one case where a valid config does not yet exist. `loadConfig()` interpolates `${ENV_VAR}` references and validates the result — if the user has no provider configured, it either throws or returns a config with no usable provider. Dispatching `login` before that call lets the onboarding flow write the *first* valid config without needing a config to already exist. Every other command (`chat`, `run`, `status`, `config`, `mcp`, ...) runs after `loadConfig()` and assumes a config is available.
+
+### 2. Chat `/login` is status-only — no in-chat key entry
+
+The `/login` chat command (in `useCommandHandler.ts`) **only displays provider connection status** and points the user to the top-level `tiny-agent login` command. It does **not** prompt for an API key inside the Ink chat UI:
+
+```typescript
+// useCommandHandler.ts — /login shows status + guidance, does not collect keys
+const status = formatProviderStatus(providerConfigs);
+onAddMessage(
+  MessageRole.ASSISTANT,
+  `${status}\n\n` +
+    `To connect a provider, exit and run:\n` +
+    `  tiny-agent login          Interactive provider picker\n` +
+    `  tiny-agent login openai    Connect a specific provider\n` +
+    `  tiny-agent login status    Show this status again`
+);
+```
+
+**Rationale:** The Ink chat UI uses a `TextInput` component that echoes typed characters to the terminal. There is no secure (masked) text input in the Ink UI layer. Implementing masked input inside Ink would require a new component with raw-mode stdin handling that bypasses Ink's rendering pipeline — significant complexity for a single use case. The top-level `login` command already has masked input via `promptHidden()` (raw-mode `*` echoing). Routing key entry to the top-level command keeps secrets out of the Ink render tree and reuses the existing secure input path.
+
+### 3. Literal key storage with an env-var tip (not automatic env-var migration)
+
+The `login` flow writes the API key as a **literal string** into `~/.tiny-agent/config.yaml`:
+
+```yaml
+providers:
+  openai:
+    apiKey: sk-...    # literal key, written by login
+```
+
+After a successful login, the command prints a tip advising the user to move the key to an environment variable:
+
+```
+Tip: For better security, store the key in an environment variable instead:
+  1. Set apiKey: ${OPENAI_API_KEY} in config.yaml
+  2. Export OPENAI_API_KEY=your-key in your shell profile.
+```
+
+**Rationale:** Automatically migrating the key to an environment variable would require (a) writing to the user's shell profile (`.zshrc` / `.bashrc`), which is intrusive and shell-specific, and (b) replacing the literal key with a `${OPENAI_API_KEY}` reference, which silently changes the user's config semantics. The config loader's `interpolateEnvVars()` already supports `${VAR}` references with a security check (`containsSensitivePattern` + `ALLOWED_PROVIDER_ENV_VARS` allowlist), so the env-var path is fully supported — but it must be opt-in. Storing the literal key first makes the "it just works" path zero-friction; the tip nudges security-conscious users toward the safer pattern without forcing it.
+
+## Consequences
+
+### Positive
+
+- **Zero-friction onboarding:** `tiny-agent login` → pick provider → paste key → `tiny-agent chat` works. No manual YAML editing.
+- **Secrets never enter the Ink render tree:** the chat UI cannot leak a key via a render glitch, scrollback, or a screenshot of the chat panel.
+- **Onboarding is config-bootstrapping-safe:** `login` runs before `loadConfig()`, so a brand-new user with no config file can connect a provider on their very first command.
+- **Env-var path remains first-class:** the config loader already interpolates `${VAR}` references, so users who follow the tip get the same behaviour with better security. No code change needed.
+- **The `status` subcommand is useful beyond onboarding:** `tiny-agent login status` (and `/login` in chat) give a quick "which providers am I connected to?" view at any time.
+
+### Negative
+
+- **Two-step for env-var users:** a security-conscious user runs `login`, then manually edits the config to replace the literal key with `${OPENAI_API_KEY}` and exports the env var. A future `--use-env-var` flag could automate the reference swap (without touching the shell profile).
+- **Literal key in a file on disk:** the config file at `~/.tiny-agent/config.yaml` contains the raw key until the user follows the tip. This is the standard trade-off for "just works" onboarding. The file is created with default `writeFile` permissions (typically `0644` via umask — **world-readable**), since neither `login`'s `writeConfigFile` nor the loader's `createDefaultConfig` pass a `mode` option. A future hardening should write the config with `0o600` (owner-only) when a literal key is stored.
+- **No "test connection" step:** `login` saves the key without verifying it against the provider's API. A wrong or expired key is only discovered on the first `chat` call. A future enhancement could add a lightweight health-check call per provider.
+- **`/login` in chat cannot fix a missing key:** a user who discovers they're not connected mid-chat must exit, run `tiny-agent login`, and restart. This is the accepted cost of keeping secrets out of the Ink UI.
+
+### Trade-offs
+
+- **Top-level vs. in-chat key entry:** chose top-level for secure input (raw-mode masking). The cost is the exit-and-restart flow for `/login` users. The benefit is no secrets in the Ink render tree.
+- **Literal key vs. env-var-by-default:** chose literal for zero-friction. The cost is a raw key on disk until the user follows the tip. The benefit is "it just works" with no shell-profile modification.
+- **Before `loadConfig()` vs. a bootstrap config:** chose dispatch-before-load to avoid a separate "empty config" code path. The cost is that `login` re-implements its own `readConfigFile`/`writeConfigFile` (mirroring `mcp.ts`) rather than using `loadConfig()`/`validateConfig()`. The benefit is onboarding works with no config file at all.
+
+## Alternatives Considered
+
+1. **In-chat masked `TextInput` component.** Rejected — would require a new Ink component with raw-mode stdin handling that bypasses Ink's rendering loop. High complexity for one use case, and the component would be a secrets-handling surface that needs its own security review.
+2. **Automatic env-var migration on login.** Rejected — writing to `.zshrc`/`.bashrc` is intrusive and shell-specific. Silently replacing the literal key with `${OPENAI_API_KEY}` changes config semantics without the user's informed consent. The tip approach is opt-in.
+3. **`login` as a subcommand of `config` (e.g., `tiny-agent config login`).** Rejected — `config` runs after `loadConfig()`, which assumes a valid config exists. Onboarding is the case where no valid config exists yet. Making `login` top-level and dispatching it before `loadConfig()` is the clean solution.
+4. **A `--use-env-var` flag that writes `apiKey: ${OPENAI_API_KEY}` and prints the export command without touching the shell profile.** Deferred — a reasonable future enhancement. The current tip already documents the manual steps; the flag would reduce them to one command.
+5. **Store the key in the system keychain (macOS Keychain / Linux secret-service).** Rejected for now — adds a native dependency and platform-specific code paths. The config file with `0600` permissions + env-var tip is the pragmatic baseline. Keychain integration could be revisited if the literal-key-on-disk concern becomes a blocker.
+
+## Implementation
+
+See files:
+
+- `src/cli/handlers/login.ts` — `handleLogin()`, `LOGIN_PROVIDERS`, `promptHidden()` (masked input), `applyProviderToConfig()`, `readConfigFile`/`writeConfigFile` (config I/O), `formatProviderStatus()`.
+- `src/cli/main.tsx` — `login` dispatch before `loadConfig()` (line ~616), help text, error message.
+- `src/ui/hooks/useCommandHandler.ts` — `/login` chat command (status-only, delegates to top-level `login`).
+- `src/ui/components/CommandMenu.tsx` — `/login` entry in the command picker.
+- `src/core/agent.ts` — `getProviderConfigs()` getter used by the chat `/login` command.
+- `test/cli/handlers/login.test.ts` — 30 unit tests (pure functions + `handleLogin(["status"])` smoke tests).
+
+## Related Decisions
+
+- **ADR-005: Tool System Design** — the `Tool` interface and `dangerous` routing. Not directly related, but the "keep secrets out of the render tree" principle echoes the confirmation system's "show the user what will happen before it happens" philosophy.
+- **ADR-010: Ink CLI Integration** — the Ink UI architecture. This ADR's decision to keep key entry out of the chat UI is a constraint imposed by ADR-010's `TextInput`-based architecture (no secure input component).
+- **ADR-013: ClinePass Live Model Lookup** — the most recent provider-related ADR. The `login` command's `LOGIN_PROVIDERS` list includes `clinepass` with `envVar: "CLINE_API_KEY"`, consistent with ADR-013's auth scheme.
+
+## Future Considerations
+
+- A `--use-env-var` flag on `tiny-agent login` that writes `apiKey: ${OPENAI_API_KEY}` to the config and prints the `export` command without modifying the shell profile (alternative 4).
+- A "test connection" step that makes a lightweight API call (e.g., list models) to verify the key before saving it.
+- Enforcing `0600` permissions on `~/.tiny-agent/config.yaml` after writing a literal key.
+- System keychain integration for API key storage (alternative 5) — revisit if the literal-key-on-disk concern becomes a blocker.
+- A `logout` command (the inverse of `login`) that removes the `apiKey` from a provider's config entry, with a default-model re-prompt if the logged-out provider was the active one.

--- a/src/cli/handlers/login.ts
+++ b/src/cli/handlers/login.ts
@@ -183,6 +183,26 @@ export function formatProviderStatus(providers: Config["providers"] | undefined)
 	return lines.join("\n");
 }
 
+/**
+ * Check if a config object contains any literal (non-env-var-reference) API
+ * key. An `apiKey` value like `"sk-..."` is literal; `"${OPENAI_API_KEY}"`
+ * is an env-var reference and does not count. Used to decide whether to
+ * write the config file with owner-only (0o600) permissions.
+ */
+export function containsLiteralApiKey(config: Record<string, unknown>): boolean {
+	const providers = config.providers;
+	if (!providers || typeof providers !== "object") return false;
+
+	for (const providerConfig of Object.values(providers as Record<string, unknown>)) {
+		if (!providerConfig || typeof providerConfig !== "object") continue;
+		const apiKey = (providerConfig as Record<string, unknown>).apiKey;
+		if (typeof apiKey === "string" && apiKey.length > 0 && !apiKey.startsWith("${")) {
+			return true;
+		}
+	}
+	return false;
+}
+
 // ===== Config I/O Helpers (follow the mcp.ts pattern) =====
 
 async function readConfigFile(configPath: string): Promise<Record<string, unknown>> {
@@ -205,12 +225,20 @@ async function writeConfigFile(configPath: string, config: Record<string, unknow
 		mkdirSync(CONFIG_DIR, { recursive: true });
 	}
 
+	// Write with owner-only permissions when the config contains a literal
+	// API key, to prevent other users on the system from reading secrets.
+	// Note: `mode` only applies when the file is first created — existing
+	// files keep their current permissions. `createDefaultConfig` in loader.ts
+	// always uses 0o600, so the common onboarding flow (create → login) starts
+	// with the right permissions.
+	const writeOptions = containsLiteralApiKey(config) ? { mode: 0o600, encoding: "utf-8" as const } : "utf-8";
+
 	if (configPath.endsWith(".json")) {
-		await writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+		await writeFile(configPath, JSON.stringify(config, null, 2), writeOptions);
 		return;
 	}
 	const { stringify: stringifyYaml } = await import("yaml");
-	await writeFile(configPath, stringifyYaml(config), "utf-8");
+	await writeFile(configPath, stringifyYaml(config), writeOptions);
 }
 
 // ===== Prompt Helpers (readline-based, matching build-agent.ts pattern) =====

--- a/src/cli/handlers/login.ts
+++ b/src/cli/handlers/login.ts
@@ -1,0 +1,452 @@
+import { existsSync, mkdirSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { CONFIG_DIR, getConfigPath } from "../../config/loader.js";
+import type { Config } from "../../config/schema.js";
+
+// ===== Types & Constants =====
+
+export interface LoginProviderInfo {
+	key: string;
+	name: string;
+	requiresApiKey: boolean;
+	envVar?: string;
+	defaultModel?: string;
+	getKeyUrl?: string;
+	note?: string;
+}
+
+/**
+ * Providers available for login, ordered by popularity for the onboarding
+ * picker. Keys match the `providers` object in config.yaml (see
+ * `Config["providers"]` in schema.ts).
+ */
+export const LOGIN_PROVIDERS: readonly LoginProviderInfo[] = [
+	{
+		key: "openai",
+		name: "OpenAI",
+		requiresApiKey: true,
+		envVar: "OPENAI_API_KEY",
+		defaultModel: "gpt-4o",
+		getKeyUrl: "https://platform.openai.com/api-keys",
+	},
+	{
+		key: "anthropic",
+		name: "Anthropic",
+		requiresApiKey: true,
+		envVar: "ANTHROPIC_API_KEY",
+		defaultModel: "claude-sonnet-4-20250514",
+		getKeyUrl: "https://console.anthropic.com/settings/keys",
+	},
+	{
+		key: "ollama",
+		name: "Ollama (Local)",
+		requiresApiKey: false,
+		defaultModel: "qwen3-coder",
+		note: "Runs locally — no API key needed. Install from ollama.com",
+	},
+	{
+		key: "ollamaCloud",
+		name: "Ollama (Cloud)",
+		requiresApiKey: true,
+		envVar: "OLLAMA_CLOUD_API_KEY",
+		defaultModel: "gpt-oss:120b-cloud",
+		getKeyUrl: "https://ollama.com",
+	},
+	{
+		key: "openrouter",
+		name: "OpenRouter",
+		requiresApiKey: true,
+		envVar: "OPENROUTER_API_KEY",
+		defaultModel: "openrouter/openai/gpt-4o",
+		getKeyUrl: "https://openrouter.ai/keys",
+	},
+	{
+		key: "opencode",
+		name: "OpenCode",
+		requiresApiKey: true,
+		envVar: "OPENCODE_API_KEY",
+		defaultModel: "opencode/big-pickle",
+		getKeyUrl: "https://opencode.ai",
+	},
+	{
+		key: "zai",
+		name: "Z.AI (Zhipu)",
+		requiresApiKey: true,
+		envVar: "ZAI_API_KEY",
+		defaultModel: "glm-4.7",
+		getKeyUrl: "https://open.bigmodel.cn/usercenter/apikeys",
+	},
+	{
+		key: "clinepass",
+		name: "ClinePass",
+		requiresApiKey: true,
+		envVar: "CLINE_API_KEY",
+		defaultModel: "cline-pass/glm-5.2",
+		getKeyUrl: "https://cline.bot",
+	},
+];
+
+export interface ProviderStatus {
+	key: string;
+	name: string;
+	configured: boolean;
+	hasApiKey: boolean;
+	requiresApiKey: boolean;
+}
+
+// ===== Pure Functions (no I/O — directly testable) =====
+
+/** Find a login provider by key (case-insensitive). */
+export function findProvider(key: string): LoginProviderInfo | undefined {
+	const lower = key.toLowerCase();
+	return LOGIN_PROVIDERS.find((p) => p.key.toLowerCase() === lower);
+}
+
+/** Compute connection status for every provider from a config's providers object. */
+export function getProviderStatus(providers: Config["providers"] | undefined): ProviderStatus[] {
+	return LOGIN_PROVIDERS.map((p) => {
+		const providerConfig = providers?.[p.key as keyof NonNullable<typeof providers>];
+		const configured = !!providerConfig;
+		const hasApiKey = !!providerConfig?.apiKey;
+		return {
+			key: p.key,
+			name: p.name,
+			configured,
+			hasApiKey,
+			requiresApiKey: p.requiresApiKey,
+		};
+	});
+}
+
+export interface ApplyProviderOptions {
+	apiKey?: string;
+	baseUrl?: string;
+	defaultModel?: string;
+}
+
+/**
+ * Merge a provider configuration into a raw config object (as read from the
+ * config file). Preserves all existing keys (other providers, mcpServers,
+ * skillDirectories, etc.) and only adds/overwrites the target provider +
+ * optional defaultModel. Does NOT mutate the input.
+ */
+export function applyProviderToConfig(
+	fileConfig: Record<string, unknown>,
+	providerKey: string,
+	options: ApplyProviderOptions
+): Record<string, unknown> {
+	const result: Record<string, unknown> = { ...fileConfig };
+
+	// Shallow-copy the providers object so we don't mutate the input
+	const existingProviders =
+		result.providers && typeof result.providers === "object"
+			? { ...(result.providers as Record<string, unknown>) }
+			: {};
+	result.providers = existingProviders;
+
+	const providers = existingProviders as Record<string, Record<string, unknown>>;
+	// Copy the existing provider entry to avoid mutation
+	const existing = { ...(providers[providerKey] ?? {}) };
+
+	const updated: Record<string, unknown> = { ...existing };
+	if (options.apiKey !== undefined) {
+		updated.apiKey = options.apiKey;
+	}
+	if (options.baseUrl !== undefined) {
+		updated.baseUrl = options.baseUrl;
+	}
+	providers[providerKey] = updated;
+
+	if (options.defaultModel !== undefined) {
+		result.defaultModel = options.defaultModel;
+	}
+
+	return result;
+}
+
+/** Format provider connection status as a human-readable string. */
+export function formatProviderStatus(providers: Config["providers"] | undefined): string {
+	const statuses = getProviderStatus(providers);
+	const lines: string[] = ["Provider Connection Status", "========================"];
+
+	for (const s of statuses) {
+		const icon = s.hasApiKey || (!s.requiresApiKey && s.configured) ? "●" : s.configured ? "◐" : "○";
+		let statusText: string;
+		if (s.requiresApiKey) {
+			statusText = s.hasApiKey ? "API key set" : s.configured ? "API key required" : "not configured";
+		} else {
+			statusText = s.configured ? "ready" : "ready (local)";
+		}
+		lines.push(`  ${icon} ${s.name.padEnd(16)} ${statusText}`);
+	}
+
+	return lines.join("\n");
+}
+
+// ===== Config I/O Helpers (follow the mcp.ts pattern) =====
+
+async function readConfigFile(configPath: string): Promise<Record<string, unknown>> {
+	if (!existsSync(configPath)) return {};
+	const content = await readFile(configPath, "utf-8");
+
+	if (configPath.endsWith(".json")) {
+		try {
+			return (JSON.parse(content) as Record<string, unknown>) || {};
+		} catch {
+			return {};
+		}
+	}
+	const { parse: parseYaml } = await import("yaml");
+	return (parseYaml(content) as Record<string, unknown>) || {};
+}
+
+async function writeConfigFile(configPath: string, config: Record<string, unknown>): Promise<void> {
+	if (!existsSync(CONFIG_DIR)) {
+		mkdirSync(CONFIG_DIR, { recursive: true });
+	}
+
+	if (configPath.endsWith(".json")) {
+		await writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+		return;
+	}
+	const { stringify: stringifyYaml } = await import("yaml");
+	await writeFile(configPath, stringifyYaml(config), "utf-8");
+}
+
+// ===== Prompt Helpers (readline-based, matching build-agent.ts pattern) =====
+
+async function prompt(question: string): Promise<string> {
+	const { createInterface } = await import("node:readline");
+	const rl = createInterface({ input: process.stdin, output: process.stdout });
+	return new Promise((resolve) => {
+		rl.question(question, (answer) => {
+			rl.close();
+			resolve(answer.trim());
+		});
+	});
+}
+
+/**
+ * Read a line from stdin with masked input (echoes `*` for each character).
+ * Falls back to plain readline when stdin is not a TTY (e.g. piped input).
+ */
+async function promptHidden(promptText: string): Promise<string> {
+	process.stdout.write(promptText);
+
+	const stdin = process.stdin;
+
+	// Non-TTY fallback: use plain readline (input will be visible)
+	if (!stdin.isTTY || typeof stdin.setRawMode !== "function") {
+		const { createInterface } = await import("node:readline");
+		const rl = createInterface({ input: stdin, output: process.stdout });
+		return new Promise((resolve) => {
+			rl.question("", (answer) => {
+				rl.close();
+				resolve(answer.trim());
+			});
+		});
+	}
+
+	// TTY: read character-by-character with masking
+	return new Promise((resolve) => {
+		let input = "";
+		stdin.setRawMode(true);
+		stdin.resume();
+		stdin.setEncoding("utf8");
+
+		const onData = (char: string): void => {
+			const code = char.charCodeAt(0);
+			switch (char) {
+				case "\r":
+				case "\n":
+					stdin.removeListener("data", onData);
+					stdin.setRawMode(false);
+					stdin.pause();
+					process.stdout.write("\n");
+					resolve(input.trim());
+					break;
+				case "\u0003": // Ctrl+C
+					stdin.setRawMode(false);
+					stdin.pause();
+					process.stdout.write("\n");
+					process.exit(0);
+					break;
+				case "\u007f": // Delete
+				case "\b": // Backspace
+					if (input.length > 0) {
+						input = input.slice(0, -1);
+						process.stdout.write("\b \b");
+					}
+					break;
+				default:
+					// Only store printable characters (code >= 32)
+					if (code >= 32) {
+						input += char;
+						process.stdout.write("*");
+					}
+			}
+		};
+
+		stdin.on("data", onData);
+	});
+}
+
+// ===== Interactive Flows =====
+
+async function loginProvider(provider: LoginProviderInfo): Promise<void> {
+	const configPath = getConfigPath();
+	const fileConfig = await readConfigFile(configPath);
+
+	console.log(`\n🔐 ${provider.name} Login\n`);
+
+	if (provider.requiresApiKey) {
+		if (provider.getKeyUrl) {
+			console.log(`Get your API key at: ${provider.getKeyUrl}\n`);
+		}
+
+		const apiKey = await promptHidden(`Enter your ${provider.name} API key: `);
+		if (!apiKey) {
+			console.log("\n✗ No API key entered. Login cancelled.");
+			process.exit(1);
+		}
+
+		// Suggest a default model
+		let defaultModel: string | undefined;
+		if (provider.defaultModel) {
+			const existingDefault = fileConfig.defaultModel as string | undefined;
+			console.log(`\nSuggested default model: ${provider.defaultModel}`);
+			const confirm = await prompt("Set as default model? [Y/n]: ");
+			if (confirm.toLowerCase().startsWith("y") || confirm === "") {
+				defaultModel = provider.defaultModel;
+			} else if (!existingDefault) {
+				// No existing default model — must set one for a valid config
+				console.log(`(No default model set — using ${provider.defaultModel})`);
+				defaultModel = provider.defaultModel;
+			}
+		}
+
+		const updatedConfig = applyProviderToConfig(fileConfig, provider.key, {
+			apiKey,
+			defaultModel,
+		});
+		await writeConfigFile(configPath, updatedConfig);
+
+		console.log(`\n✓ Saved ${provider.name} API key to ${configPath}`);
+		if (defaultModel) {
+			console.log(`✓ Default model set to: ${defaultModel}`);
+		}
+	} else {
+		// No API key needed (e.g. Ollama local)
+		console.log(`${provider.note ?? "No API key needed."}\n`);
+
+		const existingBaseUrl =
+			(fileConfig.providers as Record<string, { baseUrl?: string }>)?.[provider.key]?.baseUrl ??
+			"http://localhost:11434";
+		const baseUrl = await prompt(`Base URL [${existingBaseUrl}]: `);
+		const finalBaseUrl = baseUrl || existingBaseUrl;
+
+		// Auto-set default model if none exists yet
+		let defaultModel: string | undefined;
+		if (provider.defaultModel) {
+			const existingDefault = fileConfig.defaultModel as string | undefined;
+			if (!existingDefault) {
+				defaultModel = provider.defaultModel;
+				console.log(`✓ Default model set to: ${defaultModel}`);
+			}
+		}
+
+		const updatedConfig = applyProviderToConfig(fileConfig, provider.key, {
+			baseUrl: finalBaseUrl,
+			defaultModel,
+		});
+		await writeConfigFile(configPath, updatedConfig);
+
+		console.log(`\n✓ Saved ${provider.name} configuration to ${configPath}`);
+	}
+
+	console.log(`\nLogin complete! Run \`tiny-agent chat\` to start.\n`);
+
+	if (provider.envVar) {
+		console.log(
+			`Tip: For better security, store the key in an environment variable instead:\n` +
+				`  1. Set apiKey: \${${provider.envVar}} in config.yaml\n` +
+				`  2. Export ${provider.envVar}=your-key in your shell profile.\n`
+		);
+	}
+
+	process.exit(0);
+}
+
+async function loginInteractive(): Promise<void> {
+	console.log("\n🔑 Tiny Agent — Provider Login\n");
+	console.log("Connect an LLM provider so you can start chatting.\n");
+
+	// Show current status
+	const configPath = getConfigPath();
+	const fileConfig = await readConfigFile(configPath);
+	const providers = fileConfig.providers as Config["providers"] | undefined;
+	console.log(formatProviderStatus(providers));
+	console.log();
+
+	// Show picker
+	console.log("Select a provider to configure:\n");
+	LOGIN_PROVIDERS.forEach((p, i) => {
+		const num = `${i + 1}.`.padStart(4);
+		const suffix = p.requiresApiKey ? `→ ${p.getKeyUrl ?? "API key required"}` : `→ ${p.note ?? "no API key needed"}`;
+		console.log(`  ${num} ${p.name.padEnd(16)} ${suffix}`);
+	});
+	console.log();
+
+	const choice = await prompt(`Enter choice (1-${LOGIN_PROVIDERS.length}): `);
+	const index = parseInt(choice, 10) - 1;
+
+	if (Number.isNaN(index) || index < 0 || index >= LOGIN_PROVIDERS.length) {
+		console.log("\n✗ Invalid choice. Login cancelled.");
+		process.exit(1);
+	}
+
+	const provider = LOGIN_PROVIDERS[index];
+	if (!provider) {
+		console.log("\n✗ Invalid choice. Login cancelled.");
+		process.exit(1);
+	}
+
+	await loginProvider(provider);
+}
+
+async function showLoginStatus(): Promise<void> {
+	const configPath = getConfigPath();
+	const fileConfig = await readConfigFile(configPath);
+	const providers = fileConfig.providers as Config["providers"] | undefined;
+
+	console.log(`\n${formatProviderStatus(providers)}\n`);
+	console.log("Run `tiny-agent login` to configure a provider.");
+	console.log("Run `tiny-agent login <provider>` to configure a specific provider directly.\n");
+	process.exit(0);
+}
+
+// ===== Main Handler =====
+
+export async function handleLogin(args: string[]): Promise<void> {
+	const subCommand = args[0];
+
+	if (subCommand === "status") {
+		await showLoginStatus();
+		return;
+	}
+
+	// If a provider key was given as arg, go straight to it
+	if (subCommand) {
+		const provider = findProvider(subCommand);
+		if (provider) {
+			await loginProvider(provider);
+			return;
+		}
+		console.error(`Unknown provider: ${subCommand}`);
+		console.error(`Available: ${LOGIN_PROVIDERS.map((p) => p.key).join(", ")}`);
+		process.exit(1);
+	}
+
+	// Interactive picker
+	await loginInteractive();
+}

--- a/src/cli/main.tsx
+++ b/src/cli/main.tsx
@@ -10,6 +10,7 @@ import { StatusType } from "../ui/types/enums.js";
 import { isJsonMode, setJsonMode, setNoColor, shouldUseInk } from "../ui/utils.js";
 import { handleAgent } from "./handlers/agent.js";
 import { handleConfig } from "./handlers/config.js";
+import { handleLogin } from "./handlers/login.js";
 import { handleMcp } from "./handlers/mcp.js";
 import { handleMemory } from "./handlers/memory.js";
 import { handlePlan } from "./handlers/plan.js";
@@ -506,6 +507,7 @@ USAGE:
     tiny-agent config                  Show current configuration
     tiny-agent config open             Open config file in editor
     tiny-agent status                  Show provider and model capabilities
+    tiny-agent login [provider]        Connect an LLM provider (onboarding)
     tiny-agent memory [command]        Manage memories
     tiny-agent skill [command]         Manage skills
     tiny-agent mcp [command]           Manage MCP servers
@@ -562,6 +564,9 @@ EXAMPLES:
     tiny-agent run --model claude-3-5-sonnet "Help me"  Use specific model
     tiny-agent config                  Show current configuration
     tiny-agent config open             Open config in editor
+    tiny-agent login                   Connect a provider interactively
+    tiny-agent login openai            Connect OpenAI directly
+    tiny-agent login status            Show provider connection status
     tiny-agent status                  Show provider and model capabilities
     tiny-agent --upgrade               Upgrade to the latest version
     tiny-agent --help                  Show this help message
@@ -608,6 +613,13 @@ export async function main(): Promise<void> {
 			return;
 		}
 
+		// `login` runs before loadConfig() because the user may be onboarding
+		// and have no valid provider configured yet.
+		if (command === "login") {
+			await handleLogin(args);
+			return;
+		}
+
 		const config = loadConfig();
 
 		if (command === "chat") {
@@ -639,7 +651,7 @@ export async function main(): Promise<void> {
 		} else {
 			console.error(`Unknown command: ${command}`);
 			console.error(
-				"Available commands: chat, run <prompt>, trace <prompt>, config, status, memory, skill, mcp, plan, build, explore, run-plan-build, run-all, state, plan show, tasks, todo"
+				"Available commands: chat, run <prompt>, trace <prompt>, login, config, status, memory, skill, mcp, plan, build, explore, run-plan-build, run-all, state, plan show, tasks, todo"
 			);
 			console.error("Options: --model <model>, --provider <provider>, --verbose, --save, --state-file, --help");
 			process.exit(2);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -117,7 +117,12 @@ skillDirectories:
 #   - "mcp_serena_*onboarding*"  # Disable Serena onboarding tools
 `;
 
-	writeFileSync(YAML_PATH, configTemplate, "utf-8");
+	// Write with owner-only permissions (0o600) so the config file — which
+	// may later hold literal API keys after `tiny-agent login` — is not
+	// world-readable. The default template only has commented-out env-var
+	// references, but writing secure-by-default means the permissions are
+	// correct from the moment the file is created.
+	writeFileSync(YAML_PATH, configTemplate, { mode: 0o600, encoding: "utf-8" });
 }
 
 const SENSITIVE_KEY_PATTERNS = [

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -1036,6 +1036,12 @@ export class Agent {
 		return this._toolRegistry.list().length;
 	}
 
+	/** Returns the provider configs the agent was constructed with.
+	 *  Used by the `/login` chat command to display connection status. */
+	getProviderConfigs(): ProviderConfigs | undefined {
+		return this._providerConfigs;
+	}
+
 	async getMcpServerStatus(): Promise<Array<{ name: string; connected: boolean; toolCount: number }>> {
 		if (this._mcpManager) {
 			return this._mcpManager.getServerStatus();

--- a/src/ui/components/CommandMenu.tsx
+++ b/src/ui/components/CommandMenu.tsx
@@ -20,6 +20,7 @@ const STATIC_COMMANDS: Command[] = [
 	{ name: "/clear", description: "Clear the conversation" },
 	{ name: "/model", description: "Switch the model" },
 	{ name: "/agent", description: "Switch agent" },
+	{ name: "/login", description: "Show provider connection status" },
 	{ name: "/tools", description: "View tool executions" },
 	{ name: "/mcp", description: "Show MCP server status" },
 	{ name: "/memory", description: "List memories" },

--- a/src/ui/hooks/useCommandHandler.ts
+++ b/src/ui/hooks/useCommandHandler.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { readStateFile } from "../../agents/state.js";
+import { formatProviderStatus } from "../../cli/handlers/login.js";
 import type { Agent } from "../../core/agent.js";
 import type { McpManager } from "../../mcp/manager.js";
 import type { Command } from "../components/CommandMenu.js";
@@ -198,6 +199,29 @@ export function useCommandHandler({
 		[onAddMessage]
 	);
 
+	const handleLoginCommand = useCallback(() => {
+		if (!agent) {
+			onAddMessage(MessageRole.ASSISTANT, "Error: Agent not initialized. Cannot show provider status.");
+			return;
+		}
+
+		// Show current provider connection status + onboarding guidance.
+		// The actual key entry happens via the top-level `tiny-agent login`
+		// command, because the Ink chat UI does not have a secure (masked)
+		// text input for secrets.
+		const providerConfigs = agent.getProviderConfigs();
+		const status = formatProviderStatus(providerConfigs);
+
+		onAddMessage(
+			MessageRole.ASSISTANT,
+			`${status}\n\n` +
+				`To connect a provider, exit and run:\n` +
+				`  tiny-agent login          Interactive provider picker\n` +
+				`  tiny-agent login openai    Connect a specific provider\n` +
+				`  tiny-agent login status    Show this status again`
+		);
+	}, [agent, onAddMessage]);
+
 	const handleMemoryCommand = useCallback(() => {
 		if (!agent) {
 			onAddMessage(MessageRole.ASSISTANT, "Error: Agent not initialized.");
@@ -237,6 +261,7 @@ export function useCommandHandler({
   /clear   - Clear conversation
   /model   - Switch model
   /agent   - Switch agent
+  /login   - Show provider connection status
   /tools   - View tool executions
   /mcp     - Show MCP server status
   /memory  - List memories
@@ -265,6 +290,9 @@ export function useCommandHandler({
 Use ←/→ to navigate, Enter to select.`
 						);
 					}
+					break;
+				case "/login":
+					handleLoginCommand();
 					break;
 				case "/mcp":
 					handleMcpCommand();
@@ -299,6 +327,7 @@ Use ←/→ to navigate, Enter to select.`
 			onSetShowToolsPanel,
 			onExit,
 			handleSkillCommand,
+			handleLoginCommand,
 			handleMcpCommand,
 			handleMemoryCommand,
 			handlePlanCommand,

--- a/test/cli/handlers/login.test.ts
+++ b/test/cli/handlers/login.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { existsSync, unlinkSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import {
+	applyProviderToConfig,
+	findProvider,
+	formatProviderStatus,
+	getProviderStatus,
+	handleLogin,
+	LOGIN_PROVIDERS,
+} from "../../../src/cli/handlers/login.js";
+import type { Config } from "../../../src/config/schema.js";
+
+describe("login handler", () => {
+	describe("LOGIN_PROVIDERS", () => {
+		it("should include all 8 providers from the factory", () => {
+			const keys = LOGIN_PROVIDERS.map((p) => p.key);
+			expect(keys).toContain("openai");
+			expect(keys).toContain("anthropic");
+			expect(keys).toContain("ollama");
+			expect(keys).toContain("ollamaCloud");
+			expect(keys).toContain("openrouter");
+			expect(keys).toContain("opencode");
+			expect(keys).toContain("zai");
+			expect(keys).toContain("clinepass");
+			expect(keys).toHaveLength(8);
+		});
+
+		it("should have a default model for every provider", () => {
+			for (const p of LOGIN_PROVIDERS) {
+				expect(p.defaultModel, `${p.key} should have a defaultModel`).toBeDefined();
+			}
+		});
+
+		it("should mark ollama as not requiring an API key", () => {
+			const ollama = LOGIN_PROVIDERS.find((p) => p.key === "ollama");
+			expect(ollama?.requiresApiKey).toBe(false);
+		});
+
+		it("should mark all cloud providers as requiring an API key", () => {
+			for (const p of LOGIN_PROVIDERS) {
+				if (p.key === "ollama") continue;
+				expect(p.requiresApiKey, `${p.key} should require an API key`).toBe(true);
+			}
+		});
+
+		it("should include an envVar for every provider that requires an API key", () => {
+			for (const p of LOGIN_PROVIDERS) {
+				if (p.requiresApiKey) {
+					expect(p.envVar, `${p.key} should have an envVar`).toBeDefined();
+				}
+			}
+		});
+	});
+
+	describe("findProvider()", () => {
+		it("should find a provider by exact key", () => {
+			expect(findProvider("openai")?.key).toBe("openai");
+			expect(findProvider("anthropic")?.key).toBe("anthropic");
+		});
+
+		it("should be case-insensitive", () => {
+			expect(findProvider("OpenAI")?.key).toBe("openai");
+			expect(findProvider("ANTHROPIC")?.key).toBe("anthropic");
+			expect(findProvider("OllamaCloud")?.key).toBe("ollamaCloud");
+		});
+
+		it("should return undefined for an unknown provider", () => {
+			expect(findProvider("nonexistent")).toBeUndefined();
+		});
+
+		it("should return undefined for empty string", () => {
+			expect(findProvider("")).toBeUndefined();
+		});
+	});
+
+	describe("getProviderStatus()", () => {
+		it("should return not-configured for an empty providers object", () => {
+			const statuses = getProviderStatus(undefined);
+			expect(statuses).toHaveLength(8);
+			for (const s of statuses) {
+				expect(s.configured).toBe(false);
+				expect(s.hasApiKey).toBe(false);
+			}
+		});
+
+		it("should mark a provider with an API key as configured + hasApiKey", () => {
+			const providers: Config["providers"] = {
+				openai: { apiKey: "sk-test" },
+			};
+			const openai = getProviderStatus(providers).find((s) => s.key === "openai");
+			expect(openai?.configured).toBe(true);
+			expect(openai?.hasApiKey).toBe(true);
+		});
+
+		it("should mark a provider configured without an API key as configured but no key", () => {
+			const providers: Config["providers"] = {
+				ollama: { baseUrl: "http://localhost:11434" },
+			};
+			const ollama = getProviderStatus(providers).find((s) => s.key === "ollama");
+			expect(ollama?.configured).toBe(true);
+			expect(ollama?.hasApiKey).toBe(false);
+		});
+
+		it("should reflect multiple configured providers", () => {
+			const providers: Config["providers"] = {
+				openai: { apiKey: "sk-test" },
+				anthropic: { apiKey: "sk-ant" },
+				ollama: { baseUrl: "http://localhost:11434" },
+			};
+			const statuses = getProviderStatus(providers);
+			const configured = statuses.filter((s) => s.configured);
+			expect(configured).toHaveLength(3);
+		});
+	});
+
+	describe("applyProviderToConfig()", () => {
+		it("should add a new provider to an empty config", () => {
+			const result = applyProviderToConfig({}, "openai", { apiKey: "sk-test" });
+			expect(result.providers).toEqual({ openai: { apiKey: "sk-test" } });
+		});
+
+		it("should add a provider without overwriting existing providers", () => {
+			const input: Record<string, unknown> = {
+				providers: { anthropic: { apiKey: "sk-ant" } },
+			};
+			const result = applyProviderToConfig(input, "openai", { apiKey: "sk-test" });
+			expect(result.providers).toEqual({
+				anthropic: { apiKey: "sk-ant" },
+				openai: { apiKey: "sk-test" },
+			});
+		});
+
+		it("should preserve other top-level keys (mcpServers, skillDirectories)", () => {
+			const input: Record<string, unknown> = {
+				defaultModel: "llama3.2",
+				mcpServers: { context7: { command: "npx" } },
+				skillDirectories: ["~/.tiny-agent/skills/"],
+				providers: { anthropic: { apiKey: "sk-ant" } },
+			};
+			const result = applyProviderToConfig(input, "openai", { apiKey: "sk-test" });
+			expect(result.defaultModel).toBe("llama3.2");
+			expect(result.mcpServers).toEqual({ context7: { command: "npx" } });
+			expect(result.skillDirectories).toEqual(["~/.tiny-agent/skills/"]);
+		});
+
+		it("should overwrite an existing provider's API key", () => {
+			const input: Record<string, unknown> = {
+				providers: { openai: { apiKey: "old-key", baseUrl: "https://custom.api" } },
+			};
+			const result = applyProviderToConfig(input, "openai", { apiKey: "new-key" });
+			expect(result.providers).toEqual({
+				openai: { apiKey: "new-key", baseUrl: "https://custom.api" },
+			});
+		});
+
+		it("should preserve an existing baseUrl when only updating the API key", () => {
+			const input: Record<string, unknown> = {
+				providers: { openai: { baseUrl: "https://custom.api" } },
+			};
+			const result = applyProviderToConfig(input, "openai", { apiKey: "sk-test" });
+			expect(result.providers).toEqual({
+				openai: { baseUrl: "https://custom.api", apiKey: "sk-test" },
+			});
+		});
+
+		it("should set the defaultModel when provided", () => {
+			const result = applyProviderToConfig({}, "openai", {
+				apiKey: "sk-test",
+				defaultModel: "gpt-4o",
+			});
+			expect(result.defaultModel).toBe("gpt-4o");
+		});
+
+		it("should NOT set defaultModel when not provided", () => {
+			const input: Record<string, unknown> = { defaultModel: "llama3.2" };
+			const result = applyProviderToConfig(input, "openai", { apiKey: "sk-test" });
+			expect(result.defaultModel).toBe("llama3.2");
+		});
+
+		it("should set both apiKey and baseUrl", () => {
+			const result = applyProviderToConfig({}, "ollama", {
+				baseUrl: "http://localhost:11434",
+				defaultModel: "qwen3-coder",
+			});
+			expect(result.providers).toEqual({ ollama: { baseUrl: "http://localhost:11434" } });
+			expect(result.defaultModel).toBe("qwen3-coder");
+		});
+
+		it("should not mutate the input object", () => {
+			const input: Record<string, unknown> = {
+				providers: { openai: { apiKey: "old" } },
+			};
+			applyProviderToConfig(input, "openai", { apiKey: "new" });
+			// Original should be unchanged
+			const originalProviders = input.providers as Record<string, { apiKey: string }>;
+			expect(originalProviders.openai?.apiKey).toBe("old");
+		});
+	});
+	describe("formatProviderStatus()", () => {
+		it("should include a header and every provider name", () => {
+			const output = formatProviderStatus(undefined);
+			expect(output).toContain("Provider Connection Status");
+			expect(output).toContain("OpenAI");
+			expect(output).toContain("Anthropic");
+			expect(output).toContain("Ollama (Local)");
+			expect(output).toContain("OpenRouter");
+		});
+
+		it("should show 'not configured' for unconfigured providers", () => {
+			const output = formatProviderStatus(undefined);
+			expect(output).toContain("not configured");
+		});
+
+		it("should show 'API key set' for a configured provider with a key", () => {
+			const providers: Config["providers"] = { openai: { apiKey: "sk-test" } };
+			const output = formatProviderStatus(providers);
+			expect(output).toContain("API key set");
+		});
+
+		it("should show 'ready' for a configured local provider", () => {
+			const providers: Config["providers"] = { ollama: { baseUrl: "http://localhost:11434" } };
+			const output = formatProviderStatus(providers);
+			// Ollama local doesn't require API key — "ready" when configured
+			expect(output).toContain("ready");
+		});
+	});
+});
+
+// ===== handleLogin() smoke tests =====
+// Follows the state.test.ts pattern: spy on console.log/console.error +
+// process.exit, write a temp config file, and assert output + exit codes.
+// Both config env vars are overridden (see beforeEach) so getConfigPath()
+// never touches the user's real ~/.tiny-agent/config.{yaml,json}.
+
+describe("handleLogin", () => {
+	// Use a unique temp path per module load. We override BOTH config env vars
+	// so getConfigPath() can never fall through to the user's real
+	// ~/.tiny-agent/config.{yaml,json} (which would make the "missing config"
+	// test flaky depending on the host machine).
+	const TEMP_CONFIG_FILE = `/tmp/test-login-config-${Date.now()}.yaml`;
+	const TEMP_CONFIG_JSON = `/tmp/test-login-config-${Date.now()}.json`;
+	let originalConfigYaml: string | undefined;
+	let originalConfigJson: string | undefined;
+
+	beforeEach(() => {
+		originalConfigYaml = process.env.TINY_AGENT_CONFIG_YAML;
+		originalConfigJson = process.env.TINY_AGENT_CONFIG_JSON;
+		process.env.TINY_AGENT_CONFIG_YAML = TEMP_CONFIG_FILE;
+		process.env.TINY_AGENT_CONFIG_JSON = TEMP_CONFIG_JSON;
+		for (const f of [TEMP_CONFIG_FILE, TEMP_CONFIG_JSON]) {
+			if (existsSync(f)) unlinkSync(f);
+		}
+	});
+
+	afterEach(() => {
+		for (const f of [TEMP_CONFIG_FILE, TEMP_CONFIG_JSON]) {
+			if (existsSync(f)) unlinkSync(f);
+		}
+		if (originalConfigYaml === undefined) {
+			delete process.env.TINY_AGENT_CONFIG_YAML;
+		} else {
+			process.env.TINY_AGENT_CONFIG_YAML = originalConfigYaml;
+		}
+		if (originalConfigJson === undefined) {
+			delete process.env.TINY_AGENT_CONFIG_JSON;
+		} else {
+			process.env.TINY_AGENT_CONFIG_JSON = originalConfigJson;
+		}
+	});
+
+	it("should show provider status with 'status' subcommand (configured providers)", async () => {
+		// Write a temp config with a couple of providers configured
+		const yamlContent = `defaultModel: gpt-4o
+providers:
+  openai:
+    apiKey: sk-test-key
+  ollama:
+    baseUrl: http://localhost:11434
+`;
+		await writeFile(TEMP_CONFIG_FILE, yamlContent, "utf-8");
+
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+
+		await expect(handleLogin(["status"])).rejects.toThrow("exit");
+
+		// Should have printed the status header and provider names
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Provider Connection Status"));
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("OpenAI"));
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("API key set"));
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Run `tiny-agent login`"));
+		// Should exit with code 0 (success)
+		expect(processExitSpy).toHaveBeenCalledWith(0);
+
+		consoleLogSpy.mockRestore();
+		processExitSpy.mockRestore();
+	});
+
+	it("should show 'not configured' when no providers are configured", async () => {
+		// Write a minimal config with no providers
+		const yamlContent = `defaultModel: llama3.2
+providers: {}
+`;
+		await writeFile(TEMP_CONFIG_FILE, yamlContent, "utf-8");
+
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+
+		await expect(handleLogin(["status"])).rejects.toThrow("exit");
+
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("not configured"));
+		expect(processExitSpy).toHaveBeenCalledWith(0);
+
+		consoleLogSpy.mockRestore();
+		processExitSpy.mockRestore();
+	});
+
+	it("should show status even when config file does not exist", async () => {
+		// No config file written — getConfigPath() returns the (non-existent)
+		// path, readConfigFile returns {}, and all providers show as not configured.
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+
+		await expect(handleLogin(["status"])).rejects.toThrow("exit");
+
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Provider Connection Status"));
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("not configured"));
+		expect(processExitSpy).toHaveBeenCalledWith(0);
+
+		consoleLogSpy.mockRestore();
+		processExitSpy.mockRestore();
+	});
+
+	it("should exit with error for an unknown provider argument", async () => {
+		const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+
+		await expect(handleLogin(["nonexistent"])).rejects.toThrow("exit");
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Unknown provider: nonexistent"));
+		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining(LOGIN_PROVIDERS.map((p) => p.key).join(", ")));
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+
+		consoleErrorSpy.mockRestore();
+		processExitSpy.mockRestore();
+	});
+});

--- a/test/cli/handlers/login.test.ts
+++ b/test/cli/handlers/login.test.ts
@@ -4,6 +4,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import * as readline from "node:readline";
 import {
 	applyProviderToConfig,
+	containsLiteralApiKey,
 	findProvider,
 	formatProviderStatus,
 	getProviderStatus,
@@ -224,6 +225,68 @@ describe("login handler", () => {
 			const output = formatProviderStatus(providers);
 			// Ollama local doesn't require API key — "ready" when configured
 			expect(output).toContain("ready");
+		});
+	});
+
+	describe("containsLiteralApiKey()", () => {
+		// Construct env-var reference strings via concatenation to avoid
+		// Biome's noTemplateCurlyInString lint rule, which flags ${...} in
+		// non-template-literal strings. These represent the literal text
+		// "${OPENAI_API_KEY}" as it would appear in config.yaml.
+		const OPENAI_REF = "${" + "OPENAI_API_KEY}";
+		const ANTHROPIC_REF = "${" + "ANTHROPIC_API_KEY}";
+
+		it("should return false for an empty config", () => {
+			expect(containsLiteralApiKey({})).toBe(false);
+		});
+
+		it("should return false when no providers object exists", () => {
+			expect(containsLiteralApiKey({ defaultModel: "gpt-4o" })).toBe(false);
+		});
+
+		it("should return false for providers with no apiKey", () => {
+			expect(containsLiteralApiKey({ providers: { ollama: { baseUrl: "http://localhost:11434" } } })).toBe(false);
+		});
+
+		it("should return true for a literal API key", () => {
+			expect(containsLiteralApiKey({ providers: { openai: { apiKey: "sk-test-key" } } })).toBe(true);
+		});
+
+		it("should return false for an env-var reference apiKey", () => {
+			expect(containsLiteralApiKey({ providers: { openai: { apiKey: OPENAI_REF } } })).toBe(false);
+		});
+
+		it("should return false for an empty apiKey string", () => {
+			expect(containsLiteralApiKey({ providers: { openai: { apiKey: "" } } })).toBe(false);
+		});
+
+		it("should return true if any provider has a literal key", () => {
+			expect(
+				containsLiteralApiKey({
+					providers: {
+						ollama: { baseUrl: "http://localhost:11434" },
+						openai: { apiKey: OPENAI_REF },
+						anthropic: { apiKey: "sk-ant-test" },
+					},
+				})
+			).toBe(true);
+		});
+
+		it("should return false when all apiKeys are env-var references", () => {
+			expect(
+				containsLiteralApiKey({
+					providers: {
+						openai: { apiKey: OPENAI_REF },
+						anthropic: { apiKey: ANTHROPIC_REF },
+					},
+				})
+			).toBe(false);
+		});
+
+		it("should handle non-object providers gracefully", () => {
+			expect(containsLiteralApiKey({ providers: "not-an-object" })).toBe(false);
+			expect(containsLiteralApiKey({ providers: null })).toBe(false);
+			expect(containsLiteralApiKey({ providers: [] })).toBe(false);
 		});
 	});
 });

--- a/test/cli/handlers/login.test.ts
+++ b/test/cli/handlers/login.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { existsSync, unlinkSync } from "node:fs";
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
+import * as readline from "node:readline";
 import {
 	applyProviderToConfig,
 	findProvider,
@@ -352,5 +353,140 @@ providers: {}
 
 		consoleErrorSpy.mockRestore();
 		processExitSpy.mockRestore();
+	});
+
+	// ===== Interactive picker smoke tests =====
+	// These mock readline.createInterface so that prompt() and promptHidden()
+	// (non-TTY fallback) return predetermined answers from a queue.
+	// stdin.isTTY is forced to false so promptHidden takes the readline path.
+
+	it("should complete interactive picker login for OpenAI (provider 1)", async () => {
+		const answers = ["1", "sk-test-key-123", "y"];
+		let answerIndex = 0;
+
+		// Force non-TTY so promptHidden uses the readline fallback
+		const originalIsTTY = process.stdin.isTTY;
+		process.stdin.isTTY = false;
+
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+		const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+			() =>
+				({
+					question: (_q: string, cb: (answer: string) => void) => {
+						queueMicrotask(() => cb(answers[answerIndex++] ?? ""));
+					},
+					close: () => {},
+				}) as unknown as readline.Interface
+		);
+
+		await expect(handleLogin([])).rejects.toThrow("exit");
+
+		// Should have shown the picker header and provider list
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Provider Login"));
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Select a provider"));
+		// Should have shown the OpenAI login header
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("OpenAI Login"));
+		// Should have saved the key and set the default model
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Saved OpenAI API key"));
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Default model set to: gpt-4o"));
+		// Should have printed the env-var security tip (OpenAI has envVar: OPENAI_API_KEY)
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("OPENAI_API_KEY"));
+		expect(processExitSpy).toHaveBeenCalledWith(0);
+
+		// Verify the config file was actually written with the API key
+		const written = await readFile(TEMP_CONFIG_FILE, "utf-8");
+		expect(written).toContain("sk-test-key-123");
+		expect(written).toContain("gpt-4o");
+
+		process.stdin.isTTY = originalIsTTY;
+		consoleLogSpy.mockRestore();
+		stdoutWriteSpy.mockRestore();
+		processExitSpy.mockRestore();
+		createInterfaceSpy.mockRestore();
+	});
+
+	it("should complete interactive picker login for Ollama local (provider 3)", async () => {
+		// Ollama (Local) is index 2 (choice "3"). It requires no API key,
+		// so the flow is: pick → accept default base URL → save.
+		const answers = ["3", ""];
+		let answerIndex = 0;
+
+		const originalIsTTY = process.stdin.isTTY;
+		process.stdin.isTTY = false;
+
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+		const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+			() =>
+				({
+					question: (_q: string, cb: (answer: string) => void) => {
+						queueMicrotask(() => cb(answers[answerIndex++] ?? ""));
+					},
+					close: () => {},
+				}) as unknown as readline.Interface
+		);
+
+		await expect(handleLogin([])).rejects.toThrow("exit");
+
+		// Should have shown the Ollama note (no API key needed)
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("no API key needed"));
+		// Should have saved the configuration
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Saved Ollama (Local) configuration"));
+		// Should auto-set the default model (no existing default in empty config)
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Default model set to: qwen3-coder"));
+		expect(processExitSpy).toHaveBeenCalledWith(0);
+
+		// Verify the config file was written with the base URL and default model
+		const written = await readFile(TEMP_CONFIG_FILE, "utf-8");
+		expect(written).toContain("http://localhost:11434");
+		expect(written).toContain("qwen3-coder");
+
+		process.stdin.isTTY = originalIsTTY;
+		consoleLogSpy.mockRestore();
+		stdoutWriteSpy.mockRestore();
+		processExitSpy.mockRestore();
+		createInterfaceSpy.mockRestore();
+	});
+
+	it("should exit with error for an invalid picker choice", async () => {
+		const answers = ["99"];
+		let answerIndex = 0;
+
+		const originalIsTTY = process.stdin.isTTY;
+		process.stdin.isTTY = false;
+
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+		const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+			() =>
+				({
+					question: (_q: string, cb: (answer: string) => void) => {
+						queueMicrotask(() => cb(answers[answerIndex++] ?? ""));
+					},
+					close: () => {},
+				}) as unknown as readline.Interface
+		);
+
+		await expect(handleLogin([])).rejects.toThrow("exit");
+
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Invalid choice"));
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+
+		// Config file should NOT have been written
+		expect(existsSync(TEMP_CONFIG_FILE)).toBe(false);
+
+		process.stdin.isTTY = originalIsTTY;
+		consoleLogSpy.mockRestore();
+		processExitSpy.mockRestore();
+		createInterfaceSpy.mockRestore();
 	});
 });


### PR DESCRIPTION
## What

Add a `tiny-agent login` command and `/login` chat command to make provider onboarding frictionless. New users can connect an LLM provider interactively without manually editing `~/.tiny-agent/config.yaml`.

- **`src/cli/handlers/login.ts`** (new): Provider login handler with an interactive picker, direct-provider mode (`tiny-agent login openai`), and a `status` subcommand. API key entry uses masked input (TTY raw-mode `*` echoing). Suggests a sensible default model per provider. Config read/write follows the existing `mcp.ts` pattern (dynamic `yaml` import, handles both YAML and JSON).
- **`src/cli/main.tsx`**: Dispatches `login` before `loadConfig()` (onboarding-safe — users may have no valid config yet). Updated help text and error message.
- **`src/ui/hooks/useCommandHandler.ts`**: Added `/login` chat command showing provider connection status + guidance to run `tiny-agent login` (the Ink chat UI cannot securely capture secrets).
- **`src/ui/components/CommandMenu.tsx`**: Added `/login` to the static command picker.
- **`src/core/agent.ts`**: Added `getProviderConfigs()` so the chat `/login` command can display in-memory provider status.
- **`README.md`**: New "Provider Login (Onboarding)" section with usage examples and a provider/key-URL table. Updated API key troubleshooting, CLI Commands table, Chat Commands table, and Features bullet.
- **`docs/README.md`**: Added missing ADR-012 and ADR-013 entries to the ADR table.
- **`test/cli/handlers/login.test.ts`** (new): 30 tests — 26 pure-function tests (LOGIN_PROVIDERS metadata, findProvider, getProviderStatus, applyProviderToConfig, formatProviderStatus) + 4 smoke tests for `handleLogin` (status with configured/empty/missing config, unknown-provider error).

## Why

New users had to manually create `~/.tiny-agent/config.yaml`, find their provider's API key URL, set environment variables, and edit YAML — all before they could chat. This friction made onboarding the hardest part of using tiny-agent. The `login` command turns this into a 3-step guided flow: pick a provider → enter your key (masked) → start chatting.

## How

- **Pure helpers first**: `findProvider`, `getProviderStatus`, `applyProviderToConfig`, and `formatProviderStatus` are pure functions with no I/O, fully unit-tested. `applyProviderToConfig` preserves all existing config keys (other providers, mcpServers, skillDirectories) and does not mutate its input.
- **Masked key entry**: `promptHidden` uses `stdin.setRawMode(true)` to read character-by-character, echoing `*` per character. Falls back to plain readline in non-TTY mode (e.g. piped input). Ctrl+C restores raw mode before exiting.
- **Config I/O**: `readConfigFile`/`writeConfigFile` handle both `.yaml` and `.json` config files, matching the `getConfigPath()` resolution. Follows the `mcp.ts` handler pattern.
- **Login before loadConfig**: `tiny-agent login` is dispatched before `loadConfig()` in `main.tsx`, so it works even when no valid config exists yet (the onboarding case).
- **Chat `/login` is status-only**: The Ink chat UI has no secure masked text input, so the chat `/login` command shows provider status and guides the user to run the top-level `tiny-agent login` command for actual key entry.
- **Test isolation**: Smoke tests override both `TINY_AGENT_CONFIG_YAML` and `TINY_AGENT_CONFIG_JSON` env vars so `getConfigPath()` never falls through to the user's real config.

## Checklist

- [x] Tests added or updated (30 tests, all passing)
- [x] Documentation updated (README onboarding section, CLI/chat command tables, docs/README.md ADR table)
- [x] No breaking changes (new command only; existing commands unaffected)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive provider login with masked API key entry, provider selection, and configuration saving.
  * Added `tiny-agent login`, provider-specific login, and login status commands.
  * Added `/login` chat command to view provider connection status.
  * Expanded documented provider support, including Z.AI and ClinePass.
  * Added onboarding guidance and API key sources to the documentation.

* **Documentation**
  * Documented the login flow, provider status checks, and related design decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->