### PR TITLE
feat(cli): add /logout command to remove provider API keys

### DIFF
--- a/src/cli/handlers/login.ts
+++ b/src/cli/handlers/login.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { CONFIG_DIR, getConfigPath } from "../../config/loader.js";
 import type { Config } from "../../config/schema.js";
+import { detectProvider } from "../../providers/model-registry.js";
 
 // ===== Types & Constants =====
 
@@ -453,7 +454,211 @@ async function showLoginStatus(): Promise<void> {
 	process.exit(0);
 }
 
-// ===== Main Handler =====
+// ===== Logout: Pure Helper =====
+
+/**
+ * Remove the `apiKey` from a provider's config entry, preserving `baseUrl`
+ * and any other fields. Does NOT delete the provider entry itself — the
+ * provider stays "configured" (e.g. with a custom baseUrl) but is
+ * "disconnected" (no key). Does NOT mutate the input.
+ *
+ * If the provider has no apiKey or no entry at all, the config is returned
+ * unchanged (idempotent for the "already logged out" state).
+ */
+export function removeApiKeyFromConfig(
+	fileConfig: Record<string, unknown>,
+	providerKey: string
+): Record<string, unknown> {
+	const result: Record<string, unknown> = { ...fileConfig };
+
+	const existingProviders =
+		result.providers && typeof result.providers === "object"
+			? { ...(result.providers as Record<string, unknown>) }
+			: {};
+	result.providers = existingProviders;
+
+	const providers = existingProviders as Record<string, Record<string, unknown>>;
+	const existing = providers[providerKey];
+	if (!existing || typeof existing !== "object") {
+		return result;
+	}
+
+	// Shallow-copy and delete the apiKey key
+	const updated: Record<string, unknown> = { ...existing };
+	delete updated.apiKey;
+	providers[providerKey] = updated;
+
+	return result;
+}
+
+// ===== Logout: Interactive Flows =====
+
+/**
+ * Check if the given provider key matches the provider that the current
+ * `defaultModel` auto-detects to. Returns false if no defaultModel is set
+ * or if detectProvider throws.
+ */
+function isActiveProvider(providerKey: string, defaultModel: unknown): boolean {
+	if (typeof defaultModel !== "string" || !defaultModel) return false;
+	try {
+		return detectProvider(defaultModel) === providerKey;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Prompt the user to pick a new default model from the remaining configured
+ * providers. If no other providers are configured, falls back to the Ollama
+ * local default (qwen3-coder).
+ */
+async function promptNewDefaultModel(
+	fileConfig: Record<string, unknown>,
+	loggedOutProviderKey: string
+): Promise<string | undefined> {
+	// Find providers that still have an apiKey (or don't require one)
+	const providers = (fileConfig.providers ?? {}) as Record<string, Record<string, unknown>>;
+	const candidates = LOGIN_PROVIDERS.filter((p) => {
+		if (p.key === loggedOutProviderKey) return false;
+		const cfg = providers[p.key];
+		if (!cfg) return false;
+		if (p.requiresApiKey) return !!cfg.apiKey;
+		return true; // no-key providers like Ollama local are always "ready"
+	});
+
+	if (candidates.length === 0) {
+		// No other providers configured — fall back to Ollama local default
+		const fallback = "qwen3-coder";
+		console.log(`\nNo other providers configured. Falling back to: ${fallback}`);
+		return fallback;
+	}
+
+	if (candidates.length === 1) {
+		const only = candidates[0];
+		if (only?.defaultModel) {
+			console.log(`\nSwitching default model to ${only.name}: ${only.defaultModel}`);
+			return only.defaultModel;
+		}
+	}
+
+	// Multiple candidates — show a picker
+	console.log("\nSelect a new default model:\n");
+	candidates.forEach((p, i) => {
+		const num = `${i + 1}.`.padStart(4);
+		const model = p.defaultModel ?? "(unknown)";
+		console.log(`  ${num} ${p.name.padEnd(16)} ${model}`);
+	});
+	console.log();
+
+	const choice = await prompt(`Enter choice (1-${candidates.length}): `);
+	const index = parseInt(choice, 10) - 1;
+
+	if (Number.isNaN(index) || index < 0 || index >= candidates.length) {
+		console.log("\n✗ Invalid choice. Keeping current default model.");
+		return undefined;
+	}
+
+	const selected = candidates[index];
+	return selected?.defaultModel;
+}
+
+async function logoutProvider(provider: LoginProviderInfo): Promise<void> {
+	// Refuse for providers that don't have an API key (e.g. Ollama local)
+	if (!provider.requiresApiKey) {
+		console.log(`\n${provider.name} has no API key to remove.`);
+		console.log(`Use 'tiny-agent login ${provider.key}' to reconfigure the base URL.\n`);
+		process.exit(0);
+	}
+
+	const configPath = getConfigPath();
+	const fileConfig = await readConfigFile(configPath);
+
+	// Check if the provider has an apiKey to remove
+	const providerConfig = (fileConfig.providers as Record<string, Record<string, unknown>>)?.[provider.key];
+	const hasApiKey = !!providerConfig?.apiKey;
+
+	if (!providerConfig) {
+		console.log(`\n${provider.name} is not configured. Nothing to log out.\n`);
+		process.exit(0);
+	}
+
+	if (!hasApiKey) {
+		console.log(`\n${provider.name} is configured but has no API key set. Already logged out.\n`);
+		process.exit(0);
+	}
+
+	// Remove the apiKey
+	let updatedConfig = removeApiKeyFromConfig(fileConfig, provider.key);
+
+	// Check if the logged-out provider was the active default model
+	const currentDefault = fileConfig.defaultModel;
+	if (isActiveProvider(provider.key, currentDefault)) {
+		console.log(`\n⚠️  The default model (${currentDefault}) uses ${provider.name}.`);
+		const newModel = await promptNewDefaultModel(updatedConfig, provider.key);
+		if (newModel) {
+			updatedConfig = { ...updatedConfig, defaultModel: newModel };
+			console.log(`✓ Default model set to: ${newModel}`);
+		}
+	}
+
+	await writeConfigFile(configPath, updatedConfig);
+
+	console.log(`\n✓ Removed ${provider.name} API key from ${configPath}`);
+	console.log(
+		`\nLogout complete! The ${provider.name} provider entry is preserved (baseUrl, etc.) but has no API key.\n`
+	);
+	process.exit(0);
+}
+
+async function logoutInteractive(): Promise<void> {
+	console.log("\n🔒 Tiny Agent — Provider Logout\n");
+
+	const configPath = getConfigPath();
+	const fileConfig = await readConfigFile(configPath);
+	const providers = fileConfig.providers as Config["providers"] | undefined;
+
+	// Show current status
+	console.log(formatProviderStatus(providers));
+	console.log();
+
+	// Filter to providers that have an API key set (can be logged out)
+	const providersWithKeys = LOGIN_PROVIDERS.filter((p) => {
+		if (!p.requiresApiKey) return false;
+		const cfg = providers?.[p.key as keyof NonNullable<typeof providers>];
+		return !!cfg?.apiKey;
+	});
+
+	if (providersWithKeys.length === 0) {
+		console.log("No providers have an API key set. Nothing to log out.\n");
+		process.exit(0);
+	}
+
+	// Show picker
+	console.log("Select a provider to log out:\n");
+	providersWithKeys.forEach((p, i) => {
+		const num = `${i + 1}.`.padStart(4);
+		console.log(`  ${num} ${p.name}`);
+	});
+	console.log();
+
+	const choice = await prompt(`Enter choice (1-${providersWithKeys.length}): `);
+	const index = parseInt(choice, 10) - 1;
+
+	if (Number.isNaN(index) || index < 0 || index >= providersWithKeys.length) {
+		console.log("\n✗ Invalid choice. Logout cancelled.");
+		process.exit(1);
+	}
+
+	const provider = providersWithKeys[index];
+	if (!provider) {
+		console.log("\n✗ Invalid choice. Logout cancelled.");
+		process.exit(1);
+	}
+
+	await logoutProvider(provider);
+}
+
+// ===== Main Handlers =====
 
 export async function handleLogin(args: string[]): Promise<void> {
 	const subCommand = args[0];
@@ -477,4 +682,41 @@ export async function handleLogin(args: string[]): Promise<void> {
 
 	// Interactive picker
 	await loginInteractive();
+}
+
+// ===== Logout: Status & Main Handler =====
+
+async function showLogoutStatus(): Promise<void> {
+	const configPath = getConfigPath();
+	const fileConfig = await readConfigFile(configPath);
+	const providers = fileConfig.providers as Config["providers"] | undefined;
+
+	console.log(`\n${formatProviderStatus(providers)}\n`);
+	console.log("Run `tiny-agent logout` to remove a provider's API key interactively.");
+	console.log("Run `tiny-agent logout <provider>` to log out a specific provider directly.\n");
+	process.exit(0);
+}
+
+export async function handleLogout(args: string[]): Promise<void> {
+	const subCommand = args[0];
+
+	if (subCommand === "status") {
+		await showLogoutStatus();
+		return;
+	}
+
+	// If a provider key was given as arg, go straight to it
+	if (subCommand) {
+		const provider = findProvider(subCommand);
+		if (provider) {
+			await logoutProvider(provider);
+			return;
+		}
+		console.error(`Unknown provider: ${subCommand}`);
+		console.error(`Available: ${LOGIN_PROVIDERS.map((p) => p.key).join(", ")}`);
+		process.exit(1);
+	}
+
+	// Interactive picker
+	await logoutInteractive();
 }

--- a/src/cli/main.tsx
+++ b/src/cli/main.tsx
@@ -10,7 +10,7 @@ import { StatusType } from "../ui/types/enums.js";
 import { isJsonMode, setJsonMode, setNoColor, shouldUseInk } from "../ui/utils.js";
 import { handleAgent } from "./handlers/agent.js";
 import { handleConfig } from "./handlers/config.js";
-import { handleLogin } from "./handlers/login.js";
+import { handleLogin, handleLogout } from "./handlers/login.js";
 import { handleMcp } from "./handlers/mcp.js";
 import { handleMemory } from "./handlers/memory.js";
 import { handlePlan } from "./handlers/plan.js";
@@ -508,6 +508,7 @@ USAGE:
     tiny-agent config open             Open config file in editor
     tiny-agent status                  Show provider and model capabilities
     tiny-agent login [provider]        Connect an LLM provider (onboarding)
+    tiny-agent logout [provider]       Remove a provider's API key
     tiny-agent memory [command]        Manage memories
     tiny-agent skill [command]         Manage skills
     tiny-agent mcp [command]           Manage MCP servers
@@ -566,7 +567,9 @@ EXAMPLES:
     tiny-agent config open             Open config in editor
     tiny-agent login                   Connect a provider interactively
     tiny-agent login openai            Connect OpenAI directly
+    tiny-agent logout openai           Remove OpenAI's API key
     tiny-agent login status            Show provider connection status
+    tiny-agent logout status           Show provider connection status
     tiny-agent status                  Show provider and model capabilities
     tiny-agent --upgrade               Upgrade to the latest version
     tiny-agent --help                  Show this help message
@@ -620,6 +623,13 @@ export async function main(): Promise<void> {
 			return;
 		}
 
+		// `logout` also runs before loadConfig() so it can remove a key even if
+		// the remaining config is invalid (e.g. no providers left at all).
+		if (command === "logout") {
+			await handleLogout(args);
+			return;
+		}
+
 		const config = loadConfig();
 
 		if (command === "chat") {
@@ -651,7 +661,7 @@ export async function main(): Promise<void> {
 		} else {
 			console.error(`Unknown command: ${command}`);
 			console.error(
-				"Available commands: chat, run <prompt>, trace <prompt>, login, config, status, memory, skill, mcp, plan, build, explore, run-plan-build, run-all, state, plan show, tasks, todo"
+				"Available commands: chat, run <prompt>, trace <prompt>, login, logout, config, status, memory, skill, mcp, plan, build, explore, run-plan-build, run-all, state, plan show, tasks, todo"
 			);
 			console.error("Options: --model <model>, --provider <provider>, --verbose, --save, --state-file, --help");
 			process.exit(2);

--- a/src/ui/components/CommandMenu.tsx
+++ b/src/ui/components/CommandMenu.tsx
@@ -21,6 +21,7 @@ const STATIC_COMMANDS: Command[] = [
 	{ name: "/model", description: "Switch the model" },
 	{ name: "/agent", description: "Switch agent" },
 	{ name: "/login", description: "Show provider connection status" },
+	{ name: "/logout", description: "Show provider logout guidance" },
 	{ name: "/tools", description: "View tool executions" },
 	{ name: "/mcp", description: "Show MCP server status" },
 	{ name: "/memory", description: "List memories" },

--- a/src/ui/hooks/useCommandHandler.ts
+++ b/src/ui/hooks/useCommandHandler.ts
@@ -222,6 +222,28 @@ export function useCommandHandler({
 		);
 	}, [agent, onAddMessage]);
 
+	const handleLogoutCommand = useCallback(() => {
+		if (!agent) {
+			onAddMessage(MessageRole.ASSISTANT, "Error: Agent not initialized. Cannot show provider status.");
+			return;
+		}
+
+		// Show current provider connection status + logout guidance.
+		// The actual key removal happens via the top-level `tiny-agent logout`
+		// command, because it writes to the config file on disk.
+		const providerConfigs = agent.getProviderConfigs();
+		const status = formatProviderStatus(providerConfigs);
+
+		onAddMessage(
+			MessageRole.ASSISTANT,
+			`${status}\n\n` +
+				`To remove a provider's API key, exit and run:\n` +
+				`  tiny-agent logout          Interactive provider picker\n` +
+				`  tiny-agent logout openai   Log out a specific provider\n` +
+				`  tiny-agent logout status   Show this status again`
+		);
+	}, [agent, onAddMessage]);
+
 	const handleMemoryCommand = useCallback(() => {
 		if (!agent) {
 			onAddMessage(MessageRole.ASSISTANT, "Error: Agent not initialized.");
@@ -262,6 +284,7 @@ export function useCommandHandler({
   /model   - Switch model
   /agent   - Switch agent
   /login   - Show provider connection status
+  /logout  - Show provider logout status
   /tools   - View tool executions
   /mcp     - Show MCP server status
   /memory  - List memories
@@ -293,6 +316,9 @@ Use ←/→ to navigate, Enter to select.`
 					break;
 				case "/login":
 					handleLoginCommand();
+					break;
+				case "/logout":
+					handleLogoutCommand();
 					break;
 				case "/mcp":
 					handleMcpCommand();
@@ -328,6 +354,7 @@ Use ←/→ to navigate, Enter to select.`
 			onExit,
 			handleSkillCommand,
 			handleLoginCommand,
+			handleLogoutCommand,
 			handleMcpCommand,
 			handleMemoryCommand,
 			handlePlanCommand,

--- a/test/cli/handlers/login.test.ts
+++ b/test/cli/handlers/login.test.ts
@@ -9,7 +9,9 @@ import {
 	formatProviderStatus,
 	getProviderStatus,
 	handleLogin,
+	handleLogout,
 	LOGIN_PROVIDERS,
+	removeApiKeyFromConfig,
 } from "../../../src/cli/handlers/login.js";
 import type { Config } from "../../../src/config/schema.js";
 
@@ -199,35 +201,6 @@ describe("login handler", () => {
 			expect(originalProviders.openai?.apiKey).toBe("old");
 		});
 	});
-	describe("formatProviderStatus()", () => {
-		it("should include a header and every provider name", () => {
-			const output = formatProviderStatus(undefined);
-			expect(output).toContain("Provider Connection Status");
-			expect(output).toContain("OpenAI");
-			expect(output).toContain("Anthropic");
-			expect(output).toContain("Ollama (Local)");
-			expect(output).toContain("OpenRouter");
-		});
-
-		it("should show 'not configured' for unconfigured providers", () => {
-			const output = formatProviderStatus(undefined);
-			expect(output).toContain("not configured");
-		});
-
-		it("should show 'API key set' for a configured provider with a key", () => {
-			const providers: Config["providers"] = { openai: { apiKey: "sk-test" } };
-			const output = formatProviderStatus(providers);
-			expect(output).toContain("API key set");
-		});
-
-		it("should show 'ready' for a configured local provider", () => {
-			const providers: Config["providers"] = { ollama: { baseUrl: "http://localhost:11434" } };
-			const output = formatProviderStatus(providers);
-			// Ollama local doesn't require API key — "ready" when configured
-			expect(output).toContain("ready");
-		});
-	});
-
 	describe("containsLiteralApiKey()", () => {
 		// Construct env-var reference strings via concatenation to avoid
 		// Biome's noTemplateCurlyInString lint rule, which flags ${...} in
@@ -287,6 +260,109 @@ describe("login handler", () => {
 			expect(containsLiteralApiKey({ providers: "not-an-object" })).toBe(false);
 			expect(containsLiteralApiKey({ providers: null })).toBe(false);
 			expect(containsLiteralApiKey({ providers: [] })).toBe(false);
+		});
+	});
+
+	describe("formatProviderStatus()", () => {
+		it("should include a header and every provider name", () => {
+			const output = formatProviderStatus(undefined);
+			expect(output).toContain("Provider Connection Status");
+			expect(output).toContain("OpenAI");
+			expect(output).toContain("Anthropic");
+			expect(output).toContain("Ollama (Local)");
+			expect(output).toContain("OpenRouter");
+		});
+
+		it("should show 'not configured' for unconfigured providers", () => {
+			const output = formatProviderStatus(undefined);
+			expect(output).toContain("not configured");
+		});
+
+		it("should show 'API key set' for a configured provider with a key", () => {
+			const providers: Config["providers"] = { openai: { apiKey: "sk-test" } };
+			const output = formatProviderStatus(providers);
+			expect(output).toContain("API key set");
+		});
+
+		it("should show 'ready' for a configured local provider", () => {
+			const providers: Config["providers"] = { ollama: { baseUrl: "http://localhost:11434" } };
+			const output = formatProviderStatus(providers);
+			// Ollama local doesn't require API key — "ready" when configured
+			expect(output).toContain("ready");
+		});
+	});
+
+	describe("removeApiKeyFromConfig()", () => {
+		it("should remove the apiKey and preserve other fields", () => {
+			const input: Record<string, unknown> = {
+				providers: { openai: { apiKey: "sk-test", baseUrl: "https://custom.api" } },
+			};
+			const result = removeApiKeyFromConfig(input, "openai");
+			expect(result.providers).toEqual({ openai: { baseUrl: "https://custom.api" } });
+		});
+
+		it("should remove the apiKey when it is the only field", () => {
+			const input: Record<string, unknown> = {
+				providers: { openai: { apiKey: "sk-test" } },
+			};
+			const result = removeApiKeyFromConfig(input, "openai");
+			expect(result.providers).toEqual({ openai: {} });
+		});
+
+		it("should preserve other providers", () => {
+			const input: Record<string, unknown> = {
+				providers: {
+					openai: { apiKey: "sk-test" },
+					anthropic: { apiKey: "sk-ant" },
+				},
+			};
+			const result = removeApiKeyFromConfig(input, "openai");
+			expect(result.providers).toEqual({
+				openai: {},
+				anthropic: { apiKey: "sk-ant" },
+			});
+		});
+
+		it("should preserve other top-level keys (defaultModel, mcpServers)", () => {
+			const input: Record<string, unknown> = {
+				defaultModel: "gpt-4o",
+				mcpServers: { context7: { command: "npx" } },
+				providers: { openai: { apiKey: "sk-test" } },
+			};
+			const result = removeApiKeyFromConfig(input, "openai");
+			expect(result.defaultModel).toBe("gpt-4o");
+			expect(result.mcpServers).toEqual({ context7: { command: "npx" } });
+		});
+
+		it("should be idempotent — return unchanged if no apiKey exists", () => {
+			const input: Record<string, unknown> = {
+				providers: { openai: { baseUrl: "https://custom.api" } },
+			};
+			const result = removeApiKeyFromConfig(input, "openai");
+			expect(result.providers).toEqual({ openai: { baseUrl: "https://custom.api" } });
+		});
+
+		it("should return unchanged if the provider entry doesn't exist", () => {
+			const input: Record<string, unknown> = {
+				providers: { anthropic: { apiKey: "sk-ant" } },
+			};
+			const result = removeApiKeyFromConfig(input, "openai");
+			expect(result.providers).toEqual({ anthropic: { apiKey: "sk-ant" } });
+		});
+
+		it("should return unchanged if no providers object exists", () => {
+			const result = removeApiKeyFromConfig({ defaultModel: "gpt-4o" }, "openai");
+			expect(result.providers).toEqual({});
+			expect(result.defaultModel).toBe("gpt-4o");
+		});
+
+		it("should not mutate the input object", () => {
+			const input: Record<string, unknown> = {
+				providers: { openai: { apiKey: "sk-original" } },
+			};
+			removeApiKeyFromConfig(input, "openai");
+			const originalProviders = input.providers as Record<string, { apiKey: string }>;
+			expect(originalProviders.openai?.apiKey).toBe("sk-original");
 		});
 	});
 });
@@ -551,5 +627,328 @@ providers: {}
 		consoleLogSpy.mockRestore();
 		processExitSpy.mockRestore();
 		createInterfaceSpy.mockRestore();
+	});
+});
+
+// ===== handleLogout() smoke tests =====
+// Follows the same pattern as the handleLogin smoke tests: spy on
+// console.log/console.error + process.exit, write a temp config file, and
+// assert output + exit codes. Both config env vars are overridden so
+// getConfigPath() never touches the user's real config.
+
+describe("handleLogout", () => {
+	const TEMP_CONFIG_FILE = `/tmp/test-logout-config-${Date.now()}.yaml`;
+	const TEMP_CONFIG_JSON = `/tmp/test-logout-config-${Date.now()}.json`;
+	let originalConfigYaml: string | undefined;
+	let originalConfigJson: string | undefined;
+
+	beforeEach(() => {
+		originalConfigYaml = process.env.TINY_AGENT_CONFIG_YAML;
+		originalConfigJson = process.env.TINY_AGENT_CONFIG_JSON;
+		process.env.TINY_AGENT_CONFIG_YAML = TEMP_CONFIG_FILE;
+		process.env.TINY_AGENT_CONFIG_JSON = TEMP_CONFIG_JSON;
+		for (const f of [TEMP_CONFIG_FILE, TEMP_CONFIG_JSON]) {
+			if (existsSync(f)) unlinkSync(f);
+		}
+	});
+
+	afterEach(() => {
+		for (const f of [TEMP_CONFIG_FILE, TEMP_CONFIG_JSON]) {
+			if (existsSync(f)) unlinkSync(f);
+		}
+		if (originalConfigYaml === undefined) {
+			delete process.env.TINY_AGENT_CONFIG_YAML;
+		} else {
+			process.env.TINY_AGENT_CONFIG_YAML = originalConfigYaml;
+		}
+		if (originalConfigJson === undefined) {
+			delete process.env.TINY_AGENT_CONFIG_JSON;
+		} else {
+			process.env.TINY_AGENT_CONFIG_JSON = originalConfigJson;
+		}
+	});
+
+	it("should show provider status with 'status' subcommand", async () => {
+		const yamlContent = `defaultModel: gpt-4o
+providers:
+  openai:
+    apiKey: sk-test-key
+`;
+		await writeFile(TEMP_CONFIG_FILE, yamlContent, "utf-8");
+
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+
+		await expect(handleLogout(["status"])).rejects.toThrow("exit");
+
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Provider Connection Status"));
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Run `tiny-agent logout`"));
+		expect(processExitSpy).toHaveBeenCalledWith(0);
+
+		consoleLogSpy.mockRestore();
+		processExitSpy.mockRestore();
+	});
+
+	it("should exit with error for an unknown provider argument", async () => {
+		const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+
+		await expect(handleLogout(["nonexistent"])).rejects.toThrow("exit");
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Unknown provider: nonexistent"));
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+
+		consoleErrorSpy.mockRestore();
+		processExitSpy.mockRestore();
+	});
+
+	it("should refuse to log out Ollama (no API key)", async () => {
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+
+		await expect(handleLogout(["ollama"])).rejects.toThrow("exit");
+
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("no API key to remove"));
+		expect(processExitSpy).toHaveBeenCalledWith(0);
+
+		consoleLogSpy.mockRestore();
+		processExitSpy.mockRestore();
+	});
+
+	it("should report 'not configured' for an unconfigured provider", async () => {
+		// No config file — openai is not configured
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+
+		await expect(handleLogout(["openai"])).rejects.toThrow("exit");
+
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("not configured"));
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Nothing to log out"));
+		expect(processExitSpy).toHaveBeenCalledWith(0);
+
+		consoleLogSpy.mockRestore();
+		processExitSpy.mockRestore();
+	});
+
+	it("should remove the API key and preserve baseUrl", async () => {
+		const yamlContent = `defaultModel: gpt-4o
+providers:
+  openai:
+    apiKey: sk-test-key
+    baseUrl: https://custom.api
+`;
+		await writeFile(TEMP_CONFIG_FILE, yamlContent, "utf-8");
+
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+
+		await expect(handleLogout(["openai"])).rejects.toThrow("exit");
+
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Removed OpenAI API key"));
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Logout complete"));
+		expect(processExitSpy).toHaveBeenCalledWith(0);
+
+		// Verify the API key was removed but baseUrl was preserved
+		const written = await readFile(TEMP_CONFIG_FILE, "utf-8");
+		expect(written).not.toContain("sk-test-key");
+		expect(written).toContain("https://custom.api");
+
+		consoleLogSpy.mockRestore();
+		processExitSpy.mockRestore();
+	});
+
+	it("should prompt for a new default model when logging out the active provider", async () => {
+		// OpenAI is the active provider (defaultModel: gpt-4o → detectProvider → openai).
+		// Anthropic and OpenRouter are also configured, so the picker should
+		// offer 2 candidates (the multi-candidate path that shows the picker).
+		const yamlContent = `defaultModel: gpt-4o
+providers:
+  openai:
+    apiKey: sk-test-key
+  anthropic:
+    apiKey: sk-ant-key
+  openrouter:
+    apiKey: sk-or-key
+`;
+		await writeFile(TEMP_CONFIG_FILE, yamlContent, "utf-8");
+
+		// Answer "1" to pick Anthropic (first candidate) from the picker
+		const answers = ["1"];
+		let answerIndex = 0;
+
+		const originalIsTTY = process.stdin.isTTY;
+		process.stdin.isTTY = false;
+
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+		const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+			() =>
+				({
+					question: (_q: string, cb: (answer: string) => void) => {
+						queueMicrotask(() => cb(answers[answerIndex++] ?? ""));
+					},
+					close: () => {},
+				}) as unknown as readline.Interface
+		);
+
+		await expect(handleLogout(["openai"])).rejects.toThrow("exit");
+
+		// Should have warned that the default model uses the logged-out provider
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("default model"));
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Select a new default model"));
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Default model set to"));
+		expect(processExitSpy).toHaveBeenCalledWith(0);
+
+		// Verify the config: openai key removed, defaultModel switched to Anthropic's model
+		const written = await readFile(TEMP_CONFIG_FILE, "utf-8");
+		expect(written).not.toContain("sk-test-key");
+		expect(written).toContain("sk-ant-key");
+		expect(written).not.toContain("gpt-4o");
+		expect(written).toContain("claude-sonnet-4");
+
+		process.stdin.isTTY = originalIsTTY;
+		consoleLogSpy.mockRestore();
+		processExitSpy.mockRestore();
+		createInterfaceSpy.mockRestore();
+	});
+
+	it("should fall back to qwen3-coder when no other providers are configured", async () => {
+		// Only OpenAI is configured — no other candidate after logout
+		const yamlContent = `defaultModel: gpt-4o
+providers:
+  openai:
+    apiKey: sk-test-key
+`;
+		await writeFile(TEMP_CONFIG_FILE, yamlContent, "utf-8");
+
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+
+		await expect(handleLogout(["openai"])).rejects.toThrow("exit");
+
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("No other providers configured"));
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("qwen3-coder"));
+		expect(processExitSpy).toHaveBeenCalledWith(0);
+
+		const written = await readFile(TEMP_CONFIG_FILE, "utf-8");
+		expect(written).not.toContain("sk-test-key");
+		expect(written).toContain("qwen3-coder");
+
+		consoleLogSpy.mockRestore();
+		processExitSpy.mockRestore();
+	});
+
+	it("should report 'already logged out' when no API key is set", async () => {
+		const yamlContent = `defaultModel: gpt-4o
+providers:
+  openai:
+    baseUrl: https://custom.api
+`;
+		await writeFile(TEMP_CONFIG_FILE, yamlContent, "utf-8");
+
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+
+		await expect(handleLogout(["openai"])).rejects.toThrow("exit");
+
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("no API key set"));
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Already logged out"));
+		expect(processExitSpy).toHaveBeenCalledWith(0);
+
+		consoleLogSpy.mockRestore();
+		processExitSpy.mockRestore();
+	});
+
+	it("should complete interactive picker logout for OpenAI", async () => {
+		// Config has OpenAI + Anthropic keys. Picker shows only providers WITH keys.
+		// Answer "1" selects OpenAI (first in the filtered list). The default model
+		// gpt-4o uses OpenAI, so a new-default-model prompt appears — but with only
+		// Anthropic remaining as a candidate, it auto-selects (single-candidate path).
+		const yamlContent = `defaultModel: gpt-4o
+providers:
+  openai:
+    apiKey: sk-test-key
+  anthropic:
+    apiKey: sk-ant-key
+`;
+		await writeFile(TEMP_CONFIG_FILE, yamlContent, "utf-8");
+
+		const answers = ["1"];
+		let answerIndex = 0;
+
+		const originalIsTTY = process.stdin.isTTY;
+		process.stdin.isTTY = false;
+
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+		const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+			() =>
+				({
+					question: (_q: string, cb: (answer: string) => void) => {
+						queueMicrotask(() => cb(answers[answerIndex++] ?? ""));
+					},
+					close: () => {},
+				}) as unknown as readline.Interface
+		);
+
+		await expect(handleLogout([])).rejects.toThrow("exit");
+
+		// Should have shown the logout picker header
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Provider Logout"));
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Select a provider to log out"));
+		// Should have removed the OpenAI key
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Removed OpenAI API key"));
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Logout complete"));
+		expect(processExitSpy).toHaveBeenCalledWith(0);
+
+		// Verify the config: OpenAI key removed, Anthropic key preserved, default switched
+		const written = await readFile(TEMP_CONFIG_FILE, "utf-8");
+		expect(written).not.toContain("sk-test-key");
+		expect(written).toContain("sk-ant-key");
+
+		process.stdin.isTTY = originalIsTTY;
+		consoleLogSpy.mockRestore();
+		processExitSpy.mockRestore();
+		createInterfaceSpy.mockRestore();
+	});
+
+	it("should report 'nothing to log out' when no providers have keys", async () => {
+		const yamlContent = `defaultModel: qwen3-coder
+providers:
+  ollama:
+    baseUrl: http://localhost:11434
+`;
+		await writeFile(TEMP_CONFIG_FILE, yamlContent, "utf-8");
+
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("exit");
+		});
+
+		await expect(handleLogout([])).rejects.toThrow("exit");
+
+		expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Nothing to log out"));
+		expect(processExitSpy).toHaveBeenCalledWith(0);
+
+		consoleLogSpy.mockRestore();
+		processExitSpy.mockRestore();
 	});
 });


