### PR TITLE
refactor(agents): extract StepExecutor to deepen buildAgent step execution

### DIFF
--- a/src/agents/build-agent.ts
+++ b/src/agents/build-agent.ts
@@ -1,4 +1,3 @@
-import { promptChoice } from "../cli/prompt.js";
 import { loadConfig } from "../config/loader.js";
 import { createProvider, parseModelString } from "../providers/factory.js";
 import type { Message } from "../providers/types.js";
@@ -7,6 +6,7 @@ import { fileTools } from "../tools/file-tools.js";
 import { ToolRegistry } from "../tools/registry.js";
 import { type Step as GrammarStep, type Plan, parse as parsePlanGrammar } from "./plan-grammar.js";
 import { readStateFile, writeStateFile } from "./state.js";
+import { StepExecutor } from "./step-executor.js";
 import type { StateFile } from "./types.js";
 
 export interface BuildAgentOptions {
@@ -42,17 +42,6 @@ export interface BuildAgentResult {
 	steps?: BuildStep[];
 }
 
-interface ExecutionDecision {
-	action: "retry" | "skip" | "abort";
-}
-
-interface ToolCall {
-	name: string;
-	args: Record<string, unknown>;
-}
-
-type ExecutionOutcome = { success: boolean; output?: string; error?: string };
-
 const BUILD_SYSTEM_PROMPT = `You are a build executor. Your task is to parse a plan and execute the steps to implement the solution.
 
 For each step in the plan:
@@ -83,102 +72,10 @@ For dry-run mode:
 - Do not modify any files
 - Do not update the state file`;
 
-type MappedBuildAction = { kind: "call"; call: ToolCall } | { kind: "unmappable"; reason: string };
-
-/**
- * Map a build-time intent (BuildAction) into a registry-shaped ToolCall, or
- * report why it can't be mapped. Folding mapping + reason into one exhaustive
- * function keeps every action variant's translation in a single place, so a
- * new BuildAction variant only needs one switch arm — not two (mapping +
- * unmappable-message). Confirmation is handled by the registry, not here;
- * the registry routes dangerous ops through the CLI's confirmation handler
- * with the right danger level (write/edit/delete/bash-destructive).
- */
-function mapBuildAction(action: BuildAction): MappedBuildAction {
-	switch (action.type) {
-		case "create": {
-			if (!action.path) return { kind: "unmappable", reason: "create action requires a path" };
-			return {
-				kind: "call",
-				call: {
-					name: "write_file",
-					args: { path: action.path, content: action.content ?? "" },
-				},
-			};
-		}
-		case "modify": {
-			if (!action.path) return { kind: "unmappable", reason: "modify action requires a path" };
-			if (action.oldContent && action.content) {
-				return {
-					kind: "call",
-					call: {
-						name: "edit_file",
-						args: {
-							path: action.path,
-							old_str: action.oldContent,
-							new_str: action.content,
-						},
-					},
-				};
-			}
-			if (action.content) {
-				return {
-					kind: "call",
-					call: {
-						name: "write_file",
-						args: { path: action.path, content: action.content },
-					},
-				};
-			}
-			return {
-				kind: "unmappable",
-				reason: "modify action requires both oldContent and content, or just content",
-			};
-		}
-		case "delete": {
-			if (!action.path) return { kind: "unmappable", reason: "delete action requires a path" };
-			return { kind: "call", call: { name: "delete_file", args: { path: action.path } } };
-		}
-		case "execute": {
-			return { kind: "call", call: { name: "bash", args: { command: action.description } } };
-		}
-	}
-}
-
-/**
- * Tiny readline-based prompt for retry/skip/abort decisions after a failed action.
- *
- * This is intentionally NOT a parallel confirmation funnel — it's a recovery
- * decision only. Dangerous-op confirmation lives entirely in ToolRegistry via
- * confirmation.ts. Maintained in build-agent because the recovery path is
- * unique to build-time execution flow.
- */
-async function promptRecoveryDecision(promptText: string, options: string[]): Promise<string> {
-	return promptChoice(promptText, options);
-}
-
-async function handleExecutionError(
-	error: string,
-	stepNumber: number,
-	stateFilePath: string,
-	state: StateFile
-): Promise<ExecutionDecision> {
-	console.error(`\n❌ Error in step ${stepNumber}: ${error}`);
-
-	const decision = await promptRecoveryDecision(`\nWhat would you like to do?`, ["retry", "skip", "abort"]);
-
-	const stateError = {
-		timestamp: new Date().toISOString(),
-		phase: "build" as const,
-		message: error,
-		details: { step: stepNumber },
-	};
-
-	state.errors = [...state.errors, stateError];
-	await writeStateFile(stateFilePath, state);
-
-	return { action: decision.toLowerCase() as "retry" | "skip" | "abort" };
-}
+// Re-export mapBuildAction and MappedBuildAction from step-executor.ts for
+// backward compatibility. The canonical home is now step-executor.ts
+// (extracted to break the build-agent.ts ↔ step-executor.ts runtime cycle).
+export { type MappedBuildAction, mapBuildAction, type ToolCall } from "./step-executor.js";
 
 /**
  * Convert a Plan returned by `PlanGrammar.parse` into the build-agent's
@@ -357,7 +254,7 @@ export async function buildAgent(planContent: string, options?: BuildAgentOption
 		if (verbose) {
 			console.log(`Found ${steps.length} steps to execute`);
 		}
-
+		const stepExecutor = new StepExecutor(registry);
 		const executedSteps: BuildStep[] = [];
 
 		for (const step of steps) {
@@ -373,91 +270,36 @@ export async function buildAgent(planContent: string, options?: BuildAgentOption
 				await writeStateFile(stateFilePath, state);
 			}
 
-			const stepChanges: Array<{
-				type: "create" | "modify" | "delete";
-				path: string;
-				diff?: string;
-			}> = [];
+			const stepResult = await stepExecutor.executeStep(step);
 
-			let stepSuccess = true;
+			// Log step errors to state file (the executor handles the prompt + retry)
+			if (stepResult.error) {
+				state.errors = [
+					...state.errors,
+					{
+						timestamp: new Date().toISOString(),
+						phase: "build" as const,
+						message: stepResult.error,
+						details: { step: step.stepNumber },
+					},
+				];
+			}
 
-			for (const action of step.actions) {
-				let executionResult: ExecutionOutcome;
+			if (stepResult.shouldAbort) {
+				state.status = "failed";
+				await writeStateFile(stateFilePath, state);
 
-				const mapped = mapBuildAction(action);
-				if (mapped.kind === "unmappable") {
-					executionResult = { success: false, error: mapped.reason };
-				} else {
-					// Confirmation for dangerous ops (create/modify/delete/destructive-bash)
-					// is handled inside registry.execute via the CLI's confirmation handler.
-					executionResult = await registry.execute(mapped.call.name, mapped.call.args);
-				}
-
-				if (executionResult.success) {
-					console.log(`  ✓ ${action.description}`);
-
-					const actionPath = action.path;
-					if (actionPath && (action.type === "create" || action.type === "modify" || action.type === "delete")) {
-						stepChanges.push({
-							type: action.type as "create" | "modify" | "delete",
-							path: actionPath,
-						});
-					}
-				} else {
-					console.error(`  ✗ ${action.description}: ${executionResult.error}`);
-					stepSuccess = false;
-
-					const decision = await handleExecutionError(
-						executionResult.error || "Unknown error",
-						step.stepNumber,
-						stateFilePath,
-						state
-					);
-
-					if (decision.action === "abort") {
-						state.status = "failed";
-						await writeStateFile(stateFilePath, state);
-
-						return {
-							success: false,
-							error: `Build aborted at step ${step.stepNumber}`,
-							steps: executedSteps,
-						};
-					}
-
-					if (decision.action === "skip") {
-						console.log(`  Skipping step ${step.stepNumber}`);
-						executedSteps.push({
-							...step,
-							status: "skipped",
-						});
-						break;
-					}
-
-					if (decision.action === "retry" && mapped.kind === "call") {
-						console.log(`  Retrying step ${step.stepNumber}...`);
-						const retryResult = await registry.execute(mapped.call.name, mapped.call.args);
-						if (retryResult.success) {
-							console.log(`  ✓ ${action.description} (retry successful)`);
-							const actionPath = action.path;
-							if (actionPath && (action.type === "create" || action.type === "modify" || action.type === "delete")) {
-								stepChanges.push({
-									type: action.type as "create" | "modify" | "delete",
-									path: actionPath,
-								});
-							}
-							stepSuccess = true;
-						} else {
-							stepSuccess = false;
-						}
-					}
-				}
+				return {
+					success: false,
+					error: `Build aborted at step ${step.stepNumber}`,
+					steps: executedSteps,
+				};
 			}
 
 			executedSteps.push({
 				...step,
-				status: stepSuccess ? "completed" : "failed",
-				changes: stepChanges.length > 0 ? stepChanges : undefined,
+				status: stepResult.status,
+				changes: stepResult.changes.length > 0 ? stepResult.changes : undefined,
 			});
 
 			state.results.build = convertStepsToBuildResult(executedSteps);

--- a/src/agents/step-executor.ts
+++ b/src/agents/step-executor.ts
@@ -1,0 +1,212 @@
+/**
+ * StepExecutor — owns the per-step action execution + error recovery flow
+ * extracted from buildAgent().
+ *
+ * Given a BuildStep + ToolRegistry, this module:
+ * 1. Maps each action to a tool call via mapBuildAction (moved here to break
+ *    the build-agent.ts ↔ step-executor.ts runtime cycle)
+ * 2. Executes via the registry (confirmation handled inside registry)
+ * 3. Tracks file changes (create/modify/delete with path)
+ * 4. On failure, prompts for retry/skip/abort (via promptChoice or injected fn)
+ * 5. Returns a structured StepResult so buildAgent() can write state
+ *
+ * This makes the step execution path independently testable with a mock
+ * ToolRegistry and a mock prompt function — no state file, no plan parsing
+ * needed. State-file writes stay in buildAgent() as the orchestration layer.
+ */
+
+import { promptChoice } from "../cli/prompt.js";
+import type { ToolRegistry } from "../tools/registry.js";
+import type { BuildAction, BuildStep } from "./build-agent.js";
+
+/** A tool call shaped for the registry's execute method. */
+export interface ToolCall {
+	name: string;
+	args: Record<string, unknown>;
+}
+
+/** Either a mappable tool call or a reason why the action can't be mapped. */
+export type MappedBuildAction = { kind: "call"; call: ToolCall } | { kind: "unmappable"; reason: string };
+
+/**
+ * Map a build-time intent (BuildAction) into a registry-shaped ToolCall, or
+ * report why it can't be mapped. Folding mapping + reason into one exhaustive
+ * function keeps every action variant's translation in a single place, so a
+ * new BuildAction variant only needs one switch arm — not two (mapping +
+ * unmappable-message). Confirmation is handled by the registry, not here;
+ * the registry routes dangerous ops through the CLI's confirmation handler
+ * with the right danger level (write/edit/delete/bash-destructive).
+ */
+export function mapBuildAction(action: BuildAction): MappedBuildAction {
+	switch (action.type) {
+		case "create": {
+			if (!action.path) return { kind: "unmappable", reason: "create action requires a path" };
+			return {
+				kind: "call",
+				call: {
+					name: "write_file",
+					args: { path: action.path, content: action.content ?? "" },
+				},
+			};
+		}
+		case "modify": {
+			if (!action.path) return { kind: "unmappable", reason: "modify action requires a path" };
+			if (action.oldContent && action.content) {
+				return {
+					kind: "call",
+					call: {
+						name: "edit_file",
+						args: {
+							path: action.path,
+							old_str: action.oldContent,
+							new_str: action.content,
+						},
+					},
+				};
+			}
+			if (action.content) {
+				return {
+					kind: "call",
+					call: {
+						name: "write_file",
+						args: { path: action.path, content: action.content },
+					},
+				};
+			}
+			return {
+				kind: "unmappable",
+				reason: "modify action requires both oldContent and content, or just content",
+			};
+		}
+		case "delete": {
+			if (!action.path) return { kind: "unmappable", reason: "delete action requires a path" };
+			return { kind: "call", call: { name: "delete_file", args: { path: action.path } } };
+		}
+		case "execute": {
+			return { kind: "call", call: { name: "bash", args: { command: action.description } } };
+		}
+	}
+}
+
+/** The result of executing one step's actions. */
+export interface StepResult {
+	status: "completed" | "failed" | "skipped";
+	changes: Array<{
+		type: "create" | "modify" | "delete";
+		path: string;
+		diff?: string;
+	}>;
+	/** Error message if the step failed (for state-file logging by buildAgent). */
+	error?: string;
+	/** If true, the user chose to abort — buildAgent should stop immediately. */
+	shouldAbort: boolean;
+}
+
+type ExecutionOutcome = { success: boolean; output?: string; error?: string };
+
+/** Optional dependency injection for the recovery prompt (testability). */
+export interface StepExecutorOptions {
+	promptFn?: (question: string, options: string[]) => Promise<string>;
+}
+
+export class StepExecutor {
+	private _registry: ToolRegistry;
+	private _promptFn: (question: string, options: string[]) => Promise<string>;
+
+	constructor(registry: ToolRegistry, options: StepExecutorOptions = {}) {
+		this._registry = registry;
+		this._promptFn = options.promptFn ?? promptChoice;
+	}
+
+	/**
+	 * Execute all actions in a step, handling retry/skip/abort on failure.
+	 *
+	 * Returns a structured StepResult — the caller (buildAgent) is responsible
+	 * for writing the state file based on the result.
+	 */
+	async executeStep(step: BuildStep): Promise<StepResult> {
+		const changes: StepResult["changes"] = [];
+		let stepSuccess = true;
+		let lastError: string | undefined;
+		let shouldAbort = false;
+
+		for (const action of step.actions) {
+			const result = await this._executeAction(action);
+
+			if (result.success) {
+				console.log(`  ✓ ${action.description}`);
+				this._trackChange(action, changes);
+				continue;
+			}
+
+			// Action failed — prompt for recovery
+			console.error(`  ✗ ${action.description}: ${result.error}`);
+			stepSuccess = false;
+			lastError = result.error || "Unknown error";
+
+			const decision = await this._promptRecovery(lastError, step.stepNumber);
+
+			if (decision === "abort") {
+				shouldAbort = true;
+				break;
+			}
+
+			if (decision === "skip") {
+				console.log(`  Skipping step ${step.stepNumber}`);
+				return {
+					status: "skipped",
+					changes,
+					error: lastError,
+					shouldAbort: false,
+				};
+			}
+
+			// retry — attempt the same action once more
+			if (decision === "retry") {
+				console.log(`  Retrying step ${step.stepNumber}...`);
+				const retryResult = await this._executeAction(action);
+				if (retryResult.success) {
+					console.log(`  ✓ ${action.description} (retry successful)`);
+					this._trackChange(action, changes);
+					stepSuccess = true;
+				} else {
+					stepSuccess = false;
+				}
+			}
+		}
+
+		return {
+			status: stepSuccess ? "completed" : "failed",
+			changes: changes.length > 0 ? changes : [],
+			error: stepSuccess ? undefined : lastError,
+			shouldAbort,
+		};
+	}
+
+	/** Execute a single action via the registry, mapping it to a tool call first. */
+	private async _executeAction(action: BuildAction): Promise<ExecutionOutcome> {
+		const mapped = mapBuildAction(action);
+		if (mapped.kind === "unmappable") {
+			return { success: false, error: mapped.reason };
+		}
+		return this._registry.execute(mapped.call.name, mapped.call.args);
+	}
+
+	/** Track a file change if the action has a path and is a file operation. */
+	private _trackChange(action: BuildAction, changes: StepResult["changes"]): void {
+		const actionPath = action.path;
+		if (actionPath && (action.type === "create" || action.type === "modify" || action.type === "delete")) {
+			changes.push({
+				type: action.type,
+				path: actionPath,
+			});
+		}
+	}
+
+	/** Prompt the user for a retry/skip/abort decision after a failed action. */
+	private async _promptRecovery(error: string, stepNumber: number): Promise<"retry" | "skip" | "abort"> {
+		console.error(`\n❌ Error in step ${stepNumber}: ${error}`);
+		const decision = await this._promptFn("\nWhat would you like to do?", ["retry", "skip", "abort"]);
+		return decision.toLowerCase() as "retry" | "skip" | "abort";
+	}
+}

--- a/test/agents/step-executor.test.ts
+++ b/test/agents/step-executor.test.ts
@@ -1,0 +1,274 @@
+import { beforeEach, describe, expect, it, vi } from "bun:test";
+import type { BuildStep } from "../../src/agents/build-agent.js";
+import { mapBuildAction, StepExecutor } from "../../src/agents/step-executor.js";
+import { ToolRegistry } from "../../src/tools/registry.js";
+
+// Mock write_file tool for change tracking
+const writeFileTool = {
+	name: "write_file",
+	description: "Write a file",
+	parameters: { type: "object" as const, properties: {}, required: [] },
+	execute: async () => ({ success: true, output: "File written" }),
+};
+
+// Mock edit_file tool for change tracking
+const editFileTool = {
+	name: "edit_file",
+	description: "Edit a file",
+	parameters: { type: "object" as const, properties: {}, required: [] },
+	execute: async () => ({ success: true, output: "File edited" }),
+};
+
+// Mock delete_file tool for change tracking
+const deleteFileTool = {
+	name: "delete_file",
+	description: "Delete a file",
+	parameters: { type: "object" as const, properties: {}, required: [] },
+	execute: async () => ({ success: true, output: "File deleted" }),
+};
+
+// Command-aware bash mock:
+// - "fail" → always fails
+// - "flaky" → fails on first call, succeeds on retry
+// - anything else → succeeds
+let bashFlakyCallCount = 0;
+
+const bashTool = {
+	name: "bash",
+	description: "Run a bash command",
+	parameters: { type: "object" as const, properties: {}, required: [] },
+	execute: async (args: Record<string, unknown>) => {
+		const command = String(args?.command ?? "");
+		if (command === "flaky") {
+			bashFlakyCallCount++;
+			if (bashFlakyCallCount === 1) {
+				return { success: false, error: "Transient error" };
+			}
+			return { success: true, output: "Success on retry" };
+		}
+		if (command === "fail") {
+			return { success: false, error: "Something went wrong" };
+		}
+		return { success: true, output: "Command executed" };
+	},
+};
+
+/** Helper: create a StepExecutor with a mocked prompt function. */
+function makeExecutor(registry: ToolRegistry, decision: string): StepExecutor {
+	const mockPrompt = vi.fn<(q: string, opts: string[]) => Promise<string>>().mockResolvedValue(decision);
+	return new StepExecutor(registry, { promptFn: mockPrompt });
+}
+
+describe("StepExecutor", () => {
+	let registry: ToolRegistry;
+
+	beforeEach(() => {
+		registry = new ToolRegistry();
+		registry.register(writeFileTool);
+		registry.register(editFileTool);
+		registry.register(deleteFileTool);
+		registry.register(bashTool);
+		bashFlakyCallCount = 0;
+	});
+
+	describe("executeStep()", () => {
+		it("should complete successfully when all actions succeed", async () => {
+			const executor = new StepExecutor(registry);
+			const step: BuildStep = {
+				stepNumber: 1,
+				description: "Create a file",
+				actions: [{ type: "execute", description: "echo hello" }],
+			};
+
+			const result = await executor.executeStep(step);
+
+			expect(result.status).toBe("completed");
+			expect(result.shouldAbort).toBe(false);
+			expect(result.error).toBeUndefined();
+		});
+
+		it("should track file changes for create actions", async () => {
+			const executor = new StepExecutor(registry);
+			const step: BuildStep = {
+				stepNumber: 1,
+				description: "Create a file",
+				actions: [{ type: "create", path: "/tmp/test.ts", content: "hello", description: "Create test.ts" }],
+			};
+
+			const result = await executor.executeStep(step);
+
+			expect(result.status).toBe("completed");
+			expect(result.changes).toHaveLength(1);
+			expect(result.changes[0]?.type).toBe("create");
+			expect(result.changes[0]?.path).toBe("/tmp/test.ts");
+		});
+
+		it("should track file changes for modify actions", async () => {
+			const executor = new StepExecutor(registry);
+			const step: BuildStep = {
+				stepNumber: 1,
+				description: "Modify a file",
+				actions: [
+					{ type: "modify", path: "/tmp/test.ts", oldContent: "old", content: "new", description: "Modify test.ts" },
+				],
+			};
+
+			const result = await executor.executeStep(step);
+
+			expect(result.status).toBe("completed");
+			expect(result.changes).toHaveLength(1);
+			expect(result.changes[0]?.type).toBe("modify");
+			expect(result.changes[0]?.path).toBe("/tmp/test.ts");
+		});
+
+		it("should track file changes for delete actions", async () => {
+			const executor = new StepExecutor(registry);
+			const step: BuildStep = {
+				stepNumber: 1,
+				description: "Delete a file",
+				actions: [{ type: "delete", path: "/tmp/test.ts", description: "Delete test.ts" }],
+			};
+
+			const result = await executor.executeStep(step);
+
+			expect(result.status).toBe("completed");
+			expect(result.changes).toHaveLength(1);
+			expect(result.changes[0]?.type).toBe("delete");
+			expect(result.changes[0]?.path).toBe("/tmp/test.ts");
+		});
+
+		it("should not track changes for execute actions (no path)", async () => {
+			const executor = new StepExecutor(registry);
+			const step: BuildStep = {
+				stepNumber: 1,
+				description: "Run a command",
+				actions: [{ type: "execute", description: "echo hello" }],
+			};
+
+			const result = await executor.executeStep(step);
+
+			expect(result.status).toBe("completed");
+			expect(result.changes).toHaveLength(0);
+		});
+
+		it("should handle multiple actions in one step", async () => {
+			const executor = new StepExecutor(registry);
+			const step: BuildStep = {
+				stepNumber: 1,
+				description: "Multi-action step",
+				actions: [
+					{ type: "create", path: "/tmp/a.ts", content: "a", description: "Create a.ts" },
+					{ type: "create", path: "/tmp/b.ts", content: "b", description: "Create b.ts" },
+					{ type: "execute", description: "echo hello" },
+				],
+			};
+
+			const result = await executor.executeStep(step);
+
+			expect(result.status).toBe("completed");
+			expect(result.changes).toHaveLength(2);
+		});
+
+		it("should return unmappable error for create action without path", async () => {
+			const executor = makeExecutor(registry, "skip");
+			const step: BuildStep = {
+				stepNumber: 1,
+				description: "Bad action",
+				actions: [{ type: "create", content: "content", description: "Create without path" }],
+			};
+
+			const result = await executor.executeStep(step);
+
+			expect(result.status).toBe("skipped");
+			expect(result.error).toContain("requires a path");
+		});
+
+		it("should abort when user chooses abort after failure", async () => {
+			const executor = makeExecutor(registry, "abort");
+			const step: BuildStep = {
+				stepNumber: 1,
+				description: "Failing step",
+				actions: [{ type: "execute", description: "fail" }],
+			};
+
+			const result = await executor.executeStep(step);
+
+			expect(result.shouldAbort).toBe(true);
+			expect(result.status).toBe("failed");
+		});
+
+		it("should skip when user chooses skip after failure", async () => {
+			const executor = makeExecutor(registry, "skip");
+			const step: BuildStep = {
+				stepNumber: 1,
+				description: "Failing step",
+				actions: [{ type: "execute", description: "fail" }],
+			};
+
+			const result = await executor.executeStep(step);
+
+			expect(result.status).toBe("skipped");
+			expect(result.shouldAbort).toBe(false);
+			expect(result.error).toBeDefined();
+		});
+
+		it("should retry successfully when user chooses retry", async () => {
+			const executor = makeExecutor(registry, "retry");
+			const step: BuildStep = {
+				stepNumber: 1,
+				description: "Flaky step",
+				actions: [{ type: "execute", description: "flaky" }],
+			};
+
+			const result = await executor.executeStep(step);
+
+			expect(result.status).toBe("completed");
+			expect(result.shouldAbort).toBe(false);
+		});
+
+		it("should fail when retry also fails", async () => {
+			const executor = makeExecutor(registry, "retry");
+			const step: BuildStep = {
+				stepNumber: 1,
+				description: "Always failing step",
+				actions: [{ type: "execute", description: "fail" }],
+			};
+
+			const result = await executor.executeStep(step);
+
+			expect(result.status).toBe("failed");
+			expect(result.error).toBeDefined();
+		});
+	});
+
+	describe("mapBuildAction()", () => {
+		it("should map execute actions to bash tool calls", () => {
+			const result = mapBuildAction({ type: "execute", description: "npm test" });
+			expect(result.kind).toBe("call");
+			if (result.kind === "call") {
+				expect(result.call.name).toBe("bash");
+			}
+		});
+
+		it("should map create actions to write_file tool calls", () => {
+			const result = mapBuildAction({
+				type: "create",
+				path: "/tmp/test.ts",
+				content: "hello",
+				description: "Create test.ts",
+			});
+			expect(result.kind).toBe("call");
+			if (result.kind === "call") {
+				expect(result.call.name).toBe("write_file");
+			}
+		});
+
+		it("should return unmappable for create without path", () => {
+			const result = mapBuildAction({ type: "create", content: "hello", description: "No path" });
+			expect(result.kind).toBe("unmappable");
+			if (result.kind === "unmappable") {
+				expect(result.reason).toContain("requires a path");
+			}
+		});
+	});
+});


### PR DESCRIPTION
## What

Extract a `StepExecutor` class from `buildAgent()` that owns the per-step action execution + error recovery flow (retry/skip/abort). State-file writes remain in `buildAgent()` as the orchestration layer.

- **NEW** `src/agents/step-executor.ts` — `StepExecutor` class with `executeStep(step) → StepResult`, `mapBuildAction()` (moved here to break the runtime cycle), `ToolCall` + `MappedBuildAction` types, and dependency-injected `promptFn` for testability
- **MODIFIED** `src/agents/build-agent.ts` — refactored `buildAgent()` step loop to call `stepExecutor.executeStep(step)` and handle state-file writes based on the returned `StepResult`; re-exports `mapBuildAction`/`MappedBuildAction`/`ToolCall` from `step-executor.js` for backward compatibility
- **NEW** `test/agents/step-executor.test.ts` — 14 tests covering success, change tracking (create/modify/delete), unmappable errors, abort, skip, retry-then-succeed, retry-then-fail, and `mapBuildAction()` unit tests

## Why

`buildAgent()` was a 200-line function interleaving plan parsing, state-file I/O, tool execution, error recovery (retry/skip/abort with readline prompt), and state updates. The step execution path couldn't be tested without a real `ToolRegistry` and a real state file. This extraction makes the execute/retry/skip/abort flow independently testable with a mock registry and a mock prompt function — no state file, no plan parsing needed.

This is Candidate 5 from the architecture review (rated **Speculative** — the retry/skip/abort loop was tightly coupled to state-file writes, so the clean extraction required deciding where the state-write boundary sits).

## How

- **StepExecutor** owns: action execution via the registry + `mapBuildAction`, change tracking (create/modify/delete with path), error recovery prompt (retry/skip/abort), retry logic. Returns a structured `StepResult { status, changes, error, shouldAbort }` — NO state-file writes.
- **buildAgent()** stays the orchestration layer: parses the plan, iterates steps, calls `stepExecutor.executeStep(step)`, writes state based on the result, breaks on `shouldAbort`.
- **Circular dependency broken**: `mapBuildAction` + `ToolCall` + `MappedBuildAction` moved INTO `step-executor.ts`. `step-executor.ts` uses `import type` for `BuildAction`/`BuildStep` from `build-agent.js` (type-only, erased at compile time). `build-agent.ts` re-exports them for backward compat.
- **Dependency injection**: `StepExecutorOptions.promptFn` defaults to `promptChoice` but tests inject a `vi.fn()` mock — no module-level mocking needed.
- **Tests**: command-aware bash mock routes `"fail"` → failure, `"flaky"` → fails-on-first-call-then-succeeds, anything else → success. This correctly exercises the retry/skip/abort paths.

## Checklist

- [x] Tests added or updated (14 new tests)
- [x] No breaking changes (backward compat re-exports maintained)
- [ ] Documentation updated (architecture review candidates don't need docs)
