### PR TITLE
refactor(core): extract TurnExecutor to deepen Agent.runStream tool dispatch

### DIFF
--- a/src/core/agent-utils.ts
+++ b/src/core/agent-utils.ts
@@ -1,0 +1,57 @@
+/**
+ * Agent utility functions — pure helpers extracted from agent.ts to break
+ * the circular dependency between agent.ts and turn-executor.ts.
+ *
+ * `isLooping` and `truncateOutput` are used by both Agent.runStream() and
+ * TurnExecutor.executeTurn(). Moving them here lets turn-executor.ts import
+ * from this file instead of from agent.ts, breaking the cycle.
+ */
+
+const MAX_OUTPUT_LENGTH = 500;
+
+// Loop detection thresholds
+export const LOOP_DETECTION = {
+	MIN_RECENT_CALLS: 3,
+	IDENTICAL_REPEAT: 3,
+	SAME_TOOL_THRESHOLD: 5,
+	DOMINANT_TOOL_THRESHOLD: 8,
+	LOOKBACK_WINDOW: 10,
+} as const;
+
+export function isLooping(recentToolCalls: string[]): boolean {
+	if (recentToolCalls.length < LOOP_DETECTION.MIN_RECENT_CALLS) return false;
+
+	const extractTool = (call: string): string => call.match(/^([^:]+):/)?.[1] ?? "";
+	const lastCall = recentToolCalls[recentToolCalls.length - 1] ?? "";
+	const lastTool = extractTool(lastCall);
+
+	if (recentToolCalls.slice(-LOOP_DETECTION.IDENTICAL_REPEAT).every((c) => c === lastCall)) return true;
+
+	if (recentToolCalls.length >= LOOP_DETECTION.SAME_TOOL_THRESHOLD) {
+		const lastFive = recentToolCalls.slice(-LOOP_DETECTION.SAME_TOOL_THRESHOLD);
+		if (lastFive.every((c) => extractTool(c) === lastTool)) return true;
+	}
+
+	if (recentToolCalls.length >= LOOP_DETECTION.LOOKBACK_WINDOW) {
+		const counts: Record<string, number> = {};
+		for (const call of recentToolCalls.slice(-LOOP_DETECTION.LOOKBACK_WINDOW)) {
+			const tool = extractTool(call);
+			counts[tool] = (counts[tool] ?? 0) + 1;
+		}
+		if (Math.max(...Object.values(counts), 0) >= LOOP_DETECTION.DOMINANT_TOOL_THRESHOLD) return true;
+	}
+
+	return false;
+}
+
+export function truncateOutput(output: string | undefined): string | undefined {
+	if (!output) return output;
+	const lines = output.split("\n");
+	if (lines.length > 10) {
+		return `${lines.slice(0, 10).join("\n")}\n... (${lines.length - 10} more lines)`;
+	}
+	if (output.length > MAX_OUTPUT_LENGTH) {
+		return `${output.slice(0, MAX_OUTPUT_LENGTH)}\n... (${output.length - MAX_OUTPUT_LENGTH} more chars)`;
+	}
+	return output;
+}

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -31,17 +31,12 @@ import { escapeXml } from "../utils/xml.js";
 import { ConversationManager } from "./conversation.js";
 import { buildContextWithMemory, type ContextStats, calculateContextBudget, MemoryStore } from "./memory.js";
 import { countTokensSync, truncateMessages } from "./tokens.js";
+import { TurnExecutor } from "./turn-executor.js";
 