### PR DESCRIPTION
## What

Add a `tiny-agent logout` top-level command and `/logout` chat command that remove a provider's API key from the config file. The logout command mirrors the login command structure: interactive picker, direct provider argument (`tiny-agent logout openai`), and a status-only subcommand (`tiny-agent logout status`).

**Files changed:**
- `src/cli/handlers/login.ts` — `removeApiKeyFromConfig` pure function, `isActiveProvider` helper (uses `detectProvider`), `promptNewDefaultModel` interactive picker, `logoutProvider`/`logoutInteractive`/`showLogoutStatus` flows, `handleLogout` export
- `src/cli/main.tsx` — `handleLogout` import + dispatch before `loadConfig()`, help text updates
- `src/ui/components/CommandMenu.tsx` — `/logout` added to `STATIC_COMMANDS`
- `src/ui/hooks/useCommandHandler.ts` — `handleLogoutCommand` callback (status-only, mirrors `/login`), `/logout` case in command switch
- `test/cli/handlers/login.test.ts` — 18 new tests (8 `removeApiKeyFromConfig` unit tests + 10 `handleLogout` smoke tests)

## Why

Users who have configured a provider via `tiny-agent login` need a symmetric way to disconnect — removing the API key from the config file without manually editing YAML. This is especially important for:
- Rotating compromised keys
- Switching from one provider to another
- Cleaning up before sharing a config file

