### PR TITLE
feat(providers): add QwenCloud provider with qw/ prefix and curated capability map

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -12,6 +12,7 @@ Layered, dependency-inverted architecture. The CLI is the outermost layer; every
                      ┌──────────────▼───────────────┐
                      │  src/cli/ (dispatcher)       │
                      │  handlers/* command shims    │
+                     │  shared.ts (createAgent)     │
                      └──────────────┬───────────────┘
                                     │
         ┌───────────────────────────┼───────────────────────────┐
@@ -20,7 +21,8 @@ Layered, dependency-inverted architecture. The CLI is the outermost layer; every
 │  src/core/     │         │  src/agents/    │         │  src/skills/     │
 │  agent loop,   │         │  plan/build/    │         │  loader, parser, │
 │  memory,       │         │  explore agents │         │  registry        │
-│  tokens        │         │  + PlanGrammar  │         └──────────────────┘
+│  tokens,       │         │  + PlanGrammar  │         └──────────────────┘
+│  TurnExecutor  │         │  + StepExecutor │
 └───────┬────────┘         └────────┬────────┘
         │                           │
         │                  ┌────────▼─────────────────────────┐
@@ -42,24 +44,29 @@ Layered, dependency-inverted architecture. The CLI is the outermost layer; every
         │
 ┌───────▼────────────────────────────────────────────────────────────┐
 │  Cross-cutting: src/observability/  src/config/  src/utils/        │
+│  src/config/config-io.ts  src/cli/prompt.ts                       │
 └───────────────────────────────────────────────────────────────────┘
 ```
 
 ## Key Layers
 
 ### 1. Entry (`index.ts`)
-- Parses CLI args with `src/utils/command.ts`.
-- Loads config (`src/config/loader.ts`).
-- Boots the agent loop (`src/core/agent.ts`) with the resolved provider and tool registry.
-- Handles `--upgrade` (delegates to `src/cli/handlers/upgrade.ts`) and `--help`.
+- Imports and executes `main()` from `src/cli/index.js`.
+- Global error handler catches and reports fatal errors.
 
 ### 2. CLI Dispatcher (`src/cli/`, `src/cli/handlers/`)
-- `src/cli/main.tsx` mounts the Ink UI.
-- `src/cli/chat-commands.ts` and the per-feature handlers (`plan.ts`, `agent.ts`, `state.ts`, `memory.ts`, `config.ts`, `mcp.ts`, `skill.ts`, `trace.ts`, `status.ts`, `upgrade.ts`, `login.ts`) implement each subcommand.
+- `src/cli/main.tsx` mounts the Ink UI, parses CLI args, dispatches to handlers.
+- `src/cli/shared.ts` houses `createLLMClient`, `setupTools`, and `createAgent()` — the agent factory that consolidates the full construction sequence (createLLMClient → setupTools → new Agent → createSkillTool → register → waitForSkills). Returns `{ agent, mcpManager, toolRegistry, agentsMdPath }`.
+- `src/cli/prompt.ts` — the single source of truth for readline-based user input: `prompt()`, `promptHidden()` (raw-mode `*` masking), `promptChoice()`. Extracted from login.ts, build-agent.ts, and plan-agent.ts.
+- `src/cli/chat-commands.ts` — `/-slash` command parser.
+- Per-feature handlers: `agent.ts`, `plan.ts`, `state.ts`, `memory.ts`, `config.ts`, `mcp.ts`, `skill.ts`, `trace.ts`, `status.ts`, `upgrade.ts`, `login.ts`.
 - Handlers return structured results; the CLI layer never throws to the user.
+- **Login/logout** (`src/cli/handlers/login.ts`): dispatched before `loadConfig()` so onboarding works with no config file (ADR-014).
 
 ### 3. Agent Loop (`src/core/agent.ts`)
 - Drives the conversation: user message → provider call → tool dispatch → response → repeat.
+- **TurnExecutor** (`src/core/turn-executor.ts`) — owns the per-turn tool execution + error recovery. Extracted from `runStream()` (~400 lines → testable unit). Handles tool batch execution, not-found/declined/loop-break detection, and returns a structured `TurnResult`.
+- **agent-utils.ts** (`src/core/agent-utils.ts`) — `isLooping()`, `truncateOutput()`, `LOOP_DETECTION`, `MAX_OUTPUT_LENGTH`. Extracted to break the circular dependency between `agent.ts` and `turn-executor.ts`.
 - Token-bounded via `src/core/tokens.ts`.
 - Memory persistence via `src/core/memory.ts`.
 
@@ -72,13 +79,15 @@ Three specialized agents share an atomic state file (`.tiny-state.json`) and a c
 | build-agent | `build-agent.ts` | Parses a plan and executes its steps (file ops, bash) |
 | explore-agent | `explore-agent.ts` | Read-only codebase reconnaissance |
 
-Shared state types in `src/agents/types.ts`; reader/writer with atomic writes in `src/agents/state.ts`.
+- **StepExecutor** (`src/agents/step-executor.ts`) — owns the per-step action execution + error recovery (retry/skip/abort). Extracted from `buildAgent()`. Uses dependency-injected `promptFn` for testability. `mapBuildAction()` lives here to break the runtime circular dependency with `build-agent.ts` (type-only imports back).
+- Shared state types in `src/agents/types.ts`; reader/writer with atomic writes in `src/agents/state.ts`.
 
 ### 5. Tool Registry (`src/tools/registry.ts`)
 Single `ToolRegistry` instance is constructed per session and accumulates:
 - Built-in tools (`file-tools.ts`, `bash-tool.ts`, `search-tools.ts`, `web-search-tool.ts`, `skill-tool.ts`)
 - Skills exposed as tools (`skill-tool.ts` wraps the skills loader)
 - MCP server tools (registered dynamically as MCP servers connect)
+- Plugin tools (`plugin-loader.ts`)
 
 Tools conform to `Tool` interface (`src/tools/types.ts`) with a `name`, `description`, `parameters` JSON Schema, optional `dangerous` callback (for confirmation routing), and an async `execute(args) → ToolResult`.
 
@@ -102,6 +111,12 @@ SKILL.md discovery + frontmatter parsing. Built-in skills live in `src/skills/bu
 - Opt-in Langfuse export.
 - Redacted structured logger.
 
+### 10. Config I/O (`src/config/config-io.ts`)
+- Single source of truth for config file reading/writing.
+- `readConfigFile()` — YAML/JSON dispatch, returns `{}` on missing/parse error.
+- `writeConfigFile()` — creates `CONFIG_DIR`, writes with `0o600` permissions when a literal API key is present (via `chmod` after write for existing files).
+- `containsLiteralApiKey()` — detects non-env-var-reference API keys.
+
 ## Data Flow: A Single Turn
 
 ```
@@ -114,8 +129,11 @@ src/core/agent.ts                 (main loop)
 src/providers/<x>.ts              (chat / chatStream)
    │
    ▼ tool calls returned by model
-src/tools/registry.ts.execute     (single) / .executeBatch (multi)
+src/core/turn-executor.ts         (executeTurn: batch execution + error recovery)
    │  confirmation via src/tools/confirmation.ts
+   ▼
+src/tools/registry.ts.execute     (single) / .executeBatch (multi)
+   │
    ▼
 src/tools/<tool>.ts               (file / bash / search / web / skill / mcp-*)
    │
@@ -129,6 +147,9 @@ src/core/agent.ts                 (compose next message, loop or finalize)
 - **`ToolRegistry`** — single source of truth for available tools. Re-used by the agent loop, the CLI tool inspector, and any embedded plugin.
 - **`StateFile`** (`src/agents/state.ts`) — atomic JSON state shared across plan/build/explore agents.
 - **`provider/model-string`** — single source of truth for "which model runs".
+- **`createAgent()`** (`src/cli/shared.ts`) — single source of truth for "how to build a fully-wired Agent". Used by both `handleRun` and `handleInteractiveChat`.
+- **`config-io.ts`** — single source of truth for config file I/O. Used by `login.ts` and `mcp.ts`.
+- **`prompt.ts`** — single source of truth for readline prompting. Used by `login.ts`, `plan-agent.ts`, `step-executor.ts`.
 
 ## Plugin Surface
 
@@ -138,3 +159,14 @@ src/core/agent.ts                 (compose next message, loop or finalize)
 ## Embedded Mode
 
 For the compiled binary (`bun build --compile`), the skills and version metadata are embedded as TS modules so the binary has no runtime dependency on the source tree. See `scripts/generate-embedded-skills.ts` and `scripts/generate-version.ts`.
+
+## ADRs
+
+Architecture decisions are documented in `docs/adr/` (ADR-001 through ADR-014). See `docs/README.md` for the full index. Key ADRs:
+
+- ADR-005: Tool system design (Tool interface, registry, dangerous-routing)
+- ADR-010: Ink CLI integration (React/Ink UI architecture)
+- ADR-011: Multi-agent system (plan/build/explore sharing state file + PlanGrammar)
+- ADR-012: GatewayOpenAIProvider base class (held back by 30% duplication threshold)
+- ADR-013: ClinePass live model lookup (replace baked capability table with live fetch)
+- ADR-014: Login command onboarding design (top-level dispatch, status-only chat, literal key storage)

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -5,30 +5,30 @@ Real signals from `rg TODO/FIXME/HACK`, file-size outliers, and observed issues 
 ## Tech Debt
 
 ### Case-insensitive-filesystem `Justfile` / `justfile` collision
-- **What**: `git ls-files` shows BOTH `Justfile` (uppercase, blob `5afb0dd`) and `justfile` (lowercase, blob `504ff73`) tracked as separate paths in the tree.
-- **Why it's a problem**: On case-insensitive macOS APFS (the developer's working env), they collapse to one disk file, so `git status` is permanently chatty and `rm`/`git checkout` interactions are confusing. Linux/Windows CI is unaffected, which is why it hasn't broken CI.
-- **Fix**: A single chore commit on the branch to remove the duplicate path (`git rm justfile` + commit). Safe to do as a follow-up; not blocking PRs.
+- **What**: `git ls-files` shows BOTH `Justfile` (uppercase) and `justfile` (lowercase) tracked as separate paths in the tree.
+- **Why it's a problem**: On case-insensitive macOS APFS, they collapse to one disk file, so `git status` is permanently chatty.
+- **Fix**: A single chore commit to remove the duplicate path (`git rm justfile` + commit). Safe to do as a follow-up.
 
-### `_stepError` write-only assignments
-- **Where**: `src/agents/build-agent.ts` — `let _stepError: string | undefined; ... _stepError = executionResult.error; ... _stepError = retryResult.error;` — assigned but never read.
-- **Why**: Leftover from earlier debugging; prefix-underscore says "intentionally unused".
-- **Fix**: Either remove the variable entirely, or wire it into `state.errors` (it currently duplicates what `handleExecutionError` already writes). Low priority — TypeScript strict mode tolerates this.
+### `_stepError` write-only assignments (resolved)
+- **Where**: `src/agents/build-agent.ts` — previously had `let _stepError` assigned but never read.
+- **Status**: Likely resolved by the StepExecutor extraction (PR #65). The variable was part of the old inline execution loop that was moved to `step-executor.ts`. Verify it's gone.
 
-### Lint info: `continue` in `mode === "none"` branch
+### Lint info: `continue` in `plan-grammar.ts`
 - **Where**: `src/agents/plan-grammar.ts` around line 284 — biome flags a redundant `continue` at the end of the `for` loop iteration.
-- **Why**: Either the lint rule is over-zealous (the explicit `continue` is documentation) or the loop body genuinely has nothing to do when `mode === "none"`. Worth a quick look — likely delete the line.
+- **Fix**: Delete the line. 1-line fix, removes a lint warning.
 
 ### `parsePlanToSteps` more permissive than main's prior regex
-- **What**: After the recent merge of PR #56, build-agent uses PR's `PlanGrammar.parse` for plan parsing, which accepts `## Phase 1` (no title required) where main's old regex required a colon + description.
-- **Risk**: If any persisted plan in the wild relies on main's strict title-required parsing, it now silently produces empty-title phases. Test coverage includes the new permissive form but not the regression case.
+- **What**: After PR #56, build-agent uses `PlanGrammar.parse` for plan parsing, which accepts `## Phase 1` (no title required) where the old regex required a colon + description.
+- **Risk**: Persisted plans relying on strict title-required parsing now silently produce empty-title phases.
 - **Fix**: Add a regression test that asserts empty-title phase detection is reported in `validate()` errors.
 
 ## Performance
 
-### Largest files (lines of code, real counts from `find src -name '*.ts' -exec wc -l`)
+### Largest files (lines of code)
 ```
-src/core/agent.ts                1166   ← monolithic, top candidate for splitting
-src/agents/build-agent.ts         586
+src/core/agent.ts                1052  ← still largest, but TurnExecutor extraction reduced it from ~1173
+src/cli/main.tsx                  605  ← reduced by createAgent factory extraction
+src/cli/handlers/login.ts         590  ← includes both login AND logout handlers
 src/agents/explore-agent.ts       551
 src/core/memory.ts                514
 src/tools/file-tools.ts           449
@@ -36,30 +36,33 @@ src/agents/plan-grammar.ts        408
 src/providers/anthropic.ts        370
 src/tools/search-tools.ts         354
 src/ui/hooks/useCommandHandler.ts 334
-src/providers/ollama.ts           324
 ```
-- **src/core/agent.ts** at 1166 lines is the largest file in the repo by a wide margin and the clearest refactor target — likely extract: conversation-state machine, tool-dispatch loop, streaming token handler, error-recovery policy.
-- **build-agent.ts** at 586 lines is borderline monolithic. Refactor opportunity: extract `executeBuildAction` (now removed) back into `src/tools/` if PR #52's registry-based path stabilizes further.
+
+- **`src/core/agent.ts`** at 1052 lines is still the largest file. The TurnExecutor extraction (PR #63) removed ~120 lines of inline tool dispatch logic, and agent-utils.ts extracted `isLooping`/`truncateOutput`. Further refactoring could extract the streaming/observability instrumentation.
+- **`src/cli/handlers/login.ts`** at 590 lines houses both login and logout. If logout grows further, consider splitting into `login.ts` + `logout.ts`.
 
 ### Streaming provider perf
 - Provider streaming tests exist but no benchmark on first-token latency. `test/performance/benchmarks.test.ts` covers token counting and grep/glob but not streaming TTFT.
 
 ## Security
 
-- **Secret redaction** in `src/observability/redact.ts` covers `.env`, `.aws/`, `.ssh/`, etc. — good coverage but only applies to log lines, not to tool output sent back to the model. If a tool reads `~/.aws/credentials` and the dangerous-tool check fails, the result is still in `tool.execute()` return — review path-validation in `src/tools/file-tools.ts:validatePath`.
-- **Sensitive bash classifier** (`src/tools/bash-tool.ts`) is a regex/allowlist — adequate for common patterns but won't catch every destructive command. Default-deny would be safer; consider flipping for `rm -rf /` family in particular.
-- **MCP servers** run with the same fs/network privileges as the agent. No sandboxing layer beyond what Bun provides. Document this in user-facing docs.
+- **Config file permissions**: `writeConfigFile()` in `src/config/config-io.ts` now enforces `0o600` via `chmod` after write when `containsLiteralApiKey()` returns true (PR #67 on `fix/design-smells` branch — verify it's merged). Previously, `mode: 0o600` only applied on file creation, leaving existing files world-readable.
+- **`promptHidden` Ctrl+C**: Now rejects the promise instead of calling `process.exit(0)` (PR #67). Callers use `try/catch` to handle cancellation. Verify merged.
+- **Secret redaction** in `src/observability/redact.ts` covers `.env`, `.aws/`, `.ssh/`, etc. — good coverage but only applies to log lines, not to tool output sent back to the model.
+- **Sensitive bash classifier** (`src/tools/bash-tool.ts`) is a regex/allowlist — adequate for common patterns but won't catch every destructive command. Default-deny would be safer.
+- **MCP servers** run with the same fs/network privileges as the agent. No sandboxing layer beyond what Bun provides.
 
 ## Fragile Areas
 
-- **PlanGrammar round-trip** — `serialize(plan) → parse(text) → deep-equal(original)` is the load-bearing invariant. Test suite covers it, but any new field added to `Plan`/`Phase`/`Step` MUST update the `serialize` template AND a test.
+- **PlanGrammar round-trip** — `serialize(plan) → parse(text) → deep-equal(original)` is the load-bearing invariant. Any new field added to `Plan`/`Phase`/`Step` MUST update the `serialize` template AND a test.
 - **`ToolRegistry.executeBatch`** confirmation logic has multiple branches (`false`, `{type: "partial"}`, all-approved) — easy to break. The CLI's confirmation handler in `src/tools/confirmation.ts` is the counterpart and must stay in sync.
-- **Provider streaming** events are emitted into `src/observability/` — if a provider fails to flush on error, traces go incomplete. `test/observability/agent-observability.test.ts` exists but coverage of partial-failure scenarios is thin.
+- **Provider streaming** events are emitted into `src/observability/` — if a provider fails to flush on error, traces go incomplete. Coverage of partial-failure scenarios is thin.
+- **Circular dependency breaking pattern** — `turn-executor.ts` ↔ `agent-utils.ts` and `step-executor.ts` ↔ `build-agent.ts` rely on `import type` being erased at compile time. If someone accidentally adds a runtime import, the cycle returns. No automated guard exists.
 
 ## Observability
 
-- **Langfuse** is opt-in via env vars. No local trace viewer — users without a Langfuse account have no way to inspect what the agent did beyond stdout. A built-in HTML trace dump would help debugging.
-- **Token cost** uses `src/observability/model-pricing.json` — bundled snapshot. Drift from real provider pricing is possible; consider fetching on startup like `models-dev.ts` does for capabilities.
+- **Langfuse** is opt-in via env vars. No local trace viewer — users without a Langfuse account have no way to inspect what the agent did beyond stdout.
+- **Token cost** uses `src/observability/model-pricing.json` — bundled snapshot. Drift from real provider pricing is possible.
 
 ## Test Coverage Gaps
 
@@ -67,21 +70,24 @@ src/providers/ollama.ts           324
 - No test for `src/cli/handlers/upgrade.ts` (binary swap, partial-download rollback).
 - No e2e covering an MCP server lifecycle (connect, tool call, disconnect, reconnect).
 - No concurrency test for `src/core/memory.ts` writes from concurrent agents (the state file is shared).
+- **`promptHidden` Ctrl+C rejection** — the TTY raw-mode path's `reject(new Error("Interrupted by user (Ctrl+C)"))` is untested. All existing tests use the non-TTY fallback. Adding a test requires mocking `stdin.setRawMode` and simulating a `\u0003` character.
 
 ## Build & Release
 
-- **Embedded skills** generated at build time — if a contributor forgets to run `bun run generate:skills`, the built binary ships stale content. CI runs it (`.github/workflows/ci.yml`), but a pre-commit hook would catch it locally.
+- **Embedded skills** generated at build time — if a contributor forgets to run `bun run generate:skills`, the built binary ships stale content. CI runs it, but a pre-commit hook would catch it locally.
 - **Version constant** — `src/utils/version-constant.ts` is generated; commit-time check exists in CI but a developer who bypasses CI gets a stale `0.0.0` build.
 
 ## Documentation
 
-- ADRs in `docs/adr/` are good (001-011), but `docs/README.md` is missing — entry point for new contributors is implicit via AGENTS.md/CLAUDE.md.
-- No architecture diagram in docs (this codemap fills that gap going forward).
+- ADRs in `docs/adr/` are comprehensive (001-014). `docs/README.md` has the full index.
+- `README.md` has been updated with login/logout command documentation and ADR list (PR #68).
+- No architecture diagram in docs (this codebase map fills that gap).
 
 ## Quick Wins (sorted by ROI)
 
 1. Delete the redundant `continue` in `src/agents/plan-grammar.ts` (1 line, removes a lint warning).
-2. Remove the lowercase `justfile` tracking on this branch (chore commit, clears up `git status`).
+2. Remove the lowercase `justfile` tracking (chore commit, clears up `git status`).
 3. Add a regression test for empty-title phase detection in `plan-grammar.test.ts`.
-4. Wire `_stepError` into `state.errors` properly or delete it.
+4. Verify `_stepError` is gone from `build-agent.ts` after StepExecutor extraction.
 5. Add a `--dump-trace <path>` flag that writes the current session's trace to a local HTML file (offline trace viewer).
+6. Merge PR #67 (design smell fixes) if not yet merged — addresses `0o600` chmod, `promptChoice` null, `promptHidden` rejection.

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,6 +1,6 @@
 # Conventions
 
-Driven by `AGENTS.md`, `CLAUDE.md`, and `biome.json`. All enforced by Biome lint + format on save / pre-commit.
+Driven by `AGENTS.md`, `CLAUDE.md`, and `biome.json`. All enforced by Biome lint + format on save / pre-commit (via `prek`).
 
 ## Imports
 
@@ -8,6 +8,7 @@ Driven by `AGENTS.md`, `CLAUDE.md`, and `biome.json`. All enforced by Biome lint
   ```ts
   import * as fs from "node:fs/promises";
   import { createInterface } from "node:readline";
+  import { chmod, readFile, writeFile } from "node:fs/promises";
   ```
 - External deps: bare specifier.
   ```ts
@@ -25,11 +26,11 @@ Driven by `AGENTS.md`, `CLAUDE.md`, and `biome.json`. All enforced by Biome lint
 
 | Kind | Convention | Example |
 |---|---|---|
-| Files | kebab-case | `plan-grammar.ts` |
-| Classes / types / React components | PascalCase | `ToolRegistry`, `BuildStep` |
-| Functions / variables | camelCase | `parsePlanToSteps` |
-| Constants | SCREAMING_SNAKE_CASE | `BUILD_SYSTEM_PROMPT` |
-| Private members | `_prefix` | `_tools`, `_dryRun` |
+| Files | kebab-case | `plan-grammar.ts`, `config-io.ts` |
+| Classes / types / React components | PascalCase | `ToolRegistry`, `BuildStep`, `TurnExecutor` |
+| Functions / variables | camelCase | `parsePlanToSteps`, `createAgent` |
+| Constants | SCREAMING_SNAKE_CASE | `BUILD_SYSTEM_PROMPT`, `LOOP_DETECTION` |
+| Private members | `_prefix` | `_tools`, `_registry`, `_promptFn` |
 | React props | `interface XProps` or inline | `<Message ... />` |
 
 ## Strings & Variables
@@ -47,6 +48,7 @@ const timeout = args.timeout ?? 60000;  // ?? for nullish defaults
 - Use `zod` for runtime input validation (tools, configs, env vars).
 - `noUncheckedIndexedAccess` — every `arr[i]` is `T | undefined`; check before use.
 - `noImplicitOverride` — `override` keyword required on subclass overrides.
+- Use `as const` for literal type narrowing (e.g. `{ type: "object" as const }`).
 
 ## React / JSX (Ink)
 
@@ -72,6 +74,10 @@ async function readSomething(path: string): Promise<Result<string>> {
 ```
 
 Use specific error codes: `ENOENT`, `EACCES`, `EISDIR`, `ENOTDIR`. Avoid `any`; cast as `NodeJS.ErrnoException` for fs errors.
+
+**Exception**: CLI handlers (`src/cli/handlers/*`) may call `process.exit(code)` after `console.error` for user-facing errors (e.g. invalid args, login cancellation). This is the accepted pattern for top-level CLI commands.
+
+**Note**: `promptHidden()` currently calls `process.exit(0)` on Ctrl+C. PR #67 (`fix/design-smells`) changes this to reject the promise with `new Error("Interrupted by user (Ctrl+C)")` so callers can `try/catch` — pending merge.
 
 ## Async Patterns
 
@@ -99,14 +105,45 @@ async function fetchData(url: string): Promise<Result<Data>> {
 
 ## CLI Authoring (`src/cli/handlers/`)
 
-- Each handler exports an async function `(config, args, options) → Promise<void>`.
+- Each handler exports an async function `(args, config?, options?) → Promise<void>`.
 - Handlers never throw to the user — they `console.error` and `process.exit(code)`.
 - Exit codes: `0` ok, `1` runtime error, `2` usage error.
+- **Login/logout** are special: dispatched before `loadConfig()` so they work without an existing config (ADR-014).
+
+## Config I/O (`src/config/config-io.ts`)
+
+- All config file reading/writing goes through `readConfigFile()` / `writeConfigFile()`.
+- `writeConfigFile()` uses `mode: 0o600` on file creation when `containsLiteralApiKey()` returns true. PR #67 adds `chmod` after write to enforce `0o600` on existing files — pending merge.
+- Never inline `await import("yaml")` or `writeFile` for config operations — use the shared module.
+
+## Prompting (`src/cli/prompt.ts`)
+
+- All readline-based user input goes through `prompt()`, `promptHidden()`, or `promptChoice()`.
+- `promptHidden()` uses raw-mode `*` masking in TTY, falls back to plain readline in non-TTY.
+- `promptChoice()` currently returns `options[0] ?? ""` on no match (silent first-option fallback). PR #67 changes this to return `null` — pending merge.
+- Never inline `createInterface` from `node:readline` — use the shared module.
+
+## Dependency Injection
+
+- Prefer dependency injection over module-level mocking.
+- `StepExecutor` accepts an optional `promptFn` in `StepExecutorOptions` — tests pass a `vi.fn()` mock.
+- `ToolRegistry` is injectable — tests pass a registry pre-loaded with stubs.
+- Provider factory accepts a `providers` map — tests inject a stub provider.
+
+## Circular Dependency Breaking
+
+When extracting a module creates a runtime cycle, use the established pattern:
+1. Move shared utilities to a separate `*-utils.ts` file (e.g. `agent-utils.ts`).
+2. Use `import type` for type-only imports (erased at compile time, no runtime cycle).
+3. Re-export from the original file for backward compatibility.
+- Example: `turn-executor.ts` imports from `agent-utils.ts` (not `agent.ts`); `agent.ts` re-exports from `agent-utils.ts`.
+- Example: `step-executor.ts` uses `import type` for `BuildAction`/`BuildStep` from `build-agent.ts`; `build-agent.ts` re-exports `mapBuildAction` from `step-executor.ts`.
 
 ## Logging / Output
 
 - Structured logger via `src/observability/logger.ts`; never `console.log` from the agent loop.
-- Ink UI uses `console.log` for terminal output that bypasses the UI (e.g. `--upgrade`).
+- Ink UI uses `console.log` for terminal output that bypasses the UI (e.g. `--upgrade`, `login`).
+- CLI handlers use `console.log` for user-facing output and `console.error` for errors.
 
 ## File Organization
 
@@ -119,4 +156,4 @@ async function fetchData(url: string): Promise<Result<Data>> {
 - `bun run lint` — Biome checks.
 - `bun run format` — Biome write.
 - `bun run lint:fix` — Biome write + auto-fix.
-- Pre-commit hook runs lint on staged files (`.husky/pre-commit`).
+- Pre-commit hook runs `prek` which executes `biome check` (staged files) and `tsc --noEmit` (full project) via `.husky/pre-commit`.

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -10,20 +10,31 @@ Each provider implements the same interface (`src/providers/types.ts`) and is wi
 | Anthropic | `src/providers/anthropic.ts` | `@anthropic-ai/sdk`. Tool format adapter (`toAnthropicFormat`). |
 | Ollama | `src/providers/ollama.ts` | Local model server. Pulls model list dynamically. |
 | Ollama Cloud | `src/providers/ollama-cloud.ts` | Hosted variant. |
-| OpenRouter | `src/providers/openrouter.ts` | Multi-model aggregator (OpenAI-compatible). |
-| OpenCode | `src/providers/opencode.ts` | Custom gateway. |
-| z.ai (GLM) | `src/providers/zai.ts` | Custom provider for z.ai models. |
+| OpenRouter | `src/providers/openrouter.ts` | Multi-model aggregator (OpenAI-compatible). Looks up capabilities from models.dev. |
+| OpenCode | `src/providers/opencode.ts` | Custom gateway with curated coding models. |
+| Z.AI (GLM) | `src/providers/zai.ts` | Custom provider for z.ai / Zhipu models (GLM-4.7, etc). |
+| ClinePass | `src/providers/clinepass.ts` | Live model lookup via `GET /api/v1/models` (ADR-013). |
 | Models registry | `src/providers/models-dev.ts` | Fetches the open `models.dev` JSON to populate the registry at startup. |
 | Registry / capability map | `src/providers/model-registry.ts`, `src/providers/capabilities.ts` | Single source of truth for which models support tools, vision, JSON mode, etc. |
+| Factory | `src/providers/factory.ts` | Model-string → provider instance. Parses `provider/model-name` strings. |
 
-The registry is loaded once at startup, cached, and re-used by every provider.
+The registry is loaded once at startup, cached, and re-used by every provider. The `detectProvider(modelString)` function in `model-registry.ts` maps a model string to its provider key.
+
+## Login/Logout Onboarding (`src/cli/handlers/login.ts`)
+
+- **`tiny-agent login`** — Interactive provider picker with masked API key entry (`promptHidden`). Writes literal keys to `~/.tiny-agent/config.yaml` with `0o600` permissions when a literal key is present (via `src/config/config-io.ts`).
+- **`tiny-agent logout`** — Removes a provider's `apiKey` from config. Prompts for a new `defaultModel` if the logged-out provider was the active one. Refuses for Ollama (no key).
+- **`/login` in chat** — Status-only (shows connection status + onboarding guidance). No key collection in the Ink UI (ADR-014).
+- **`/logout` in chat** — Shows logout guidance (delegates to top-level `tiny-agent logout`).
+- **ADR-014** documents the design decisions: top-level dispatch before `loadConfig()`, chat is status-only, literal key storage with env-var tip.
 
 ## Model Context Protocol (`src/mcp/`)
 
 - **MCP client**: `src/mcp/client.ts` + `src/mcp/manager.ts` — supports stdio and HTTP transports.
-- Servers are configured under `mcp.servers` in the user's `tiny-agent.json`.
+- Servers are configured under `mcpServers` in the user's `~/.tiny-agent/config.yaml`.
 - Each connected server's tools are registered into the local `ToolRegistry` so they're addressable like any other tool (`mcp_<server>_<tool>`).
 - Error type lives in `src/mcp/types.ts`.
+- CLI management via `src/cli/handlers/mcp.ts` (`tiny-agent mcp list/enable/disable/add`).
 
 ## Web Search (`src/tools/web-search-tool.ts`)
 
@@ -37,21 +48,28 @@ The registry is loaded once at startup, cached, and re-used by every provider.
 - `SKILL.md` discovery walks the configured skills directories (project + user `~/.config/tiny-agent/skills/`).
 - Frontmatter parsed via `src/skills/parser.ts`; loader in `src/skills/loader.ts`; builtin registry in `src/skills/builtin-registry.ts`.
 - For the binary build, skills are embedded via `scripts/generate-embedded-skills.ts` → `src/skills/embedded-content.ts` so no runtime filesystem access is needed for the default skills.
+- Built-in skill: `code-simplifier` (`src/skills/builtin/code-simplifier/SKILL.md`).
 
 ## Observability (`src/observability/`)
 
 - **Langfuse** integration (`src/observability/langfuse.ts`) — opt-in via env vars (`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`).
+- **OpenTelemetry** (`src/observability/telemetry.ts`) — console exporter by default, configurable for OTLP backend.
 - **Token usage tracking** (`src/observability/token-usage.ts`) and cost estimation (`src/observability/cost.ts`) using `src/observability/pricing.ts` + `src/observability/model-pricing.json`.
 - **Structured logger** (`src/observability/logger.ts`) with redaction (`src/observability/redact.ts`) — strips API keys, env-style secrets.
-- **Telemetry** (`src/observability/telemetry.ts`), **trace context** (`src/observability/trace-context.ts`).
-- All providers emit events into this layer when configured.
+- **Trace context** (`src/observability/trace-context.ts`) — unique `traceId` per run, propagated through retrieval, tool execution, and LLM calls.
 
 ## File System / Process
 
 - Native Node `node:fs/promises`, `node:path`, `node:readline`, `node:child_process`.
 - No external filesystem abstraction; tools layer wraps `fs` calls into typed `Tool` definitions.
+- Config I/O centralized in `src/config/config-io.ts` (YAML/JSON dispatch, `0o600` permissions, `containsLiteralApiKey`).
 
 ## Upgrade Channel
 
 - Self-update via `tiny-agent --upgrade` (handler in `src/cli/handlers/upgrade.ts`) — downloads the latest release from GitHub and atomically swaps the binary.
-- Version metadata generated from `package.json` at build time.
+- Version metadata generated from `package.json` at build time via `scripts/generate-version.ts`.
+
+## Plugin System
+
+- Tool plugins via `src/tools/plugin-loader.ts` — drop a `.ts`/`.js` file exporting `Tool` into `~/.tiny-agent/plugins/` and it gets registered at startup.
+- Plugins run with the agent's full permissions (no sandbox) — see `SECURITY.md` for risks.

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -7,12 +7,12 @@
   - `noUncheckedIndexedAccess` — indexed access returns `T | undefined`
   - `noImplicitOverride` — `override` keyword required on subclass overrides
 - **Runtime**: Bun (>=1.x). Source extensions: `.ts`, `.tsx` (for Ink UI).
-- **Path aliases**: `@/*` → repo root (e.g. `import { Tool } from "@/tools/types.js"`).
+- **Path aliases**: `@/*` → `./src/*` (e.g. `import { Tool } from "@/tools/types.js"`).
 
 ## Frontend / UI
 
 - **React 18+ via Ink** (`ink` package) for the CLI UI layer (`src/ui/`).
-- **boxen / ink-spinner / ink-text-input** for terminal layout, spinners, and text input.
+- **ink-box / ink-spinner / ink-text-input** for terminal layout, spinners, and text input.
 - No browser-side code.
 
 ## Validation & Schemas
@@ -25,19 +25,25 @@
 - **Biome** (single tool for lint + format). Config: `biome.json`.
   - Indent: tabs
   - Quotes: double
+  - Line width: 120
   - Lint rules: `recommended` + `correctness`, `style`, `suspicious`, `performance`
-  - Import organization enabled
+  - Disabled rules: `noNonNullAssertion`, `noNonNullAssertedOptionalChain`, `noArrayIndexKey`, `noAssignInExpressions`
+  - Import organization enabled (`assist/source/organizeImports`)
+- **prek** (pre-commit hooks). Config: `prek.toml`.
+  - Trailing whitespace, EOF fixer, YAML/large file checks
+  - Local hooks for `biome check` (lint+format) and `tsc --noEmit` (typecheck)
 
 ## Build & Distribution
 
 - **Bun compile** — `bun build index.ts --compile --outfile=tiny-agent` produces a self-contained native binary.
 - **Embedded skills generation** — `bun run scripts/generate-embedded-skills.ts` walks `src/skills/builtin/` and emits `src/skills/embedded-content.ts` so skill content ships inside the binary.
 - **Version generation** — `bun run scripts/generate-version.ts` writes `src/utils/version-constant.ts` from `package.json`.
-- **Task runner**: `just` (Justfile). Recipes: `dev`, `build`, `test`, `lint`, `format`, `typecheck`, release patch/minor/major.
+- **Task runner**: `just` (Justfile). Recipes: `dev`, `build`, `test`, `lint`, `format`, `typecheck`, `check`, `pre`, release patch/minor/major.
+- **Release**: `bumpp` (via `bump.config.ts`) for version bumping. GitHub Actions release workflow in `.github/workflows/release.yml`.
 
 ## Testing
 
-- **bun:test** built-in test runner. 60+ test files mirroring `src/` under `test/`.
+- **bun:test** built-in test runner. 65 test files mirroring `src/` under `test/`.
 - **Coverage**: not configured; bun's `--coverage` flag is available.
 - **Performance benchmarks**: `test/performance/benchmarks.test.ts`.
 - **E2E**: `test/e2e/agent-loop.test.ts` exercises the full agent loop with stub providers.
@@ -48,21 +54,41 @@
 |---|---|
 | `@anthropic-ai/sdk` | Anthropic provider |
 | `openai` | OpenAI / OpenAI-compatible providers |
-| `ink`, `react` | CLI UI |
-| `zod`, `zod-to-json-schema` | Runtime schema validation |
+| `ollama` | Ollama API client |
+| `tiktoken` | Token counting (OpenAI tokenizer) |
+| `ink`, `react` | CLI UI (React for terminals) |
+| `ink-box`, `ink-spinner`, `ink-text-input` | Terminal layout components |
+| `zod`, `zod-to-json-schema` | Runtime schema validation + JSON Schema conversion |
 | `@modelcontextprotocol/sdk` | MCP client integration |
+| `@opentelemetry/api` | OpenTelemetry tracing |
 | `chokidar` | File watching for config reloads |
 | `yaml` | YAML parsing (skills frontmatter, config) |
 | `pino` | Structured logging |
+| `boxen` | Terminal boxes (CLI output) |
 
-Dev: `@types/*`, `bun-types`, `@biomejs/biome`.
+Dev: `@types/*`, `bun-types`, `@biomejs/biome`, `bumpp`.
 
 ## Configuration Surface
 
-- `tsconfig.json` — strict TS config.
-- `biome.json` — lint + format.
-- `package.json` — scripts, deps, `bumpp` for releases.
-- `cspell.json` — spell-check dictionary.
-- `renovate.json` — automated dependency updates.
-- `.github/workflows/ci.yml`, `.github/workflows/release.yml` — CI + release.
-- `tiny-agent.json` (project-local) and `~/.config/tiny-agent/config.json` (user) — runtime config, loaded via `src/config/loader.ts`.
+| File | Purpose |
+|---|---|
+| `tsconfig.json` | Strict TS config, ESM, path aliases |
+| `biome.json` | Lint + format rules |
+| `package.json` | Scripts, deps, release metadata |
+| `bump.config.ts` | Version bump configuration |
+| `cspell.json` | Spell-check dictionary |
+| `prek.toml` | Pre-commit hook configuration |
+| `renovate.json` | Automated dependency updates |
+| `.github/workflows/ci.yml` | CI: typecheck + lint + tests + build |
+| `.github/workflows/release.yml` | Release pipeline |
+| `Justfile` | Task runner recipes |
+| `Makefile` | Legacy wrapper (same recipes) |
+| `~/.tiny-agent/config.yaml` | User runtime config (YAML or JSON) |
+| `tiny-agent.json` | Project-local config override |
+
+## CI/CD
+
+- **GitHub Actions CI** (`.github/workflows/ci.yml`): runs `bun test` + `bun run check` (lint + typecheck) on every PR.
+- **GitHub Actions Release** (`.github/workflows/release.yml`): triggered on version tags, builds binary for multiple platforms, publishes GitHub Release + Homebrew tap.
+- **Renovate** (`renovate.json`): automated dependency PRs.
+- **Husky pre-commit** (`.husky/pre-commit`): runs `prek` hooks (biome + tsc).

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,47 +1,56 @@
 # Structure
 
 ```
-/Users/huynhdung/src/tries/2026-01-13-tiny-coding-agent
-├── index.ts                          # CLI entry, arg parsing → agent loop / --upgrade
+tiny-coding-agent/
+├── index.ts                          # CLI entry — calls main() from src/cli/index.js
 ├── package.json                      # scripts, deps, release metadata
-├── tsconfig.json                     # strict TS, ESM, paths (@/*)
-├── biome.json                        # lint + format
+├── tsconfig.json                     # strict TS, ESM, paths (@/* → ./src/*)
+├── biome.json                        # lint + format (tabs, double quotes, 120 width)
+├── bump.config.ts                    # bumpp version bump configuration
 ├── Justfile                          # task runner recipes (dev/build/test/lint/release)
-├── Makefile                          # legacy wrapper
+├── Makefile                          # legacy wrapper (same recipes)
+├── prek.toml                         # pre-commit hooks (biome + tsc)
 ├── cspell.json                       # spell-check dictionary
 ├── renovate.json                     # dep update automation
 ├── bun.lock                          # bun lockfile
 ├── AGENTS.md                         # contributor conventions (kebab-case, ESM, etc.)
-├── CLAUDE.md                         # Claude-specific notes
+├── CLAUDE.md                         # Claude-specific notes (→ @AGENTS.md)
 ├── SECURITY.md                       # security policy
-├── README.md / RELEASE.md            # user-facing docs
+├── README.md                         # user-facing guide (install, login, config, CLI commands)
+├── RELEASE.md                        # release process docs
 │
 ├── src/
 │   ├── cli/                          # CLI dispatch + per-feature handlers
-│   │   ├── main.tsx                  # Ink app mount
+│   │   ├── main.tsx                  # Ink app mount, arg parsing, command dispatch
 │   │   ├── chat-commands.ts          # /-slash command parser
-│   │   ├── shared.ts                 # shared CLI types
-│   │   ├── status-line.ts
-│   │   ├── index.ts
+│   │   ├── shared.ts                 # createLLMClient, setupTools, createAgent() factory
+│   │   ├── prompt.ts                 # prompt(), promptHidden(), promptChoice() — readline helpers
+│   │   ├── status-line.ts            # status line rendering
+│   │   ├── index.ts                  # barrel
 │   │   └── handlers/
 │   │       ├── agent.ts, plan.ts, state.ts, memory.ts
 │   │       ├── config.ts, mcp.ts, skill.ts, trace.ts
 │   │       ├── status.ts, upgrade.ts
+│   │       └── login.ts              # handleLogin() + handleLogout() (onboarding, ADR-014)
 │   │
 │   ├── core/                         # agent loop primitives
-│   │   ├── agent.ts                  # main loop
+│   │   ├── agent.ts                  # main loop (uses TurnExecutor for tool dispatch)
+│   │   ├── agent-utils.ts            # isLooping(), truncateOutput(), LOOP_DETECTION
+│   │   ├── turn-executor.ts          # TurnExecutor — per-turn tool execution + error recovery
 │   │   ├── memory.ts                 # persistent memory store
 │   │   ├── tokens.ts                 # token counting / budget
-│   │   └── index.ts
+│   │   ├── conversation.ts           # conversation state management
+│   │   └── index.ts                  # barrel (exports Agent, AgentOptions, MemoryStore, etc.)
 │   │
 │   ├── agents/                       # multi-agent system
 │   │   ├── plan-agent.ts             # LLM-driven plan generation
-│   │   ├── build-agent.ts            # plan execution via ToolRegistry
+│   │   ├── build-agent.ts            # plan execution via ToolRegistry + StepExecutor
 │   │   ├── explore-agent.ts          # read-only recon
+│   │   ├── step-executor.ts          # StepExecutor — per-step execution + retry/skip/abort
 │   │   ├── plan-grammar.ts           # canonical plan format (deep module)
 │   │   ├── state.ts                  # atomic .tiny-state.json reader/writer
-│   │   ├── types.ts                  # StateFile, StateError, etc.
-│   │   └── plan-grammar.ts           # serialize/parse/validate/exampleOutput
+│   │   ├── types.ts                  # StateFile, StateError, BuildStep, BuildAction, etc.
+│   │   └── index.ts
 │   │
 │   ├── tools/                        # Tool implementations + registry
 │   │   ├── registry.ts               # ToolRegistry class (the spine)
@@ -59,9 +68,9 @@
 │   │
 │   ├── providers/                    # LLM providers
 │   │   ├── types.ts                  # Provider interface, Message, ChatOptions
-│   │   ├── factory.ts                # model-string → provider
+│   │   ├── factory.ts                # model-string → provider instance
 │   │   ├── capabilities.ts           # per-model capability matrix
-│   │   ├── model-registry.ts         # in-memory model catalog
+│   │   ├── model-registry.ts         # in-memory model catalog + detectProvider()
 │   │   ├── models-dev.ts             # fetch from models.dev JSON
 │   │   ├── model-pricing.json        # bundled pricing snapshot
 │   │   ├── openai.ts, openai-protocol.ts
@@ -70,6 +79,7 @@
 │   │   ├── openrouter.ts
 │   │   ├── opencode.ts
 │   │   ├── zai.ts
+│   │   ├── clinepass.ts              # live model lookup (ADR-013)
 │   │   └── index.ts
 │   │
 │   ├── mcp/                          # Model Context Protocol
@@ -93,57 +103,58 @@
 │   ├── ui/                           # Ink (React) CLI UI
 │   │   ├── App.tsx                   # root component
 │   │   ├── index.ts
-│   │   ├── components/               # Header, MessageList, ChatLayout, ...
+│   │   ├── components/               # Header, MessageList, ChatLayout, StatusLine,
+│   │   │                             # CommandMenu, ModelPicker, SkillPicker, ToolCall,
+│   │   │                             # ToolOutput, TextInput, ToastList, etc.
 │   │   ├── contexts/                 # Chat, Toast, StatusLine
-│   │   ├── hooks/
+│   │   ├── hooks/                    # useCommandHandler
 │   │   ├── utils.ts
-│   │   ├── errors/
-│   │   ├── types/
-│   │   └── config/
+│   │   ├── errors/                   # chat-errors
+│   │   ├── types/                    # enums
+│   │   └── config/                   # constants
 │   │
 │   ├── config/                       # runtime config
-│   │   ├── schema.ts                 # zod schema for tiny-agent.json
-│   │   ├── loader.ts                 # user + project config merge
+│   │   ├── schema.ts                 # zod schema for config
+│   │   ├── loader.ts                 # user + project config merge, env var interpolation
+│   │   ├── config-io.ts              # readConfigFile/writeConfigFile (YAML/JSON, 0o600)
 │   │   └── index.ts
 │   │
 │   ├── observability/                # tracing, logging, cost, redaction
-│   │   ├── telemetry.ts
-│   │   ├── trace-context.ts
-│   │   ├── token-usage.ts
-│   │   ├── cost.ts
-│   │   ├── pricing.ts
-│   │   ├── redact.ts
-│   │   ├── logger.ts
-│   │   ├── langfuse.ts
-│   │   ├── timer.ts
-│   │   ├── model-pricing.json
+│   │   ├── telemetry.ts              # OpenTelemetry tracing
+│   │   ├── trace-context.ts          # traceId propagation
+│   │   ├── token-usage.ts            # token counting
+│   │   ├── cost.ts                   # cost estimation
+│   │   ├── pricing.ts                # pricing data loader
+│   │   ├── model-pricing.json        # bundled pricing snapshot
+│   │   ├── redact.ts                 # secret redaction
+│   │   ├── logger.ts                 # structured logger (pino)
+│   │   ├── langfuse.ts               # Langfuse integration
+│   │   ├── timer.ts                  # latency tracking
 │   │   └── index.ts
 │   │
-│   ├── utils/                        # tiny cross-cutting helpers
-│   │   ├── command.ts                # CLI arg parsing
-│   │   ├── retry.ts
-│   │   ├── version.ts                # generated-version consumer
-│   │   ├── version-constant.ts       # GENERATED from package.json
-│   │   └── xml.ts
-│   │
-│   └── index.ts                      # src barrel (if any)
+│   └── utils/                        # tiny cross-cutting helpers
+│       ├── command.ts                # CLI arg parsing
+│       ├── retry.ts                  # retry with backoff
+│       ├── version.ts                # generated-version consumer
+│       ├── version-constant.ts       # GENERATED from package.json
+│       └── xml.ts                    # XML parsing helpers
 │
 ├── test/                             # bun:test suites, mirrors src/
-│   ├── agents/                       # plan-agent, build-agent, plan-grammar, state, explore
+│   ├── agents/                       # plan-agent, build-agent, step-executor, plan-grammar, state, explore
 │   ├── cli/                          # main, upgrade, chat-commands, integration, handlers/*
-│   ├── core/                         # agent, memory, conversation, ...
+│   ├── core/                         # agent, turn-executor, memory, conversation, ...
 │   ├── tools/                        # bash, file, registry, search, skill, plugin
-│   ├── providers/                    # openai, anthropic, ollama, model-registry
+│   ├── providers/                    # openai, anthropic, ollama, model-registry, clinepass
 │   ├── mcp/                          # manager, mcp-errors
-│   ├── observability/                # telemetry, cost, logger, redact, ...
+│   ├── observability/                # telemetry, cost, logger, redact, token-usage, ...
 │   ├── skills/                       # parser, loader, prompt, builtin-registry
 │   ├── security/                     # command-injection, file-validation, bash-env
-│   ├── config/                       # loader
+│   ├── config/                       # config-io, loader
 │   ├── utils/                        # command, xml
 │   ├── performance/                  # benchmarks
 │   ├── e2e/                          # agent-loop integration
 │   ├── ui/                           # ink UI smoke tests
-│   └── agent.test.ts, memory.test.ts, openai-provider.test.ts, anthropic-provider.test.ts
+│   └── agent.test.ts, memory.test.ts, ...
 │
 ├── scripts/
 │   ├── generate-embedded-skills.ts   # walk src/skills/builtin → embedded-content.ts
@@ -151,36 +162,36 @@
 │   └── install.sh                    # install helper
 │
 ├── docs/
-│   ├── README.md
-│   ├── adr/                          # Architecture Decision Records (001-011)
-│   └── development-tasks.md
+│   ├── README.md                     # docs landing page + ADR index
+│   ├── adr/                          # Architecture Decision Records (001-014)
+│   └── development-tasks.md          # current sprint / WIP tasks
 │
 ├── .github/
 │   ├── workflows/
 │   │   ├── ci.yml                    # typecheck + lint + tests + build
 │   │   └── release.yml               # release pipeline
 │   └── homebrew-tiny-agent/
+│       └── tiny-agent.rb             # Homebrew formula
 │
-├── .planning/                        # this map lives here (codemap output)
-│
-├── .freebuff/                        # local-only Freebuff runtime DB
+├── .planning/                        # this codebase map
+│   └── codebase/                     # STACK, ARCHITECTURE, STRUCTURE, CONVENTIONS, TESTING, INTEGRATIONS, CONCERNS
 │
 ├── .husky/
-│   └── pre-commit
+│   └── pre-commit                    # runs prek (biome + tsc)
 │
-└── .agents/                          # lifecycle scripts (resume, setup)
+└── .agents/                          # lifecycle scripts
     ├── resume
     └── setup
 ```
 
 ## Naming Conventions
 
-- **Files**: kebab-case (`build-agent.ts`, `plan-grammar.ts`).
+- **Files**: kebab-case (`build-agent.ts`, `plan-grammar.ts`, `config-io.ts`).
 - **Classes / types / React components**: PascalCase.
 - **Functions / variables**: camelCase.
 - **Constants**: SCREAMING_SNAKE_CASE.
-- **Private members**: `_prefixed`.
-- **Test files**: mirror source path with `.test.ts` suffix (`src/agents/plan-agent.ts` → `test/agents/plan-agent.test.ts`).
+- **Private members**: `_prefixed` (e.g. `_registry`, `_promptFn`).
+- **Test files**: mirror source path with `.test.ts` suffix (`src/agents/build-agent.ts` → `test/agents/build-agent.test.ts`).
 
 ## Key Locations Cheat-Sheet
 
@@ -189,8 +200,13 @@
 | Add a new tool | `src/tools/<name>.ts` + register in `src/tools/index.ts` |
 | Add a new provider | `src/providers/<name>.ts` + wire into `factory.ts` + `model-registry.ts` |
 | Add a CLI subcommand | `src/cli/handlers/<cmd>.ts` + register in `src/cli/main.tsx` |
+| Add a chat `/command` | `src/cli/chat-commands.ts` + `src/ui/hooks/useCommandHandler.ts` + `src/ui/components/CommandMenu.tsx` |
 | Add a skill | drop `SKILL.md` under `src/skills/builtin/<name>/` and run `bun run generate:skills` |
 | Change plan format | `src/agents/plan-grammar.ts` (must keep `serialize`/`parse`/`validate` round-trip) |
-| Change agent loop | `src/core/agent.ts` |
+| Change agent loop | `src/core/agent.ts` (main loop) + `src/core/turn-executor.ts` (tool dispatch) |
+| Change step execution | `src/agents/step-executor.ts` (retry/skip/abort) + `src/agents/build-agent.ts` (orchestration) |
 | Change Ink UI | `src/ui/components/` or `src/ui/App.tsx` |
+| Change config I/O | `src/config/config-io.ts` (read/write) + `src/config/loader.ts` (loading/merge) |
 | Add observability event | `src/observability/telemetry.ts` |
+| Prompt user input | `src/cli/prompt.ts` (prompt / promptHidden / promptChoice) |
+| Build a wired Agent | `src/cli/shared.ts` → `createAgent(config, options)` |

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -5,7 +5,7 @@
 **bun:test** (Bun's built-in test runner — Jest-compatible API).
 
 ```ts
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, vi } from "bun:test";
 ```
 
 ## Test File Layout
@@ -20,7 +20,28 @@ test/
 └── ...
 ```
 
-Rule of thumb: every `src/foo/bar.ts` has a matching `test/foo/bar.test.ts`.
+**65 test files** mirroring `src/`. Rule of thumb: every `src/foo/bar.ts` has a matching `test/foo/bar.test.ts`.
+
+### Distribution by Directory
+
+| Directory | Test Files |
+|---|---|
+| `test/tools/` | 9 |
+| `test/observability/` | 8 |
+| `test/core/` | 8 |
+| `test/agents/` | 6 |
+| `test/` (top-level) | 5 |
+| `test/skills/` | 4 |
+| `test/security/` | 4 |
+| `test/providers/` | 4 |
+| `test/cli/handlers/` | 4 |
+| `test/cli/` | 4 |
+| `test/utils/` | 2 |
+| `test/mcp/` | 2 |
+| `test/config/` | 2 |
+| `test/ui/` | 1 |
+| `test/performance/` | 1 |
+| `test/e2e/` | 1 |
 
 ## Patterns
 
@@ -58,10 +79,42 @@ it("parses a plan end-to-end", async () => {
 
 ### Mocking
 
-- The project avoids `jest.mock`; instead, dependency injection is preferred.
-  - `ToolRegistry` is injectable — tests pass a registry pre-loaded with stubs.
-  - Provider factory accepts a `providers` map — tests inject a stub provider.
-- When mocking is unavoidable, define a local stub at the top of the test file.
+The project avoids `jest.mock`; instead, **dependency injection is preferred**:
+- `ToolRegistry` is injectable — tests pass a registry pre-loaded with stubs.
+- Provider factory accepts a `providers` map — tests inject a stub provider.
+- `StepExecutor` accepts `promptFn` in `StepExecutorOptions` — tests pass a `vi.fn()` mock.
+- `TurnExecutor` is tested with a mock LLM client + mock tool registry, without the full Agent setup.
+
+When mocking is unavoidable, define a local stub at the top of the test file:
+
+```ts
+// Command-aware bash mock: "fail" → failure, "flaky" → transient, else → success
+const bashTool = {
+  name: "bash",
+  description: "Run a bash command",
+  parameters: { type: "object" as const, properties: {}, required: [] },
+  execute: async (args: Record<string, unknown>) => {
+    const command = String(args?.command ?? "");
+    if (command === "fail") return { success: false, error: "Something went wrong" };
+    return { success: true, output: "Command executed" };
+  },
+};
+```
+
+### Readline Mocking
+
+`prompt.ts` functions are tested by mocking `readline.createInterface`:
+
+```ts
+const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockImplementation(
+  () => ({
+    question: (_q: string, cb: (answer: string) => void) => {
+      queueMicrotask(() => cb("  hello world  "));
+    },
+    close: () => {},
+  }) as unknown as readline.Interface
+);
+```
 
 ### Table-Driven / Parameterized
 
@@ -94,22 +147,25 @@ Not configured by default. Run with:
 bun test --coverage
 ```
 
-to see Bun's built-in coverage report. Aim for: every public function in `src/agents/`, `src/tools/`, `src/providers/`, `src/cli/handlers/` has at least one test.
-
 ## What to Test
 
-| Layer | What |
-|---|---|
-| `src/tools/registry.ts` | register / execute / executeBatch / dangerous routing |
-| `src/tools/file-tools.ts` | sensitive-file detection, .gitignore respect, error mapping |
-| `src/tools/bash-tool.ts` | destructive-command classifier, exit codes, env stripping |
-| `src/agents/plan-grammar.ts` | serialize/parse round-trip, validate edge cases |
-| `src/agents/build-agent.ts` | plan → step conversion, dry-run |
-| `src/agents/plan-agent.ts` | exploration hooks, state writes |
-| `src/cli/handlers/*` | exit codes, stdout/stderr shape, error messages |
-| `src/providers/*` | message-format conversion, streaming token events |
-| `src/observability/*` | redaction, token counting, cost math |
-| `src/security/*` | command injection, path traversal, env isolation |
+| Layer | What | Key Test Files |
+|---|---|---|
+| `src/tools/registry.ts` | register / execute / executeBatch / dangerous routing | `test/tools/registry.test.ts` |
+| `src/tools/file-tools.ts` | sensitive-file detection, .gitignore respect, error mapping | `test/tools/file-tools.test.ts` |
+| `src/tools/bash-tool.ts` | destructive-command classifier, exit codes, env stripping | `test/tools/bash-tool.test.ts` |
+| `src/agents/plan-grammar.ts` | serialize/parse round-trip, validate edge cases | `test/agents/plan-grammar.test.ts` |
+| `src/agents/build-agent.ts` | plan → step conversion, dry-run | `test/agents/build-agent.test.ts` |
+| `src/agents/step-executor.ts` | retry/skip/abort, change tracking, mapBuildAction | `test/agents/step-executor.test.ts` |
+| `src/agents/plan-agent.ts` | exploration hooks, state writes | `test/agents/plan-agent.test.ts` |
+| `src/core/agent.ts` | agent loop, streaming, error recovery | `test/core/agent.test.ts` |
+| `src/core/turn-executor.ts` | tool batch execution, loop detection, not-found/declined | `test/core/turn-executor.test.ts` |
+| `src/cli/handlers/login.ts` | login/logout flows, provider status, pure functions | `test/cli/handlers/login.test.ts` |
+| `src/config/config-io.ts` | read/write YAML/JSON, 0o600 permissions, containsLiteralApiKey | `test/config/config-io.test.ts` |
+| `src/cli/prompt.ts` | prompt, promptHidden (non-TTY), promptChoice null handling | `test/cli/prompt.test.ts` |
+| `src/providers/*` | message-format conversion, streaming token events | `test/providers/*` |
+| `src/observability/*` | redaction, token counting, cost math | `test/observability/*` |
+| `src/security/*` | command injection, path traversal, env isolation | `test/security/*` |
 
 ## Performance & E2E
 
@@ -119,7 +175,7 @@ to see Bun's built-in coverage report. Aim for: every public function in `src/ag
 ## Running
 
 ```bash
-bun test                          # everything
+bun test                          # everything (1066 tests, 0 failures)
 bun test test/agents              # one directory
 bun test memory                   # pattern match
 bun test --watch                  # watch mode
@@ -128,4 +184,4 @@ bun test --coverage               # with coverage
 
 ## CI
 
-`.github/workflows/ci.yml` runs `bun run pre` on every PR, which runs `bun test` then `bun run check` (lint + typecheck).
+`.github/workflows/ci.yml` runs `bun test` + `bun run check` (lint + typecheck) on every PR.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A lightweight, extensible coding agent built in TypeScript that helps developers
 
 - **Rich Terminal UI**: Ink-powered CLI with components for messages, spinners, and tool output
 - **TTY Detection**: Automatically adapts to terminal capabilities with plain text fallback
-- **Multi-Provider LLM Support**: Works with OpenAI, Anthropic, Ollama, OpenRouter, OpenCode, Z.AI, and ClinePass
+- **Multi-Provider LLM Support**: Works with OpenAI, Anthropic, Ollama, OpenRouter, OpenCode, Z.AI, ClinePass, and QwenCloud
 - **MCP Client Integration**: Connect to Model Context Protocol servers for extended capabilities
 - **Built-in Tools**: File operations, bash execution, grep, glob, and web search
 - **Memory System**: User-initiated persistent storage with relevance-based retrieval
@@ -73,13 +73,14 @@ tiny-agent login            # Interactive provider picker (recommended for first
 tiny-agent login openai     # Connect OpenAI directly
 tiny-agent login anthropic  # Connect Anthropic directly
 tiny-agent login ollama     # Configure local Ollama (no API key needed)
+tiny-agent login qwencloud # Connect QwenCloud directly
 tiny-agent login status     # Show which providers are connected
 ```
 
 **What it does:**
 
 1. Shows your current provider connection status.
-2. Lets you pick a provider (OpenAI, Anthropic, Ollama, OpenRouter, OpenCode, Z.AI, ClinePass).
+2. Lets you pick a provider (OpenAI, Anthropic, Ollama, OpenRouter, OpenCode, Z.AI, ClinePass, QwenCloud).
 3. Prompts for your API key with **masked input** (typed characters show as `*`).
 4. Saves the key to `~/.tiny-agent/config.yaml` and suggests a default model for that provider.
 
@@ -93,6 +94,7 @@ Get an API key from your provider:
 | OpenCode   | <https://opencode.ai>                            |
 | Z.AI       | <https://open.bigmodel.cn/usercenter/apikeys>    |
 | ClinePass  | <https://cline.bot>                              |
+| QwenCloud  | <https://home.qwencloud.com> (requires Token Plan) |
 | Ollama     | No key needed — runs locally. Install from <https://ollama.com> |
 
 > **Tip:** For better security, store the key in an environment variable instead of the config file. After running `login`, replace `apiKey: sk-...` with `apiKey: ${OPENAI_API_KEY}` and `export OPENAI_API_KEY=your-key` in your shell profile.
@@ -303,6 +305,39 @@ providers:
     apiKey: ${OLLAMA_API_KEY}
 ```
 
+### QwenCloud
+
+[QwenCloud](https://home.qwencloud.com) provides access to Qwen3.x, DeepSeek V4, and GLM-5.2 models via a Token Plan subscription. The API is OpenAI-compatible.
+
+```bash
+# Get a key from https://home.qwencloud.com (requires Token Plan)
+export QWENCLOUD_API_KEY="your-key"
+```
+
+**Config:**
+
+```yaml
+providers:
+  qwencloud:
+    apiKey: ${QWENCLOUD_API_KEY}
+```
+
+**Available models:**
+
+- `qw/qwen3.8-max-preview` - Qwen3.8 Max Preview (262K context)
+- `qw/qwen3.7-plus` - Qwen3.7 Plus (1M context, vision)
+- `qw/qwen3.7-max` - Qwen3.7 Max (262K context)
+- `qw/qwen3.6-flash` - Qwen3.6 Flash (131K context, vision)
+- `qw/deepseek-v4-pro` - DeepSeek V4 Pro (1M context)
+- `qw/glm-5.2` - GLM-5.2 (200K context)
+
+**Usage:**
+
+```bash
+tiny-agent --model qw/glm-5.2 "explain async/await"
+tiny-agent --model qw/deepseek-v4-pro "design a microservice architecture"
+```
+
 ### OpenCode Zen
 
 [OpenCode Zen](https://opencode.ai/zen) provides curated, tested models for coding agents.
@@ -395,7 +430,7 @@ tiny-agent mcp add myserver npx -y @org/mcp-server
 | Option              | Description                                             |
 | ------------------- | ------------------------------------------------------- |
 | `--model <name>`    | Override default model                                  |
-| `--provider <name>` | Override provider (openai\|anthropic\|ollama\|opencode) |
+| `--provider <name>` | Override provider (openai\|anthropic\|ollama\|opencode\|zai\|clinepass\|qwencloud) |
 | `--json`            | Output in JSON format (for programmatic consumption)    |
 | `--verbose, -v`     | Enable verbose logging                                  |
 | `--save`            | Save conversation to file                               |

--- a/src/cli/handlers/login.ts
+++ b/src/cli/handlers/login.ts
@@ -89,6 +89,14 @@ export const LOGIN_PROVIDERS: readonly LoginProviderInfo[] = [
 		defaultModel: "cline-pass/glm-5.2",
 		getKeyUrl: "https://cline.bot",
 	},
+	{
+		key: "qwencloud",
+		name: "QwenCloud",
+		requiresApiKey: true,
+		envVar: "QWENCLOUD_API_KEY",
+		defaultModel: "qw/glm-5.2",
+		getKeyUrl: "https://home.qwencloud.com",
+	},
 ];
 
 export interface ProviderStatus {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -80,6 +80,7 @@ export interface Config {
 		opencode?: ProviderConfig;
 		zai?: ProviderConfig;
 		clinepass?: ProviderConfig;
+		qwencloud?: ProviderConfig;
 	};
 	mcpServers?: Record<string, McpServerConfig>;
 	tools?: Record<string, ToolConfig>;

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -63,6 +63,7 @@ export interface ProviderConfigs {
 	opencode?: ProviderConfig;
 	zai?: ProviderConfig;
 	clinepass?: ProviderConfig;
+	qwencloud?: ProviderConfig;
 }
 
 export interface AgentOptions {

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -8,6 +8,7 @@ import { getCachedOllamaModels } from "./ollama-models.js";
 import { OpenAIProvider } from "./openai.js";
 import { OpenCodeProvider } from "./opencode.js";
 import { OpenRouterProvider } from "./openrouter.js";
+import { QwenCloudProvider } from "./qwencloud.js";
 import type { LLMClient } from "./types.js";
 import { ZaiProvider } from "./zai.js";
 
@@ -47,6 +48,7 @@ export interface CreateProviderOptions {
 		opencode?: ProviderConfig;
 		zai?: ProviderConfig;
 		clinepass?: ProviderConfig;
+		qwencloud?: ProviderConfig;
 	};
 }
 
@@ -61,6 +63,7 @@ const PROVIDER_MAP: Record<string, { class: ProviderClass<LLMClient>; requiresAp
 	opencode: { class: OpenCodeProvider as ProviderClass<LLMClient>, requiresApiKey: true },
 	zai: { class: ZaiProvider as ProviderClass<LLMClient>, requiresApiKey: true },
 	clinepass: { class: ClinePassProvider as ProviderClass<LLMClient>, requiresApiKey: true },
+	qwencloud: { class: QwenCloudProvider as ProviderClass<LLMClient>, requiresApiKey: true },
 };
 
 function createProviderInstance<T extends LLMClient>(providerType: string, config: ProviderConfig | undefined): T {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -7,6 +7,8 @@ export type { OllamaProviderConfig } from "./ollama.js";
 export { OllamaProvider } from "./ollama.js";
 export type { OpenAIProviderConfig } from "./openai.js";
 export { OpenAIProvider } from "./openai.js";
+export type { QwenCloudProviderConfig } from "./qwencloud.js";
+export { QwenCloudProvider } from "./qwencloud.js";
 export type {
 	ChatOptions,
 	ChatResponse,

--- a/src/providers/model-registry.ts
+++ b/src/providers/model-registry.ts
@@ -6,7 +6,8 @@ export type ProviderType =
 	| "openrouter"
 	| "opencode"
 	| "zai"
-	| "clinepass";
+	| "clinepass"
+	| "qwencloud";
 
 export interface ModelEntry {
 	provider: ProviderType;
@@ -109,6 +110,14 @@ const MODEL_DATABASE: ModelEntry[] = [
 		supportsTools: true,
 		contextWindow: 128000,
 		maxOutputTokens: 8192,
+	},
+	{
+		provider: "qwencloud",
+		patterns: ["^qw/"],
+		supportsThinking: true,
+		supportsTools: true,
+		contextWindow: 262144,
+		maxOutputTokens: 131072,
 	},
 	{
 		provider: "ollama",

--- a/src/providers/qwencloud.ts
+++ b/src/providers/qwencloud.ts
@@ -1,0 +1,81 @@
+import type { ModelCapabilities } from "./capabilities.js";
+import { supportsThinking as modelRegistrySupportsThinking } from "./model-registry.js";
+import type { OpenAIProviderConfig } from "./openai.js";
+import { OpenAIProvider } from "./openai.js";
+import type { ChatOptions, ChatResponse, StreamChunk } from "./types.js";
+
+export interface QwenCloudProviderConfig {
+	apiKey: string;
+	baseUrl?: string;
+}
+
+const QWENCLOUD_BASE_URL = "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1";
+
+function stripPrefix(model: string): string {
+	return model.replace(/^qw\//, "");
+}
+
+/**
+ * Per-model context-window and max-output-token fallback map.
+ * Sourced from the QwenCloud model catalog (pi-qwencloud-provider).
+ * Keyed by the bare model id (no `qw/` prefix).
+ */
+const QWENCLOUD_MODEL_CONTEXT: Record<string, { contextWindow: number; maxOutputTokens: number }> = {
+	"qwen3.8-max-preview": { contextWindow: 262144, maxOutputTokens: 131072 },
+	"qwen3.7-plus": { contextWindow: 1048576, maxOutputTokens: 131072 },
+	"qwen3.7-max": { contextWindow: 262144, maxOutputTokens: 131072 },
+	"qwen3.6-flash": { contextWindow: 131072, maxOutputTokens: 131072 },
+	"deepseek-v4-pro": { contextWindow: 1000000, maxOutputTokens: 384000 },
+	"glm-5.2": { contextWindow: 200000, maxOutputTokens: 131072 },
+};
+
+/**
+ * QwenCloud (Token Plan) is an OpenAI-compatible endpoint whose model names
+ * are prefixed with `qw/`. Inherits chat(), stream(), and tool-call buffering
+ * from `OpenAIProvider`; overrides each method to strip the prefix before
+ * delegating to super, plus a curated capability profile keyed under
+ * "qwencloud" (context windows from the QwenCloud model catalog).
+ */
+export class QwenCloudProvider extends OpenAIProvider {
+	private _qwenCapabilitiesCache = new Map<string, ModelCapabilities>();
+
+	constructor(config: QwenCloudProviderConfig) {
+		super({
+			apiKey: config.apiKey,
+			baseUrl: config.baseUrl ?? QWENCLOUD_BASE_URL,
+		} satisfies OpenAIProviderConfig);
+	}
+
+	override async chat(options: ChatOptions): Promise<ChatResponse> {
+		return super.chat({ ...options, model: stripPrefix(options.model) });
+	}
+
+	override async *stream(options: ChatOptions): AsyncGenerator<StreamChunk, void, unknown> {
+		yield* super.stream({ ...options, model: stripPrefix(options.model) });
+	}
+
+	override async getCapabilities(model: string): Promise<ModelCapabilities> {
+		const cached = this._qwenCapabilitiesCache.get(model);
+		if (cached) return cached;
+
+		const bareModel = stripPrefix(model);
+		const hasThinking = modelRegistrySupportsThinking(model);
+		const profile = QWENCLOUD_MODEL_CONTEXT[bareModel];
+
+		const capabilities: ModelCapabilities = {
+			modelName: model,
+			supportsTools: true,
+			supportsStreaming: true,
+			supportsSystemPrompt: true,
+			supportsToolStreaming: true,
+			supportsThinking: hasThinking,
+			contextWindow: profile?.contextWindow ?? 131072,
+			maxOutputTokens: profile?.maxOutputTokens ?? 4096,
+			isVerified: false,
+			source: "fallback",
+		};
+
+		this._qwenCapabilitiesCache.set(model, capabilities);
+		return capabilities;
+	}
+}

