### PR TITLE
refactor(cli): extract CLI prompt helper to consolidate 3-way readline duplication

### DIFF
--- a/src/agents/build-agent.ts
+++ b/src/agents/build-agent.ts
@@ -1,3 +1,4 @@
+import { promptChoice } from "../cli/prompt.js";
 import { loadConfig } from "../config/loader.js";
 import { createProvider, parseModelString } from "../providers/factory.js";
 import type { Message } from "../providers/types.js";
@@ -152,18 +153,8 @@ function mapBuildAction(action: BuildAction): MappedBuildAction {
  * confirmation.ts. Maintained in build-agent because the recovery path is
  * unique to build-time execution flow.
  */
-async function promptRecoveryDecision(prompt: string, options: string[]): Promise<string> {
-	const { createInterface } = await import("node:readline");
-	const rl = createInterface({ input: process.stdin, output: process.stdout });
-
-	return new Promise((resolve) => {
-		rl.question(`${prompt}\nOptions: ${options.join(", ")}: `, (answer) => {
-			rl.close();
-			const normalized = answer.toLowerCase().trim();
-			const matched = options.find((option) => option.toLowerCase() === normalized);
-			resolve(matched ?? options[0] ?? "y");
-		});
-	});
+async function promptRecoveryDecision(promptText: string, options: string[]): Promise<string> {
+	return promptChoice(promptText, options);
 }
 
 async function handleExecutionError(

--- a/src/agents/plan-agent.ts
+++ b/src/agents/plan-agent.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { prompt } from "../cli/prompt.js";
 import { loadConfig } from "../config/loader.js";
 import { createProvider, parseModelString } from "../providers/factory.js";
 import type { Message } from "../providers/types.js";
@@ -235,19 +236,8 @@ export async function planAgent(taskDescription: string, options?: PlanAgentOpti
 }
 
 export async function confirmMajorDecision(decision: string): Promise<boolean> {
-	const readline = await import("node:readline");
-	const rl = readline.createInterface({
-		input: process.stdin,
-		output: process.stdout,
-	});
-
-	return new Promise((resolve) => {
-		rl.question(
-			`⚠️  Major architectural decision detected:\n\n${decision}\n\nDo you want to proceed? (y/n): `,
-			(answer) => {
-				rl.close();
-				resolve(answer.toLowerCase().startsWith("y"));
-			}
-		);
-	});
+	const answer = await prompt(
+		`⚠️  Major architectural decision detected:\n\n${decision}\n\nDo you want to proceed? (y/n): `
+	);
+	return answer.toLowerCase().startsWith("y");
 }

--- a/src/cli/handlers/login.ts
+++ b/src/cli/handlers/login.ts
@@ -2,6 +2,7 @@ import { readConfigFile, writeConfigFile } from "../../config/config-io.js";
 import { getConfigPath } from "../../config/loader.js";
 import type { Config } from "../../config/schema.js";
 import { detectProvider } from "../../providers/model-registry.js";
+import { prompt, promptHidden } from "../prompt.js";
 
 // Re-export for backward compatibility — tests import containsLiteralApiKey
 // from login.ts. The canonical home is now config-io.ts.
@@ -185,84 +186,6 @@ export function formatProviderStatus(providers: Config["providers"] | undefined)
 	}
 
 	return lines.join("\n");
-}
-
-// ===== Prompt Helpers (readline-based, matching build-agent.ts pattern) =====
-
-async function prompt(question: string): Promise<string> {
-	const { createInterface } = await import("node:readline");
-	const rl = createInterface({ input: process.stdin, output: process.stdout });
-	return new Promise((resolve) => {
-		rl.question(question, (answer) => {
-			rl.close();
-			resolve(answer.trim());
-		});
-	});
-}
-
-/**
- * Read a line from stdin with masked input (echoes `*` for each character).
- * Falls back to plain readline when stdin is not a TTY (e.g. piped input).
- */
-async function promptHidden(promptText: string): Promise<string> {
-	process.stdout.write(promptText);
-
-	const stdin = process.stdin;
-
-	// Non-TTY fallback: use plain readline (input will be visible)
-	if (!stdin.isTTY || typeof stdin.setRawMode !== "function") {
-		const { createInterface } = await import("node:readline");
-		const rl = createInterface({ input: stdin, output: process.stdout });
-		return new Promise((resolve) => {
-			rl.question("", (answer) => {
-				rl.close();
-				resolve(answer.trim());
-			});
-		});
-	}
-
-	// TTY: read character-by-character with masking
-	return new Promise((resolve) => {
-		let input = "";
-		stdin.setRawMode(true);
-		stdin.resume();
-		stdin.setEncoding("utf8");
-
-		const onData = (char: string): void => {
-			const code = char.charCodeAt(0);
-			switch (char) {
-				case "\r":
-				case "\n":
-					stdin.removeListener("data", onData);
-					stdin.setRawMode(false);
-					stdin.pause();
-					process.stdout.write("\n");
-					resolve(input.trim());
-					break;
-				case "\u0003": // Ctrl+C
-					stdin.setRawMode(false);
-					stdin.pause();
-					process.stdout.write("\n");
-					process.exit(0);
-					break;
-				case "\u007f": // Delete
-				case "\b": // Backspace
-					if (input.length > 0) {
-						input = input.slice(0, -1);
-						process.stdout.write("\b \b");
-					}
-					break;
-				default:
-					// Only store printable characters (code >= 32)
-					if (code >= 32) {
-						input += char;
-						process.stdout.write("*");
-					}
-			}
-		};
-
-		stdin.on("data", onData);
-	});
 }
 
 // ===== Interactive Flows =====

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -1,0 +1,113 @@
+/**
+ * CLI prompt helpers — the single source of truth for readline-based user
+ * input. Extracted from login.ts (prompt, promptHidden), build-agent.ts
+ * (promptRecoveryDecision), and plan-agent.ts (inline readline).
+ *
+ * The security-sensitive `promptHidden` (raw-mode `*` echoing with Ctrl+C
+ * handling) lives here so it can be tested in isolation.
+ */
+
+/**
+ * Read a line from stdin via readline. Returns the trimmed answer.
+ */
+export async function prompt(question: string): Promise<string> {
+	const { createInterface } = await import("node:readline");
+	const rl = createInterface({ input: process.stdin, output: process.stdout });
+	return new Promise((resolve) => {
+		rl.question(question, (answer) => {
+			rl.close();
+			resolve(answer.trim());
+		});
+	});
+}
+
+/**
+ * Read a line from stdin with masked input (echoes `*` for each character).
+ * Falls back to plain readline when stdin is not a TTY (e.g. piped input).
+ *
+ * Security note: the raw-mode masking only works in a real PTY. When stdin
+ * is piped (not a TTY), the input will be visible — this is the fallback
+ * path used in tests.
+ */
+export async function promptHidden(promptText: string): Promise<string> {
+	process.stdout.write(promptText);
+
+	const stdin = process.stdin;
+
+	// Non-TTY fallback: use plain readline (input will be visible)
+	if (!stdin.isTTY || typeof stdin.setRawMode !== "function") {
+		const { createInterface } = await import("node:readline");
+		const rl = createInterface({ input: stdin, output: process.stdout });
+		return new Promise((resolve) => {
+			rl.question("", (answer) => {
+				rl.close();
+				resolve(answer.trim());
+			});
+		});
+	}
+
+	// TTY: read character-by-character with masking
+	return new Promise((resolve) => {
+		let input = "";
+		stdin.setRawMode(true);
+		stdin.resume();
+		stdin.setEncoding("utf8");
+
+		const onData = (char: string): void => {
+			const code = char.charCodeAt(0);
+			switch (char) {
+				case "\r":
+				case "\n":
+					stdin.removeListener("data", onData);
+					stdin.setRawMode(false);
+					stdin.pause();
+					process.stdout.write("\n");
+					resolve(input.trim());
+					break;
+				case "\u0003": // Ctrl+C
+					stdin.setRawMode(false);
+					stdin.pause();
+					process.stdout.write("\n");
+					process.exit(0);
+					break;
+				case "\u007f": // Delete
+				case "\b": // Backspace
+					if (input.length > 0) {
+						input = input.slice(0, -1);
+						process.stdout.write("\b \b");
+					}
+					break;
+				default:
+					// Only store printable characters (code >= 32)
+					if (code >= 32) {
+						input += char;
+						process.stdout.write("*");
+					}
+			}
+		};
+
+		stdin.on("data", onData);
+	});
+}
+
+/**
+ * Prompt the user to choose from a list of options. The prompt shows the
+ * options and accepts a case-insensitive match. Falls back to the first
+ * option if the answer doesn't match any.
+ *
+ * This consolidates the `promptRecoveryDecision` pattern from build-agent.ts
+ * and the `confirmMajorDecision` pattern from plan-agent.ts.
+ */
+export async function promptChoice(question: string, options: string[]): Promise<string> {
+	const { createInterface } = await import("node:readline");
+	const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+	return new Promise((resolve) => {
+		rl.question(`${question}\nOptions: ${options.join(", ")}: `, (answer) => {
+			rl.close();
+			const normalized = answer.toLowerCase().trim();
+			const matched = options.find((option) => option.toLowerCase() === normalized);
+			resolve(matched ?? options[0] ?? "");
+		});
+	});
+}

--- a/test/cli/prompt.test.ts
+++ b/test/cli/prompt.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "bun:test";
+import * as readline from "node:readline";
+import { prompt, promptChoice, promptHidden } from "../../src/cli/prompt.js";
+
+describe("cli/prompt", () => {
+	describe("prompt()", () => {
+		it("should return the trimmed answer", async () => {
+			const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+				() =>
+					({
+						question: (_q: string, cb: (answer: string) => void) => {
+							queueMicrotask(() => cb("  hello world  "));
+						},
+						close: () => {},
+					}) as unknown as readline.Interface
+			);
+
+			const result = await prompt("What is your name? ");
+			expect(result).toBe("hello world");
+
+			createInterfaceSpy.mockRestore();
+		});
+
+		it("should return empty string for empty input", async () => {
+			const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+				() =>
+					({
+						question: (_q: string, cb: (answer: string) => void) => {
+							queueMicrotask(() => cb(""));
+						},
+						close: () => {},
+					}) as unknown as readline.Interface
+			);
+
+			const result = await prompt("Enter something: ");
+			expect(result).toBe("");
+
+			createInterfaceSpy.mockRestore();
+		});
+
+		it("should pass the question to readline", async () => {
+			let capturedQuestion = "";
+			const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+				() =>
+					({
+						question: (q: string, cb: (answer: string) => void) => {
+							capturedQuestion = q;
+							queueMicrotask(() => cb("answer"));
+						},
+						close: () => {},
+					}) as unknown as readline.Interface
+			);
+
+			await prompt("Enter your name: ");
+			expect(capturedQuestion).toBe("Enter your name: ");
+
+			createInterfaceSpy.mockRestore();
+		});
+	});
+
+	describe("promptHidden()", () => {
+		// Force non-TTY so promptHidden uses the readline fallback path
+		beforeEach(() => {
+			process.stdin.isTTY = false;
+		});
+
+		it("should return the trimmed answer (non-TTY fallback)", async () => {
+			const stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+			const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+				() =>
+					({
+						question: (_q: string, cb: (answer: string) => void) => {
+							queueMicrotask(() => cb("sk-secret-key  "));
+						},
+						close: () => {},
+					}) as unknown as readline.Interface
+			);
+
+			const result = await promptHidden("Enter your API key: ");
+			expect(result).toBe("sk-secret-key");
+
+			stdoutWriteSpy.mockRestore();
+			createInterfaceSpy.mockRestore();
+		});
+
+		it("should write the prompt text to stdout", async () => {
+			const stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+			const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+				() =>
+					({
+						question: (_q: string, cb: (answer: string) => void) => {
+							queueMicrotask(() => cb("answer"));
+						},
+						close: () => {},
+					}) as unknown as readline.Interface
+			);
+
+			await promptHidden("Password: ");
+			expect(stdoutWriteSpy).toHaveBeenCalledWith("Password: ");
+
+			stdoutWriteSpy.mockRestore();
+			createInterfaceSpy.mockRestore();
+		});
+
+		it("should return empty string for empty input", async () => {
+			const stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+			const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+				() =>
+					({
+						question: (_q: string, cb: (answer: string) => void) => {
+							queueMicrotask(() => cb(""));
+						},
+						close: () => {},
+					}) as unknown as readline.Interface
+			);
+
+			const result = await promptHidden("Key: ");
+			expect(result).toBe("");
+
+			stdoutWriteSpy.mockRestore();
+			createInterfaceSpy.mockRestore();
+		});
+	});
+
+	describe("promptChoice()", () => {
+		it("should return the matched option (case-insensitive)", async () => {
+			const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+				() =>
+					({
+						question: (_q: string, cb: (answer: string) => void) => {
+							queueMicrotask(() => cb("SKIP"));
+						},
+						close: () => {},
+					}) as unknown as readline.Interface
+			);
+
+			const result = await promptChoice("What to do?", ["retry", "skip", "abort"]);
+			expect(result).toBe("skip");
+
+			createInterfaceSpy.mockRestore();
+		});
+
+		it("should return the first option when no match", async () => {
+			const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+				() =>
+					({
+						question: (_q: string, cb: (answer: string) => void) => {
+							queueMicrotask(() => cb("xyz"));
+						},
+						close: () => {},
+					}) as unknown as readline.Interface
+			);
+
+			const result = await promptChoice("What to do?", ["retry", "skip", "abort"]);
+			expect(result).toBe("retry");
+
+			createInterfaceSpy.mockRestore();
+		});
+
+		it("should return the first option for empty input", async () => {
+			const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+				() =>
+					({
+						question: (_q: string, cb: (answer: string) => void) => {
+							queueMicrotask(() => cb(""));
+						},
+						close: () => {},
+					}) as unknown as readline.Interface
+			);
+
+			const result = await promptChoice("What to do?", ["retry", "skip", "abort"]);
+			expect(result).toBe("retry");
+
+			createInterfaceSpy.mockRestore();
+		});
+
+		it("should include options in the prompt text", async () => {
+			let capturedQuestion = "";
+			const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+				() =>
+					({
+						question: (q: string, cb: (answer: string) => void) => {
+							capturedQuestion = q;
+							queueMicrotask(() => cb("retry"));
+						},
+						close: () => {},
+					}) as unknown as readline.Interface
+			);
+
+			await promptChoice("Choose:", ["retry", "skip", "abort"]);
+			expect(capturedQuestion).toContain("retry");
+			expect(capturedQuestion).toContain("skip");
+			expect(capturedQuestion).toContain("abort");
+
+			createInterfaceSpy.mockRestore();
+		});
+	});
+});