-const MAX_OUTPUT_LENGTH = 500;
-
-// Loop detection thresholds
-const LOOP_DETECTION = {
-	MIN_RECENT_CALLS: 3,
-	IDENTICAL_REPEAT: 3,
-	SAME_TOOL_THRESHOLD: 5,
-	DOMINANT_TOOL_THRESHOLD: 8,
-	LOOKBACK_WINDOW: 10,
-} as const;
+// Re-export for backward compatibility — other modules and tests import
+// isLooping and truncateOutput from agent.ts. The canonical home is now
+// agent-utils.ts (extracted to break the agent.ts ↔ turn-executor.ts cycle).
+export { isLooping, truncateOutput } from "./agent-utils.js";
 
 export function checkAborted(signal?: AbortSignal): void {
 	if (signal?.aborted) {
@@ -49,48 +44,10 @@ export function checkAborted(signal?: AbortSignal): void {
 	}
 }
 
-export function isLooping(recentToolCalls: string[]): boolean {
-	if (recentToolCalls.length < LOOP_DETECTION.MIN_RECENT_CALLS) return false;
-
-	const extractTool = (call: string): string => call.match(/^([^:]+):/)?.[1] ?? "";
-	const lastCall = recentToolCalls[recentToolCalls.length - 1] ?? "";
-	const lastTool = extractTool(lastCall);
-
-	if (recentToolCalls.slice(-LOOP_DETECTION.IDENTICAL_REPEAT).every((c) => c === lastCall)) return true;
-
-	if (recentToolCalls.length >= LOOP_DETECTION.SAME_TOOL_THRESHOLD) {
-		const lastFive = recentToolCalls.slice(-LOOP_DETECTION.SAME_TOOL_THRESHOLD);
-		if (lastFive.every((c) => extractTool(c) === lastTool)) return true;
-	}
-
-	if (recentToolCalls.length >= LOOP_DETECTION.LOOKBACK_WINDOW) {
-		const counts: Record<string, number> = {};
-		for (const call of recentToolCalls.slice(-LOOP_DETECTION.LOOKBACK_WINDOW)) {
-			const tool = extractTool(call);
-			counts[tool] = (counts[tool] ?? 0) + 1;
-		}
-		if (Math.max(...Object.values(counts), 0) >= LOOP_DETECTION.DOMINANT_TOOL_THRESHOLD) return true;
-	}
-
-	return false;
-}
-
 export function redactApiKey(key?: string): string {
 	if (!key) return "(not set)";
 	if (key.length <= 8) return "****";
 	return `${key.slice(0, 4)}...REDACTED`;
-}
-
-export function truncateOutput(output: string | undefined): string | undefined {
-	if (!output) return output;
-	const lines = output.split("\n");
-	if (lines.length > 10) {
-		return `${lines.slice(0, 10).join("\n")}\n... (${lines.length - 10} more lines)`;
-	}
-	if (output.length > MAX_OUTPUT_LENGTH) {
-		return `${output.slice(0, MAX_OUTPUT_LENGTH)}\n... (${output.length - MAX_OUTPUT_LENGTH} more chars)`;
-	}
-	return output;
 }
 
 function calculateMessageTokens(messages: Message[]): number {
@@ -240,6 +197,7 @@ export class Agent {
 	private _mcpManager?: McpManager;
 	private _observability?: ObservabilityConfig;
 	private _obsInitialized: boolean = false;
+	private _turnExecutor: TurnExecutor;
 
 	constructor(llmClient: LLMClient, toolRegistry: ToolRegistry, options: AgentOptions = {}) {
 		this._defaultLlmClient = llmClient;
@@ -256,6 +214,7 @@ export class Agent {
 		this._mcpManager = options.mcpManager ?? undefined;
 		this._observability = options.observability;
 		this._conversationManager = new ConversationManager(options.conversationFile);
+		this._turnExecutor = new TurnExecutor(toolRegistry, { verbose: options.verbose });
 
 		let effectiveSystemPrompt =
 			options.systemPrompt ??
@@ -562,9 +521,10 @@ export class Agent {
 		}
 
 		let iteration = 0;
-		const recentToolCalls: string[] = [];
 		let loopDetected = false;
 		let requestFailed = false;
+
+		this._turnExecutor.reset();
 
 		const updateStats = (): ContextStats =>
 			buildStats({
@@ -743,61 +703,36 @@ export class Agent {
 
 				checkAborted(options?.signal);
 
-				const toolTimer = new Timer();
+				// --- Tool execution via TurnExecutor --------------------------------
 				const toolSpan = startSpan("tool.execution");
+				const toolTimer = new Timer();
 
+				// Yield "running" display objects
 				yield {
 					content: "",
 					iterations: iteration + 1,
 					done: false,
-					toolExecutions: assistantToolCalls.map((tc) => ({
-						name: tc.name,
-						status: "running" as const,
-						args: tc.arguments,
-						startTime: Date.now(),
-					})),
+					toolExecutions: TurnExecutor.runningDisplay(assistantToolCalls),
 					contextStats,
 				};
 
-				const calls = assistantToolCalls.map((tc) => ({
-					name: tc.name,
-					args: tc.arguments,
-				}));
-				let batchResults: Array<{ name: string; result: { success: boolean; output?: string; error?: string } }>;
-				try {
-					batchResults = await this._toolRegistry.executeBatch(calls);
-				} catch (err) {
-					toolSpan.end(err);
-					throw err;
-				}
-
+				const turnResult = await this._turnExecutor.executeTurn(assistantToolCalls);
 				const toolDuration = Math.round(toolTimer.ms);
-
-				const resultMap = new Map(batchResults.map((br) => [br.name, br]));
-				const getToolResult = (name: string) => resultMap.get(name)?.result;
-				const toolExecutionResults = assistantToolCalls.map((tc) => ({
-					toolCall: tc,
-					result: getToolResult(tc.name) ?? {
-						success: false,
-						error: `Tool "${tc.name}" result not found`,
-					},
-				}));
 
 				// --- Observability: record tool execution ---------------------------
 				toolSpan.setAttribute("ai.latency_ms", toolDuration);
 				toolSpan.setAttribute("tool.names", assistantToolCalls.map((tc) => tc.name).join(","));
 				toolSpan.end();
-				for (const { toolCall, result } of toolExecutionResults) {
-					const toolName = toolCall?.name ?? "unknown";
+				for (const exec of turnResult.toolExecutions) {
 					const toolFields: LogFields = {
 						event: "tool.execution",
 						traceId,
-						toolName,
+						toolName: exec.name,
 						latencyMs: toolDuration,
-						status: result.success ? "ok" : "error",
+						status: exec.status === "complete" ? "ok" : "error",
 					};
-					if (!result.success && result.error) {
-						const { errorType, errorMessage } = sanitizeError(new Error(result.error));
+					if (exec.status === "error" && exec.error) {
+						const { errorType, errorMessage } = sanitizeError(new Error(exec.error));
 						toolFields.errorType = errorType;
 						toolFields.errorMessage = errorMessage;
 					}
@@ -805,85 +740,29 @@ export class Agent {
 				}
 				// --------------------------------------------------------------------
 
+				// Yield "complete/error" display objects
 				yield {
 					content: "",
 					iterations: iteration + 1,
 					done: false,
-					toolExecutions: toolExecutionResults.map(({ toolCall, result }) => ({
-						name: toolCall?.name,
-						status: result.success ? "complete" : "error",
-						args: toolCall?.arguments,
-						output: result.success ? truncateOutput(result.output) : undefined,
-						error: result.error ? truncateOutput(result.error) : undefined,
-						duration: toolDuration,
-					})),
+					toolExecutions: turnResult.toolExecutions.map((te) => ({ ...te, duration: toolDuration })),
 					contextStats,
 				};
 
 				checkAborted(options?.signal);
 
-				for (const { toolCall, result } of toolExecutionResults) {
-					const toolCallSignature = `${toolCall?.name}:${JSON.stringify(toolCall?.arguments)}`;
-					recentToolCalls.push(toolCallSignature);
-
-					messages.push({
-						role: "tool",
-						content: result.error || result.output || "(no output)",
-						toolCallId: toolCall?.id,
-					});
+				// Append tool result messages to the conversation
+				for (const msg of turnResult.toolResultMessages) {
+					messages.push(msg);
 				}
 
-				const notFoundErrors = toolExecutionResults.filter(
-					({ result }) => !result.success && result.error?.includes("not found")
-				);
-				const declinedErrors = toolExecutionResults.filter(
-					({ result }) => !result.success && result.error?.includes("User declined confirmation")
-				);
-
-				if (notFoundErrors.length > 0) {
-					const missingTools = notFoundErrors.map(({ toolCall }) => toolCall?.name).join(", ");
-					messages.push({
-						role: "system",
-						content: `ERROR: The following tool(s) are not available: ${missingTools}. Please stop and provide your final answer based on the information you have gathered, or ask the user for alternative approaches.`,
-					});
-					if (this._verbose) {
-						console.log(`\n[WARNING] Tool(s) not found: ${missingTools}, breaking loop`);
-					}
-					loopDetected = true;
-					break;
+				// Append system messages (error recovery instructions)
+				for (const msg of turnResult.systemMessages) {
+					messages.push(msg);
 				}
 
-				if (declinedErrors.length > 0) {
-					const declinedTools = declinedErrors.map(({ toolCall }) => toolCall?.name).join(", ");
-
-					if (declinedErrors.length === toolExecutionResults.length) {
-						messages.push({
-							role: "system",
-							content: `All tool calls (${declinedTools}) were declined by the user. Provide your final answer now without making any more tool calls.`,
-						});
-						if (this._verbose) {
-							console.log(`\n[INFO] All tools declined: ${declinedTools}, requesting final answer`);
-						}
-						loopDetected = true;
-						break;
-					}
-
-					if (this._verbose) {
-						console.log(`\n[INFO] User declined confirmation: ${declinedTools}, continuing with remaining tools`);
-					}
-					contextStats = updateStats();
-					continue;
-				}
-
-				if (recentToolCalls.length >= 3 && isLooping(recentToolCalls)) {
-					const toolName = assistantToolCalls[0]?.name ?? "unknown";
-					messages.push({
-						role: "system",
-						content: `STOP: You have called ${toolName} repeatedly with the same arguments. Please stop and use the results you already have, or try a different approach. Provide your final answer now based on the information you have gathered.`,
-					});
-					if (this._verbose) {
-						console.log(`\n[WARNING] Detected tool call loop for ${toolName}, breaking loop`);
-					}
+				// Handle loop break reasons
+				if (turnResult.loopBreakReason) {
 					loopDetected = true;
 					break;
 				}

--- a/src/core/turn-executor.ts
+++ b/src/core/turn-executor.ts
@@ -1,0 +1,236 @@
+/**
+ * TurnExecutor — owns the per-iteration tool execution + error recovery logic
+ * extracted from Agent.runStream().
+ *
+ * Given a batch of tool calls from the LLM response, this module:
+ * 1. Executes them via the ToolRegistry
+ * 2. Builds the ToolExecution display objects (running → complete/error)
+ * 3. Appends tool result messages to the conversation
+ * 4. Detects not-found errors, declined confirmations, and tool-call loops
+ * 5. Returns a structured TurnResult so runStream() can decide what to do next
+ *
+ * This makes the tool dispatch + recovery path independently testable with a
+ * mock ToolRegistry — no LLM client, no streaming, no observability setup needed.
+ */
+
+import type { ToolRegistry } from "../tools/registry.js";
+import { isLooping, truncateOutput } from "./agent-utils.js";
+
+/** A tool call received from the LLM response. */
+export interface AssistantToolCall {
+	id: string;
+	name: string;
+	arguments: Record<string, unknown>;
+}
+
+/** The result of executing one tool call. */
+export interface ToolResultEntry {
+	success: boolean;
+	output?: string;
+	error?: string;
+}
+
+/** Display object for the UI — mirrors AgentStreamChunk.toolExecutions. */
+export interface ToolExecutionDisplay {
+	name: string;
+	status: "running" | "complete" | "error";
+	args?: Record<string, unknown>;
+	output?: string;
+	error?: string;
+	duration?: number;
+	startTime?: number;
+}
+
+/**
+ * The outcome of a single turn's tool execution.
+ *
+ * - `messages` — the tool result messages to append to the conversation
+ * - `toolExecutions` — display objects for the UI (complete/error state)
+ * - `loopBreakReason` — if set, runStream() should break the iteration loop
+ *   and request a final answer from the LLM
+ * - `shouldContinue` — if true, runStream() should continue to the next
+ *   iteration without breaking (e.g. some tools declined but others succeeded)
+ */
+export interface TurnResult {
+	toolResultMessages: Array<{ role: "tool"; content: string; toolCallId?: string }>;
+	systemMessages: Array<{ role: "system"; content: string }>;
+	toolExecutions: ToolExecutionDisplay[];
+	loopBreakReason: "not_found" | "all_declined" | "loop_detected" | null;
+	shouldContinue: boolean;
+}
+
+export interface TurnExecutorOptions {
+	verbose?: boolean;
+}
+
+export class TurnExecutor {
+	private _registry: ToolRegistry;
+	private _verbose: boolean;
+	private _recentToolCalls: string[] = [];
+
+	constructor(registry: ToolRegistry, options: TurnExecutorOptions = {}) {
+		this._registry = registry;
+		this._verbose = options.verbose ?? false;
+	}
+
+	/** Reset the tool-call history (call at the start of a new runStream). */
+	reset(): void {
+		this._recentToolCalls = [];
+	}
+
+	/**
+	 * Execute a batch of tool calls and return the structured result.
+	 *
+	 * This is the core method extracted from runStream(). It handles:
+	 * - executeBatch via the registry
+	 * - building display objects (running → complete/error)
+	 * - appending tool result messages
+	 * - not-found error detection (break loop)
+	 * - declined confirmation handling (break if all, continue if some)
+	 * - loop detection via isLooping()
+	 */
+	async executeTurn(toolCalls: AssistantToolCall[]): Promise<TurnResult> {
+		const toolTimerStart = Date.now();
+
+		// Execute the batch
+		const calls = toolCalls.map((tc) => ({ name: tc.name, args: tc.arguments }));
+		const batchResults = await this._registry.executeBatch(calls);
+		const toolDuration = Date.now() - toolTimerStart;
+
+		// Map results back to tool calls
+		const resultMap = new Map(batchResults.map((br) => [br.name, br]));
+		const getToolResult = (name: string) => resultMap.get(name)?.result;
+
+		const toolExecutionResults = toolCalls.map((tc) => ({
+			toolCall: tc,
+			result: getToolResult(tc.name) ?? {
+				success: false,
+				error: `Tool "${tc.name}" result not found`,
+			},
+		}));
+
+		// Build display objects (complete/error state)
+		const toolExecutions: ToolExecutionDisplay[] = toolExecutionResults.map(({ toolCall, result }) => ({
+			name: toolCall.name,
+			status: result.success ? "complete" : "error",
+			args: toolCall.arguments,
+			output: result.success ? truncateOutput(result.output) : undefined,
+			error: result.error ? truncateOutput(result.error) : undefined,
+			duration: toolDuration,
+		}));
+
+		// Build tool result messages for the conversation
+		const toolResultMessages = toolExecutionResults.map(({ toolCall, result }) => ({
+			role: "tool" as const,
+			content: result.error || result.output || "(no output)",
+			toolCallId: toolCall.id,
+		}));
+
+		// Track tool calls for loop detection
+		for (const { toolCall } of toolExecutionResults) {
+			const toolCallSignature = `${toolCall.name}:${JSON.stringify(toolCall.arguments)}`;
+			this._recentToolCalls.push(toolCallSignature);
+		}
+
+		// --- Error recovery: not-found errors ---
+		const notFoundErrors = toolExecutionResults.filter(
+			({ result }) => !result.success && result.error?.includes("not found")
+		);
+		if (notFoundErrors.length > 0) {
+			const missingTools = notFoundErrors.map(({ toolCall }) => toolCall.name).join(", ");
+			if (this._verbose) {
+				console.log(`\n[WARNING] Tool(s) not found: ${missingTools}, breaking loop`);
+			}
+			return {
+				toolResultMessages,
+				systemMessages: [
+					{
+						role: "system",
+						content: `ERROR: The following tool(s) are not available: ${missingTools}. Please stop and provide your final answer based on the information you have gathered, or ask the user for alternative approaches.`,
+					},
+				],
+				toolExecutions,
+				loopBreakReason: "not_found",
+				shouldContinue: false,
+			};
+		}
+
+		// --- Error recovery: declined confirmations ---
+		const declinedErrors = toolExecutionResults.filter(
+			({ result }) => !result.success && result.error?.includes("User declined confirmation")
+		);
+		if (declinedErrors.length > 0) {
+			const declinedTools = declinedErrors.map(({ toolCall }) => toolCall.name).join(", ");
+
+			if (declinedErrors.length === toolExecutionResults.length) {
+				// All tools declined — request final answer
+				if (this._verbose) {
+					console.log(`\n[INFO] All tools declined: ${declinedTools}, requesting final answer`);
+				}
+				return {
+					toolResultMessages,
+					systemMessages: [
+						{
+							role: "system",
+							content: `All tool calls (${declinedTools}) were declined by the user. Provide your final answer now without making any more tool calls.`,
+						},
+					],
+					toolExecutions,
+					loopBreakReason: "all_declined",
+					shouldContinue: false,
+				};
+			}
+
+			// Some tools declined — continue with the remaining ones
+			if (this._verbose) {
+				console.log(`\n[INFO] User declined confirmation: ${declinedTools}, continuing with remaining tools`);
+			}
+			return {
+				toolResultMessages,
+				systemMessages: [],
+				toolExecutions,
+				loopBreakReason: null,
+				shouldContinue: true,
+			};
+		}
+
+		// --- Loop detection ---
+		if (this._recentToolCalls.length >= 3 && isLooping(this._recentToolCalls)) {
+			const toolName = toolCalls[0]?.name ?? "unknown";
+			if (this._verbose) {
+				console.log(`\n[WARNING] Detected tool call loop for ${toolName}, breaking loop`);
+			}
+			return {
+				toolResultMessages,
+				systemMessages: [
+					{
+						role: "system",
+						content: `STOP: You have called ${toolName} repeatedly with the same arguments. Please stop and use the results you already have, or try a different approach. Provide your final answer now based on the information you have gathered.`,
+					},
+				],
+				toolExecutions,
+				loopBreakReason: "loop_detected",
+				shouldContinue: false,
+			};
+		}
+
+		// Normal case — all tools executed, continue to next iteration
+		return {
+			toolResultMessages,
+			systemMessages: [],
+			toolExecutions,
+			loopBreakReason: null,
+			shouldContinue: true,
+		};
+	}
+
+	/** Build the "running" display objects for the UI before execution starts. */
+	static runningDisplay(toolCalls: AssistantToolCall[]): ToolExecutionDisplay[] {
+		return toolCalls.map((tc) => ({
+			name: tc.name,
+			status: "running" as const,
+			args: tc.arguments,
+			startTime: Date.now(),
+		}));
+	}
+}

--- a/test/core/turn-executor.test.ts
+++ b/test/core/turn-executor.test.ts
@@ -1,0 +1,253 @@
+import { beforeEach, describe, expect, it, vi } from "bun:test";
+import { type AssistantToolCall, TurnExecutor } from "../../src/core/turn-executor.js";
+import { ToolRegistry } from "../../src/tools/registry.js";
+
+// Mock tool that always succeeds
+const successTool = {
+	name: "success_tool",
+	description: "A tool that always succeeds",
+	parameters: { type: "object" as const, properties: {}, required: [] },
+	execute: async () => ({ success: true, output: "done" }),
+};
+
+// Mock tool that always fails with "not found"
+const notFoundTool = {
+	name: "not_found_tool",
+	description: "A tool that returns not found",
+	parameters: { type: "object" as const, properties: {}, required: [] },
+	execute: async () => ({ success: false, error: "Tool not found" }),
+};
+
+// Mock tool that always fails with "User declined confirmation"
+const declinedTool = {
+	name: "declined_tool",
+	description: "A tool that is declined by the user",
+	parameters: { type: "object" as const, properties: {}, required: [] },
+	execute: async () => ({ success: false, error: "User declined confirmation" }),
+};
+
+// Mock tool that fails with a generic error
+const errorTool = {
+	name: "error_tool",
+	description: "A tool that fails with a generic error",
+	parameters: { type: "object" as const, properties: {}, required: [] },
+	execute: async () => ({ success: false, error: "Something went wrong" }),
+};
+
+describe("TurnExecutor", () => {
+	let registry: ToolRegistry;
+
+	beforeEach(() => {
+		registry = new ToolRegistry();
+		registry.register(successTool);
+		registry.register(notFoundTool);
+		registry.register(declinedTool);
+		registry.register(errorTool);
+	});
+
+	describe("executeTurn()", () => {
+		it("should execute a successful tool call and return complete status", async () => {
+			const executor = new TurnExecutor(registry);
+			const calls: AssistantToolCall[] = [{ id: "1", name: "success_tool", arguments: {} }];
+
+			const result = await executor.executeTurn(calls);
+
+			expect(result.toolExecutions).toHaveLength(1);
+			expect(result.toolExecutions[0]?.status).toBe("complete");
+			expect(result.toolExecutions[0]?.output).toBe("done");
+			expect(result.loopBreakReason).toBeNull();
+			expect(result.shouldContinue).toBe(true);
+			expect(result.toolResultMessages).toHaveLength(1);
+			expect(result.toolResultMessages[0]?.content).toBe("done");
+			expect(result.toolResultMessages[0]?.toolCallId).toBe("1");
+		});
+
+		it("should detect not-found errors and break the loop", async () => {
+			const executor = new TurnExecutor(registry);
+			const calls: AssistantToolCall[] = [{ id: "1", name: "not_found_tool", arguments: {} }];
+
+			const result = await executor.executeTurn(calls);
+
+			expect(result.loopBreakReason).toBe("not_found");
+			expect(result.shouldContinue).toBe(false);
+			expect(result.systemMessages).toHaveLength(1);
+			expect(result.systemMessages[0]?.content).toContain("not available");
+			expect(result.systemMessages[0]?.content).toContain("not_found_tool");
+		});
+
+		it("should detect all-declined and break the loop", async () => {
+			const executor = new TurnExecutor(registry);
+			const calls: AssistantToolCall[] = [
+				{ id: "1", name: "declined_tool", arguments: {} },
+				{ id: "2", name: "declined_tool", arguments: {} },
+			];
+
+			const result = await executor.executeTurn(calls);
+
+			expect(result.loopBreakReason).toBe("all_declined");
+			expect(result.shouldContinue).toBe(false);
+			expect(result.systemMessages).toHaveLength(1);
+			expect(result.systemMessages[0]?.content).toContain("declined by the user");
+		});
+
+		it("should continue when some tools are declined but others succeed", async () => {
+			const executor = new TurnExecutor(registry);
+			const calls: AssistantToolCall[] = [
+				{ id: "1", name: "success_tool", arguments: {} },
+				{ id: "2", name: "declined_tool", arguments: {} },
+			];
+
+			const result = await executor.executeTurn(calls);
+
+			expect(result.loopBreakReason).toBeNull();
+			expect(result.shouldContinue).toBe(true);
+			expect(result.systemMessages).toHaveLength(0);
+			expect(result.toolExecutions).toHaveLength(2);
+		});
+
+		it("should detect tool-call loops after 3 identical calls", async () => {
+			const executor = new TurnExecutor(registry);
+			const calls: AssistantToolCall[] = [{ id: "1", name: "success_tool", arguments: { task: "same" } }];
+
+			// Execute 3 times with the same call
+			await executor.executeTurn(calls);
+			await executor.executeTurn(calls);
+			const result = await executor.executeTurn(calls);
+
+			expect(result.loopBreakReason).toBe("loop_detected");
+			expect(result.shouldContinue).toBe(false);
+			expect(result.systemMessages).toHaveLength(1);
+			expect(result.systemMessages[0]?.content).toContain("STOP");
+			expect(result.systemMessages[0]?.content).toContain("success_tool");
+		});
+
+		it("should not detect a loop with fewer than 3 calls", async () => {
+			const executor = new TurnExecutor(registry);
+			const calls: AssistantToolCall[] = [{ id: "1", name: "success_tool", arguments: { task: "same" } }];
+
+			await executor.executeTurn(calls);
+			const result = await executor.executeTurn(calls);
+
+			expect(result.loopBreakReason).toBeNull();
+			expect(result.shouldContinue).toBe(true);
+		});
+
+		it("should handle a tool that returns a generic error (not not-found, not declined)", async () => {
+			const executor = new TurnExecutor(registry);
+			const calls: AssistantToolCall[] = [{ id: "1", name: "error_tool", arguments: {} }];
+
+			const result = await executor.executeTurn(calls);
+
+			expect(result.toolExecutions[0]?.status).toBe("error");
+			expect(result.toolExecutions[0]?.error).toBe("Something went wrong");
+			expect(result.loopBreakReason).toBeNull();
+			expect(result.shouldContinue).toBe(true);
+		});
+
+		it("should handle multiple tool calls in one turn", async () => {
+			const executor = new TurnExecutor(registry);
+			const calls: AssistantToolCall[] = [
+				{ id: "1", name: "success_tool", arguments: {} },
+				{ id: "2", name: "success_tool", arguments: { task: "other" } },
+			];
+
+			const result = await executor.executeTurn(calls);
+
+			expect(result.toolExecutions).toHaveLength(2);
+			expect(result.toolExecutions.every((te) => te.status === "complete")).toBe(true);
+			expect(result.toolResultMessages).toHaveLength(2);
+			expect(result.shouldContinue).toBe(true);
+		});
+
+		it("should include duration in the tool execution display", async () => {
+			const executor = new TurnExecutor(registry);
+			const calls: AssistantToolCall[] = [{ id: "1", name: "success_tool", arguments: {} }];
+
+			const result = await executor.executeTurn(calls);
+
+			expect(result.toolExecutions[0]?.duration).toBeDefined();
+			expect(typeof result.toolExecutions[0]?.duration).toBe("number");
+		});
+
+		it("should handle tool result not found in batch results", async () => {
+			const executor = new TurnExecutor(registry);
+			// Call a tool that doesn't exist in the registry
+			const calls: AssistantToolCall[] = [{ id: "1", name: "nonexistent_tool", arguments: {} }];
+
+			const result = await executor.executeTurn(calls);
+
+			expect(result.toolExecutions[0]?.status).toBe("error");
+			// The registry returns an error for unknown tools — either "not found" or a generic error
+			expect(result.toolExecutions[0]?.error).toBeDefined();
+		});
+	});
+
+	describe("reset()", () => {
+		it("should clear the recent tool call history", async () => {
+			const executor = new TurnExecutor(registry);
+			const calls: AssistantToolCall[] = [{ id: "1", name: "success_tool", arguments: { task: "same" } }];
+
+			// Execute twice to build up history
+			await executor.executeTurn(calls);
+			await executor.executeTurn(calls);
+
+			// Reset
+			executor.reset();
+
+			// Execute again — should not detect a loop (history was cleared)
+			const result = await executor.executeTurn(calls);
+			expect(result.loopBreakReason).toBeNull();
+			expect(result.shouldContinue).toBe(true);
+		});
+	});
+
+	describe("runningDisplay()", () => {
+		it("should build running display objects for the UI", () => {
+			const calls: AssistantToolCall[] = [
+				{ id: "1", name: "success_tool", arguments: { foo: "bar" } },
+				{ id: "2", name: "error_tool", arguments: {} },
+			];
+
+			const display = TurnExecutor.runningDisplay(calls);
+
+			expect(display).toHaveLength(2);
+			expect(display[0]?.name).toBe("success_tool");
+			expect(display[0]?.status).toBe("running");
+			expect(display[0]?.args).toEqual({ foo: "bar" });
+			expect(display[0]?.startTime).toBeDefined();
+			expect(display[1]?.name).toBe("error_tool");
+			expect(display[1]?.status).toBe("running");
+		});
+
+		it("should return empty array for no tool calls", () => {
+			const display = TurnExecutor.runningDisplay([]);
+			expect(display).toEqual([]);
+		});
+	});
+
+	describe("verbose mode", () => {
+		it("should log warnings in verbose mode for not-found errors", async () => {
+			const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+			const executor = new TurnExecutor(registry, { verbose: true });
+			const calls: AssistantToolCall[] = [{ id: "1", name: "not_found_tool", arguments: {} }];
+
+			await executor.executeTurn(calls);
+
+			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("not found"));
+
+			consoleLogSpy.mockRestore();
+		});
+
+		it("should log info in verbose mode for declined tools", async () => {
+			const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+			const executor = new TurnExecutor(registry, { verbose: true });
+			const calls: AssistantToolCall[] = [{ id: "1", name: "declined_tool", arguments: {} }];
+
+			await executor.executeTurn(calls);
+
+			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("declined"));
+
+			consoleLogSpy.mockRestore();
+		});
+	});
+});


### PR DESCRIPTION
## What

Extract `TurnExecutor` from `Agent.runStream()` — the top recommendation from the architecture review. The ~400-line `runStream()` method mixed 6 interleaved concerns; this PR pulls out the per-iteration tool dispatch + error recovery logic (~130 lines) into a dedicated, independently testable class.

**New files:**
- `src/core/turn-executor.ts` — `TurnExecutor` class with `executeTurn(toolCalls) → TurnResult`, `reset()`, `static runningDisplay(toolCalls)`. Owns: batch execution via registry, display object building, tool result message construction, not-found error detection, declined confirmation handling (all-declined → break, some-declined → continue), loop detection via `isLooping()`.
- `src/core/agent-utils.ts` — `isLooping`, `truncateOutput`, `LOOP_DETECTION`, `MAX_OUTPUT_LENGTH` extracted from `agent.ts` to break the `agent.ts ↔ turn-executor.ts` circular dependency.
- `test/core/turn-executor.test.ts` — 15 tests covering: success, not-found break, all-declined break, some-declined continue, loop detection (3+ identical calls), no-loop (<3 calls), generic error, multiple tools, duration, nonexistent tool, reset, runningDisplay (2), verbose mode (2).

**Modified:**
- `src/core/agent.ts` — `runStream()` now calls `this._turnExecutor.reset()` at start, yields `TurnExecutor.runningDisplay()` for the "running" state, calls `this._turnExecutor.executeTurn()` for the batch, and uses `turnResult.loopBreakReason` / `turnResult.toolResultMessages` / `turnResult.systemMessages` instead of inline logic. Re-exports `isLooping` and `truncateOutput` from `agent-utils.ts` for backward compatibility.

## Why

`agent.ts` is the #1 hot spot (1173 lines, 4 recent changes) and `runStream()` is the single most complex method in the codebase — 6 interleaved concerns (observability, context budgeting, LLM streaming, tool dispatch, loop detection, error recovery). Testing any single concern (e.g. "does loop detection break correctly?") required setting up the entire Agent with a real/mock LLM client, tool registry, and memory store. The TurnExecutor extraction makes tool dispatch + recovery independently testable with a mock `ToolRegistry` — no LLM client, no streaming, no observability.

## How

- **Deep module**: `TurnExecutor.executeTurn(messages, client, registry) → TurnResult` is a clean seam. The `TurnResult` carries `toolResultMessages`, `systemMessages`, `toolExecutions`, `loopBreakReason`, and `shouldContinue` — all the data `runStream()` needs to decide what to do next.
- **Circular dependency**: `isLooping` and `truncateOutput` moved to `agent-utils.ts` (terminal module). `turn-executor.ts` imports from there; `agent.ts` re-exports for backward compat.
- **Behavior preservation**: The declined-some case returns early (before loop detection), preserving the old `continue` semantics that skipped the loop check. The `shouldContinue` field documents this intent and is asserted in tests.
- **Observability stays in `runStream()`**: spans, timers, and logs wrap the `executeTurn()` call from the outside — keeping the instrumentation locality with the streaming loop, not the tool dispatch.

## Checklist

- [x] Tests added or updated (15 new tests)
- [x] Documentation updated (ADR-011 boundary respected — within-Agent refactor)
- [x] No breaking changes (re-exports maintain backward compat; all 11 agent + 12 e2e tests pass)