--- a/test/cli/handlers/login.test.ts
+++ b/test/cli/handlers/login.test.ts
@@ -17,7 +17,7 @@ import type { Config } from "../../../src/config/schema.js";
 
 describe("login handler", () => {
 	describe("LOGIN_PROVIDERS", () => {
-		it("should include all 8 providers from the factory", () => {
+		it("should include all 9 providers from the factory", () => {
 			const keys = LOGIN_PROVIDERS.map((p) => p.key);
 			expect(keys).toContain("openai");
 			expect(keys).toContain("anthropic");
@@ -27,7 +27,8 @@ describe("login handler", () => {
 			expect(keys).toContain("opencode");
 			expect(keys).toContain("zai");
 			expect(keys).toContain("clinepass");
-			expect(keys).toHaveLength(8);
+			expect(keys).toContain("qwencloud");
+			expect(keys).toHaveLength(9);
 		});
 
 		it("should have a default model for every provider", () => {
@@ -81,7 +82,7 @@ describe("login handler", () => {
 	describe("getProviderStatus()", () => {
 		it("should return not-configured for an empty providers object", () => {
 			const statuses = getProviderStatus(undefined);
-			expect(statuses).toHaveLength(8);
+			expect(statuses).toHaveLength(9);
 			for (const s of statuses) {
 				expect(s.configured).toBe(false);
 				expect(s.hasApiKey).toBe(false);

--- a/test/providers/model-registry.test.ts
+++ b/test/providers/model-registry.test.ts
@@ -84,6 +84,34 @@ describe("detectProvider()", () => {
 		});
 	});
 
+	describe("QwenCloud models", () => {
+		it("should detect qw/* models", () => {
+			expect(detectProvider("qw/glm-5.2")).toBe("qwencloud");
+			expect(detectProvider("qw/qwen3.7-plus")).toBe("qwencloud");
+			expect(detectProvider("qw/deepseek-v4-pro")).toBe("qwencloud");
+			expect(detectProvider("qw/qwen3.6-flash")).toBe("qwencloud");
+		});
+
+		it("should detect qw/ models case-insensitively", () => {
+			expect(detectProvider("QW/GLM-5.2")).toBe("qwencloud");
+			expect(detectProvider("Qw/DeepSeek-V4-Pro")).toBe("qwencloud");
+		});
+
+		it("should report thinking + tools for qw/ models", () => {
+			expect(supportsThinking("qw/glm-5.2")).toBe(true);
+			expect(supportsTools("qw/glm-5.2")).toBe(true);
+		});
+
+		it("should return correct info for qw/ models", () => {
+			const info = getModelInfo("qw/glm-5.2");
+			expect(info?.provider).toBe("qwencloud");
+			expect(info?.supportsThinking).toBe(true);
+			expect(info?.supportsTools).toBe(true);
+			expect(info?.contextWindow).toBe(262144);
+			expect(info?.maxOutputTokens).toBe(131072);
+		});
+	});
+
 	describe("ClinePass - getModelInfo / supportsThinking / supportsTools", () => {
 		it("should return correct info for cline-pass models", () => {
 			const info = getModelInfo("cline-pass/deepseek-v4-flash");
@@ -280,6 +308,11 @@ describe("getProviderPatterns()", () => {
 	it("should return patterns for clinepass", () => {
 		const patterns = getProviderPatterns("clinepass");
 		expect(patterns).toContain("^cline-pass/");
+	});
+
+	it("should return patterns for qwencloud", () => {
+		const patterns = getProviderPatterns("qwencloud");
+		expect(patterns).toContain("^qw/");
 	});
 
 	it("should return patterns for ollama (catch-all)", () => {

--- a/test/providers/qwencloud.test.ts
+++ b/test/providers/qwencloud.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "bun:test";
+import { OpenAIProvider } from "../../src/providers/openai.js";
+import { QwenCloudProvider } from "../../src/providers/qwencloud.js";
+
+const DEFAULT_BASE_URL = "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1";
+const CUSTOM_BASE_URL = "https://custom.example.com/v1";
+
+describe("QwenCloudProvider", () => {
+	describe("constructor", () => {
+		it("should be an instance of OpenAIProvider (inherits the LLMClient contract)", () => {
+			const provider = new QwenCloudProvider({ apiKey: "test-key" });
+			expect(provider).toBeInstanceOf(QwenCloudProvider);
+			expect(provider).toBeInstanceOf(OpenAIProvider);
+		});
+
+		it("should default baseUrl to the QwenCloud Token Plan endpoint when none is supplied", () => {
+			// The OpenAIProvider constructor forwards baseUrl to the OpenAI SDK.
+			// We assert the provider constructs without error with the default URL;
+			// the actual URL is validated by the OpenAI SDK's baseURL normalization.
+			const provider = new QwenCloudProvider({ apiKey: "test-key" });
+			expect(provider).toBeInstanceOf(QwenCloudProvider);
+			// Re-create with the explicit default to confirm no throw — this is the
+			// same value the constructor computes internally.
+			const explicit = new QwenCloudProvider({ apiKey: "test-key", baseUrl: DEFAULT_BASE_URL });
+			expect(explicit).toBeInstanceOf(QwenCloudProvider);
+		});
+
+		it("should accept a custom baseUrl for self-hosted/proxy deployments", () => {
+			const provider = new QwenCloudProvider({ apiKey: "test-key", baseUrl: CUSTOM_BASE_URL });
+			expect(provider).toBeInstanceOf(QwenCloudProvider);
+		});
+	});
+
+	describe("getCapabilities()", () => {
+		it("should return curated capabilities for qw/glm-5.2 (200K context)", async () => {
+			const provider = new QwenCloudProvider({ apiKey: "test-key" });
+			const caps = await provider.getCapabilities("qw/glm-5.2");
+			expect(caps.modelName).toBe("qw/glm-5.2");
+			expect(caps.supportsTools).toBe(true);
+			expect(caps.supportsStreaming).toBe(true);
+			expect(caps.supportsThinking).toBe(true);
+			expect(caps.contextWindow).toBe(200000);
+			expect(caps.maxOutputTokens).toBe(131072);
+			expect(caps.source).toBe("fallback");
+		});
+
+		it("should return curated capabilities for qw/qwen3.7-plus (1M context)", async () => {
+			const provider = new QwenCloudProvider({ apiKey: "test-key" });
+			const caps = await provider.getCapabilities("qw/qwen3.7-plus");
+			expect(caps.modelName).toBe("qw/qwen3.7-plus");
+			expect(caps.contextWindow).toBe(1048576);
+			expect(caps.maxOutputTokens).toBe(131072);
+		});
+
+		it("should return curated capabilities for qw/deepseek-v4-pro (1M context, 384K output)", async () => {
+			const provider = new QwenCloudProvider({ apiKey: "test-key" });
+			const caps = await provider.getCapabilities("qw/deepseek-v4-pro");
+			expect(caps.contextWindow).toBe(1000000);
+			expect(caps.maxOutputTokens).toBe(384000);
+		});
+
+		it("should return curated capabilities for qw/qwen3.6-flash (131K context)", async () => {
+			const provider = new QwenCloudProvider({ apiKey: "test-key" });
+			const caps = await provider.getCapabilities("qw/qwen3.6-flash");
+			expect(caps.contextWindow).toBe(131072);
+			expect(caps.maxOutputTokens).toBe(131072);
+		});
+
+		it("should return curated capabilities for qw/qwen3.8-max-preview (262K context)", async () => {
+			const provider = new QwenCloudProvider({ apiKey: "test-key" });
+			const caps = await provider.getCapabilities("qw/qwen3.8-max-preview");
+			expect(caps.contextWindow).toBe(262144);
+			expect(caps.maxOutputTokens).toBe(131072);
+		});
+
+		it("should return curated capabilities for qw/qwen3.7-max (262K context)", async () => {
+			const provider = new QwenCloudProvider({ apiKey: "test-key" });
+			const caps = await provider.getCapabilities("qw/qwen3.7-max");
+			expect(caps.contextWindow).toBe(262144);
+			expect(caps.maxOutputTokens).toBe(131072);
+		});
+
+		it("should fall back to safe defaults for unknown models not in the catalog", async () => {
+			const provider = new QwenCloudProvider({ apiKey: "test-key" });
+			const caps = await provider.getCapabilities("qw/__unknown-model__");
+			expect(caps.modelName).toBe("qw/__unknown-model__");
+			// Fallback context window (131072) and max output (4096) for unknown models
+			expect(caps.contextWindow).toBe(131072);
+			expect(caps.maxOutputTokens).toBe(4096);
+		});
+
+		it("should memoize per-id (same model returns the same reference on repeat)", async () => {
+			const provider = new QwenCloudProvider({ apiKey: "test-key" });
+			const first = await provider.getCapabilities("qw/glm-5.2");
+			const second = await provider.getCapabilities("qw/glm-5.2");
+			expect(first).toBe(second);
+		});
+
+		it("should resolve capabilities for a bare model id (no qw/ prefix) using the same map", async () => {
+			// The provider strips the qw/ prefix internally, so a bare model id
+			// should resolve to the same curated profile. This guards against a
+			// regression where the prefix-stripping lookup key diverges.
+			const provider = new QwenCloudProvider({ apiKey: "test-key" });
+			const caps = await provider.getCapabilities("glm-5.2");
+			expect(caps.contextWindow).toBe(200000);
+			expect(caps.maxOutputTokens).toBe(131072);
+		});
+	});
+});


### PR DESCRIPTION
## What

Add QwenCloud (Token Plan) as the 9th LLM provider — an OpenAI-compatible endpoint giving access to Qwen3.x, DeepSeek V4, and GLM-5.2 models behind a static API key. Changes span 11 files (295 insertions, 7 deletions):

- **`src/providers/qwencloud.ts`** (new) — `OpenAIProvider` subclass that strips the `qw/` prefix before API calls and serves a curated capability map (context windows + max output tokens) for 6 models
- **`src/providers/model-registry.ts`** — add `"qwencloud"` to `ProviderType` union + `^qw/` detection pattern (ordered before the catch-all `ollama .*`)
- **`src/providers/factory.ts`** — register `QwenCloudProvider` in `PROVIDER_MAP` + `CreateProviderOptions`
- **`src/providers/index.ts`** — export `QwenCloudProvider` + `QwenCloudProviderConfig`
- **`src/config/schema.ts`** — add `qwencloud?: ProviderConfig` to `Config.providers`
- **`src/core/agent.ts`** — add `qwencloud?: ProviderConfig` to `ProviderConfigs` interface
- **`src/cli/handlers/login.ts`** — add QwenCloud to `LOGIN_PROVIDERS` (`envVar: QWENCLOUD_API_KEY`, `defaultModel: qw/glm-5.2`)
- **`README.md`** — document the provider with available models, config example, and usage
- **`test/providers/qwencloud.test.ts`** (new) — 12 tests covering constructor, capability profiles for all 6 models, unknown-model fallback, and memoization
- **`test/providers/model-registry.test.ts`** — `detectProvider` + `getProviderPatterns` tests for `^qw/` pattern
- **`test/cli/handlers/login.test.ts`** — provider count assertions 8→9

## Why

QwenCloud provides access to high-performance open-weight coding models (Qwen3.8 Max, DeepSeek V4 Pro, GLM-5.2) via a Token Plan subscription with an OpenAI-compatible API. Adding it as a first-class provider lets users onboard with `tiny-agent login qwencloud` and use `qw/`-prefixed model names without manual config editing. This brings the total provider count to 9, matching the breadth of the pi-qwencloud-provider extension but integrated natively.

## How

The implementation follows two established patterns in the codebase:

- **Prefix stripping** (same as `opencode.ts`) — `QwenCloudProvider` overrides `chat()`, `stream()`, and `getCapabilities()` to strip the `qw/` prefix before delegating to `super`, so the OpenAI SDK receives bare model IDs (`glm-5.2` instead of `qw/glm-5.2`).
- **Curated capability map** (same as `zai.ts`) — a static `QWENCLOUD_MODEL_CONTEXT` map keyed by bare model ID provides per-model context windows and max output tokens, sourced from the [pi-qwencloud-provider catalog](https://github.com/jellydn/pi-qwencloud-provider/blob/main/src/catalog.ts).

Key design decisions:
- The `^qw/` pattern is placed after `clinepass` and before the catch-all `ollama .*` in `MODEL_DATABASE`, so `qw/glm-5.2` correctly routes to `qwencloud` (not `zai`'s `^glm-` or `opencode`'s `^qwen-`).
- The `ProviderConfigs` interface in `agent.ts` is separate from `Config["providers"]` in `schema.ts` — both were updated to avoid a TS7053 indexing error.
- The provider uses `source: "fallback"` in capabilities (not `"api"`) since it uses a static map, not live model discovery (unlike ClinePass).

## Checklist

- [x] Tests added or updated (12 new + 8 updated assertions)
- [x] Documentation updated (README + provider section + config example)
- [x] No breaking changes (additive only — new provider key, new ProviderType member)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added QwenCloud as a supported AI provider.
  * Added QwenCloud login, logout, API key configuration, and provider selection.
  * Added support for QwenCloud models using the `qw/` model prefix.
  * Documented QwenCloud setup, available models, and usage examples.

* **Documentation**
  * Updated architecture, integration, configuration, testing, and project structure documentation.
  * Expanded guidance for MCP, plugins, observability, security, and development workflows.

* **Tests**
  * Added coverage for QwenCloud provider behavior, model detection, capabilities, and login flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->