Without `/logout`, users had to either edit `config.yaml` by hand or delete the entire provider entry (losing `baseUrl` and other settings). The `/logout` command removes only the `apiKey` field, preserving everything else.

## How

- **`removeApiKeyFromConfig`** — a pure function that deletes only the `apiKey` key from a provider's config entry, preserving `baseUrl` and other fields. Idempotent (no-op if no key exists). Does not mutate the input.
- **`logoutProvider`** — handles edge cases in order:
  1. **Ollama refusal** — Ollama (Local) has no API key to remove
  2. **Not configured** — provider entry doesn't exist
  3. **Already logged out** — provider is configured but has no `apiKey`
  4. **Active provider detection** — if the logged-out provider was the active `defaultModel`, prompt for a new one
  5. **Fallback** — if no other providers are configured, fall back to `qwen3-coder` (Ollama local, always available)
- **`promptNewDefaultModel`** — finds remaining configured providers (with API keys, or no-key providers like Ollama). Single-candidate → auto-select. Multi-candidate → interactive picker. Zero candidates → `qwen3-coder` fallback.
- **Dispatch before `loadConfig()`** — same rationale as `login`: the user may be logging out because the config is in a bad state.
- **`/logout` chat command is status-only** — mirrors the `/login` pattern. The Ink chat UI has no secure masked input, so the actual key removal happens via the top-level `tiny-agent logout` command. The chat command shows provider status + guidance.

**Stacked on PR #59** (`feat/login-command`) — the 0o600 permissions hardening commit is on the base branch, so the logout diff is clean.

## Checklist

- [x] Tests added or updated (18 new tests: 8 pure function + 10 smoke tests)
- [ ] Documentation updated
- [x] No breaking changes