### PR DESCRIPTION
## What

Extract `src/cli/prompt.ts` — a deep module that consolidates the readline prompting logic previously duplicated across `login.ts`, `build-agent.ts`, and `plan-agent.ts`. The module exports `prompt(question)`, `promptHidden(promptText)`, and `promptChoice(question, options)`.

**Files changed:**
- `src/cli/prompt.ts` (new) — plain readline prompt, masked input (raw-mode `*` echoing with Ctrl+C/Delete/Backspace handling), and choice prompt (case-insensitive option matching with first-option fallback)
- `src/cli/handlers/login.ts` — removed ~60 lines of inline `prompt()` and `promptHidden()` functions, now imports from `../prompt.js`
- `src/agents/build-agent.ts` — replaced inline `promptRecoveryDecision` body with a call to `promptChoice` from `../cli/prompt.js` (kept the wrapper for backward compatibility)
- `src/agents/plan-agent.ts` — replaced inline `confirmMajorDecision` readline code with a call to `prompt` from `../cli/prompt.js`
- `test/cli/prompt.test.ts` (new) — 10 tests covering all three functions

## Why

The `prompt(question)` readline helper was duplicated across three files with slightly different implementations. The `promptHidden()` masked-input function (security-sensitive raw-mode stdin handling) lived only in `login.ts` but deserves its own tested module. The `promptRecoveryDecision` in `build-agent.ts` was a near-copy that added an option-matching layer on top of the same readline pattern. This is Duplicated Code with no locality — the "how to safely prompt the user" knowledge was scattered.

## How

- **Deep module interface**: three exported functions cover all prompting needs — `prompt()` for plain input, `promptHidden()` for masked secrets, `promptChoice()` for option selection
- **Security-sensitive surface centralized**: the raw-mode stdin handling (Ctrl+C → exit, Delete/Backspace → erase, printable chars → `*` echo) lives in one place, testable in isolation
- **Non-TTY fallback**: `promptHidden` falls back to plain readline when stdin is not a TTY (used in tests and piped input)
- **Backward compatibility**: `build-agent.ts` keeps the `promptRecoveryDecision` wrapper function (delegates to `promptChoice`) so existing callers and tests don't break
- **`plan-agent.ts` simplified**: `confirmMajorDecision` went from 10 lines of inline readline to a 3-line call to `prompt()`

## Checklist

- [x] Tests added or updated (10 new tests in `test/cli/prompt.test.ts`)
- [ ] Documentation updated
- [x] No breaking changes (wrapper functions preserved)
