### PR TITLE
fix: address 3 design smells from code review

### DIFF
--- a/src/agents/step-executor.ts
+++ b/src/agents/step-executor.ts
@@ -106,12 +106,12 @@ type ExecutionOutcome = { success: boolean; output?: string; error?: string };
 
 /** Optional dependency injection for the recovery prompt (testability). */
 export interface StepExecutorOptions {
-	promptFn?: (question: string, options: string[]) => Promise<string>;
+	promptFn?: (question: string, options: string[]) => Promise<string | null>;
 }
 
 export class StepExecutor {
 	private _registry: ToolRegistry;
-	private _promptFn: (question: string, options: string[]) => Promise<string>;
+	private _promptFn: (question: string, options: string[]) => Promise<string | null>;
 
 	constructor(registry: ToolRegistry, options: StepExecutorOptions = {}) {
 		this._registry = registry;
@@ -207,6 +207,11 @@ export class StepExecutor {
 	private async _promptRecovery(error: string, stepNumber: number): Promise<"retry" | "skip" | "abort"> {
 		console.error(`\n❌ Error in step ${stepNumber}: ${error}`);
 		const decision = await this._promptFn("\nWhat would you like to do?", ["retry", "skip", "abort"]);
+		if (!decision) {
+			// No match — default to skip (safest: don't retry a failing action,
+			// don't abort the whole build)
+			return "skip";
+		}
 		return decision.toLowerCase() as "retry" | "skip" | "abort";
 	}
 }

--- a/src/cli/handlers/login.ts
+++ b/src/cli/handlers/login.ts
@@ -201,7 +201,13 @@ async function loginProvider(provider: LoginProviderInfo): Promise<void> {
 			console.log(`Get your API key at: ${provider.getKeyUrl}\n`);
 		}
 
-		const apiKey = await promptHidden(`Enter your ${provider.name} API key: `);
+		let apiKey: string;
+		try {
+			apiKey = await promptHidden(`Enter your ${provider.name} API key: `);
+		} catch {
+			console.log("\n✗ Login cancelled.");
+			process.exit(1);
+		}
 		if (!apiKey) {
 			console.log("\n✗ No API key entered. Login cancelled.");
 			process.exit(1);

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -25,6 +25,10 @@ export async function prompt(question: string): Promise<string> {
  * Read a line from stdin with masked input (echoes `*` for each character).
  * Falls back to plain readline when stdin is not a TTY (e.g. piped input).
  *
+ * Rejects with an error on Ctrl+C instead of calling process.exit(0), so
+ * callers can handle the interruption gracefully (e.g. abort the login
+ * flow and return to the prompt).
+ *
  * Security note: the raw-mode masking only works in a real PTY. When stdin
  * is piped (not a TTY), the input will be visible — this is the fallback
  * path used in tests.
@@ -47,7 +51,7 @@ export async function promptHidden(promptText: string): Promise<string> {
 	}
 
 	// TTY: read character-by-character with masking
-	return new Promise((resolve) => {
+	return new Promise((resolve, reject) => {
 		let input = "";
 		stdin.setRawMode(true);
 		stdin.resume();
@@ -65,10 +69,11 @@ export async function promptHidden(promptText: string): Promise<string> {
 					resolve(input.trim());
 					break;
 				case "\u0003": // Ctrl+C
+					stdin.removeListener("data", onData);
 					stdin.setRawMode(false);
 					stdin.pause();
 					process.stdout.write("\n");
-					process.exit(0);
+					reject(new Error("Interrupted by user (Ctrl+C)"));
 					break;
 				case "\u007f": // Delete
 				case "\b": // Backspace
@@ -92,13 +97,14 @@ export async function promptHidden(promptText: string): Promise<string> {
 
 /**
  * Prompt the user to choose from a list of options. The prompt shows the
- * options and accepts a case-insensitive match. Falls back to the first
- * option if the answer doesn't match any.
+ * options and accepts a case-insensitive match. Returns null when the
+ * answer doesn't match any option — callers should handle the null case
+ * (e.g. re-prompt, default, or abort) rather than silently falling back.
  *
  * This consolidates the `promptRecoveryDecision` pattern from build-agent.ts
  * and the `confirmMajorDecision` pattern from plan-agent.ts.
  */
-export async function promptChoice(question: string, options: string[]): Promise<string> {
+export async function promptChoice(question: string, options: string[]): Promise<string | null> {
 	const { createInterface } = await import("node:readline");
 	const rl = createInterface({ input: process.stdin, output: process.stdout });
 
@@ -107,7 +113,7 @@ export async function promptChoice(question: string, options: string[]): Promise
 			rl.close();
 			const normalized = answer.toLowerCase().trim();
 			const matched = options.find((option) => option.toLowerCase() === normalized);
-			resolve(matched ?? options[0] ?? "");
+			resolve(matched ?? null);
 		});
 	});
 }

--- a/src/config/config-io.ts
+++ b/src/config/config-io.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync } from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
+import { chmod, readFile, writeFile } from "node:fs/promises";
 import { CONFIG_DIR } from "./loader.js";
 
 /**
@@ -53,22 +53,35 @@ export async function readConfigFile(configPath: string): Promise<Record<string,
  * literal API key, writes with owner-only (0o600) permissions to prevent
  * other users from reading secrets.
  *
- * Note: `mode` only applies when the file is first created — existing files
- * keep their current permissions. `createDefaultConfig` in loader.ts always
- * uses 0o600, so the common onboarding flow (create → login) starts with the
- * right permissions.
+ * Enforces 0o600 permissions (owner-only) when a literal API key is present,
+ * both for new files (via `mode`) and existing files (via `chmod` after write).
+ * The `chmod` is best-effort — it may fail on platforms that don't support
+ * Unix permission bits (e.g. Windows).
  */
 export async function writeConfigFile(configPath: string, config: Record<string, unknown>): Promise<void> {
 	if (!existsSync(CONFIG_DIR)) {
 		mkdirSync(CONFIG_DIR, { recursive: true });
 	}
 
-	const writeOptions = containsLiteralApiKey(config) ? { mode: 0o600, encoding: "utf-8" as const } : "utf-8";
+	const hasLiteralKey = containsLiteralApiKey(config);
+	const writeOptions = hasLiteralKey ? { mode: 0o600, encoding: "utf-8" as const } : "utf-8";
 
 	if (configPath.endsWith(".json")) {
 		await writeFile(configPath, JSON.stringify(config, null, 2), writeOptions);
-		return;
+	} else {
+		const { stringify: stringifyYaml } = await import("yaml");
+		await writeFile(configPath, stringifyYaml(config), writeOptions);
 	}
-	const { stringify: stringifyYaml } = await import("yaml");
-	await writeFile(configPath, stringifyYaml(config), writeOptions);
+
+	// Enforce 0o600 on existing files too — Node's `mode` option only
+	// applies when the file is first created, so we chmod after every write
+	// to guarantee owner-only permissions when a literal key is present.
+	if (hasLiteralKey) {
+		try {
+			await chmod(configPath, 0o600);
+		} catch {
+			// chmod can fail on platforms that don't support it (Windows);
+			// the write already succeeded, so this is best-effort.
+		}
+	}
 }

--- a/test/agents/step-executor.test.ts
+++ b/test/agents/step-executor.test.ts
@@ -55,7 +55,7 @@ const bashTool = {
 
 /** Helper: create a StepExecutor with a mocked prompt function. */
 function makeExecutor(registry: ToolRegistry, decision: string): StepExecutor {
-	const mockPrompt = vi.fn<(q: string, opts: string[]) => Promise<string>>().mockResolvedValue(decision);
+	const mockPrompt = vi.fn<(q: string, opts: string[]) => Promise<string | null>>().mockResolvedValue(decision);
 	return new StepExecutor(registry, { promptFn: mockPrompt });
 }
 

--- a/test/cli/prompt.test.ts
+++ b/test/cli/prompt.test.ts
@@ -140,7 +140,7 @@ describe("cli/prompt", () => {
 			createInterfaceSpy.mockRestore();
 		});
 
-		it("should return the first option when no match", async () => {
+		it("should return null when no option matches", async () => {
 			const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
 				() =>
 					({
@@ -152,12 +152,12 @@ describe("cli/prompt", () => {
 			);
 
 			const result = await promptChoice("What to do?", ["retry", "skip", "abort"]);
-			expect(result).toBe("retry");
+			expect(result).toBeNull();
 
 			createInterfaceSpy.mockRestore();
 		});
 
-		it("should return the first option for empty input", async () => {
+		it("should return null for empty input", async () => {
 			const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
 				() =>
 					({
@@ -169,7 +169,7 @@ describe("cli/prompt", () => {
 			);
 
 			const result = await promptChoice("What to do?", ["retry", "skip", "abort"]);
-			expect(result).toBe("retry");
+			expect(result).toBeNull();
 
 			createInterfaceSpy.mockRestore();
 		});

--- a/test/config/config-io.test.ts
+++ b/test/config/config-io.test.ts
@@ -5,7 +5,6 @@ import { containsLiteralApiKey, readConfigFile, writeConfigFile } from "../../sr
 const TEMP_DIR = "/tmp/test-config-io";
 const TEMP_YAML = `${TEMP_DIR}/test-config.yaml`;
 const TEMP_JSON = `${TEMP_DIR}/test-config.json`;
-const TEMP_NESTED_YAML = `${TEMP_DIR}/nested/sub/config.yaml`;
 
 beforeEach(() => {
 	rmSync(TEMP_DIR, { recursive: true, force: true });
@@ -102,6 +101,23 @@ describe("config-io", () => {
 			const stats = statSync(TEMP_YAML);
 			const mode = stats.mode & 0o777;
 			expect(mode).toBe(0o600);
+		});
+
+		it("should chmod existing files to 0o600 when config has a literal API key", async () => {
+			// First write a config WITHOUT a literal key (gets default permissions)
+			const noKeyConfig = { defaultModel: "gpt-4o" };
+			await writeConfigFile(TEMP_YAML, noKeyConfig);
+			const statsBefore = statSync(TEMP_YAML);
+			const modeBefore = statsBefore.mode & 0o777;
+			expect(modeBefore).not.toBe(0o600);
+
+			// Now write a config WITH a literal key — should chmod the existing file
+			const withKeyConfig = { providers: { openai: { apiKey: "sk-test-key" } } };
+			await writeConfigFile(TEMP_YAML, withKeyConfig);
+
+			const statsAfter = statSync(TEMP_YAML);
+			const modeAfter = statsAfter.mode & 0o777;
+			expect(modeAfter).toBe(0o600);
 		});
 
 		it("should write with default permissions when config has no literal API key", async () => {


### PR DESCRIPTION
## What

Fix 3 minor design smells identified during the architecture review code review:

1. **`promptHidden` Ctrl+C** — replaced `process.exit(0)` with `reject(new Error("Interrupted by user (Ctrl+C)"))` so callers can handle the interruption gracefully
2. **`promptChoice` silent fallback** — returns `null` on no match instead of silently defaulting to `options[0]`, so callers must explicitly handle the no-match case
3. **`writeConfigFile` chmod** — calls `chmod(configPath, 0o600)` after every write when a literal API key is present, ensuring owner-only permissions on existing files (Node's `mode` option only applies on file creation)

## Why

These were flagged as design smells during the code review of the Config I/O and CLI Prompt extractions (Candidates 1 & 2):

- `process.exit(0)` in `promptHidden` prevented any caller cleanup — the login flow couldn't print a cancellation message or restore state
- `promptChoice` silently defaulting to the first option could mask user typos — a user typing "xyz" would unknowingly get "retry" instead of being asked again
- `writeConfigFile` documented that `mode` only applies on file creation, but didn't enforce `0o600` on existing files — a config file created without a key, then updated with one, would keep world-readable permissions

## How

- **`promptHidden`**: Changed Promise constructor from `(resolve)` to `(resolve, reject)`. Added `stdin.removeListener("data", onData)` before cleanup in the Ctrl+C handler. Updated `login.ts` to `try/catch` the rejection and print "Login cancelled" + `process.exit(1)`.
- **`promptChoice`**: Changed return type to `Promise<string | null>`. Updated `step-executor.ts` `StepExecutorOptions.promptFn` type to match. `_promptRecovery` defaults to `"skip"` when `null` (safest: don't retry a failing action, don't abort the whole build). Updated 2 tests to expect `null`.
- **`writeConfigFile`**: Added `chmod` import. Refactored from early-return (JSON path) to if/else so both paths converge to the chmod block. Wrapped `chmod` in try/catch for Windows compatibility (best-effort). Added 1 new test verifying chmod-on-existing-file. Removed unused `TEMP_NESTED_YAML` from config-io tests.

## Checklist

- [x] Tests added or updated (1 new test, 2 updated tests)
- [x] No breaking changes (callers updated to handle new signatures)
