### PR TITLE
refactor(core): extract streamFinalAnswer helper from runStream loop-detection block

### DIFF
--- a/src/core/agent-utils.ts
+++ b/src/core/agent-utils.ts
@@ -106,6 +106,93 @@ export interface StreamLlmResult {
  * }
  * ```
  */
+// ─── streamFinalAnswer ───────────────────────────────────────────────
+
+/** Options for streamFinalAnswer — a subset of StreamLlmOptions without tools
+ *  (the final-answer stream never includes tool calls). */
+export interface StreamFinalAnswerOptions {
+	llmClient: LLMClient;
+	model: string;
+	systemPrompt: string;
+	messages: Message[];
+	thinking?: ChatOptions["thinking"];
+	signal?: AbortSignal;
+}
+
+/** Result of streamFinalAnswer — yielded content strings + any error. */
+export interface StreamFinalAnswerResult {
+	/** All content chunks yielded, concatenated. */
+	content: string;
+	/** If the stream threw a non-Abort error, it's captured here (not thrown). */
+	error?: string;
+	/** True if the error was an AbortError (caller should rethrow). */
+	aborted?: boolean;
+}
+
+/**
+ * Create an LLM stream and iterate it to completion, yielding content strings.
+ * Unlike streamLlmResponse, this helper:
+ * - Never passes tools (final-answer mode — no tool calls)
+ * - Catches non-Abort errors and returns them in the result (does not throw)
+ * - Re-throws AbortError (caller must handle)
+ *
+ * This eliminates the duplicate stream-iteration + catch pattern between
+ * the main loop's error path and the loop-detection final-answer block
+ * in runStream().
+ *
+ * The generator yields content strings for real-time display, then returns
+ * a StreamFinalAnswerResult with the full content + any error.
+ *
+ * Usage:
+ * ```ts
+ * const gen = streamFinalAnswer({ llmClient, model, systemPrompt, messages });
+ * while (true) {
+ *   const { value, done } = await gen.next();
+ *   if (done) {
+ *     if (value.aborted) throw new DOMException("Aborted", "AbortError");
+ *     if (value.error) { /* handle error *\/ }
+ *     else { /* value.content is the full text *\/ }
+ *     break;
+ *   }
+ *   // value is a content string — yield it to the UI
+ * }
+ * ```
+ */
+export async function* streamFinalAnswer(
+	options: StreamFinalAnswerOptions
+): AsyncGenerator<string, StreamFinalAnswerResult, unknown> {
+	let fullContent = "";
+
+	try {
+		const streamGen = streamLlmResponse({
+			llmClient: options.llmClient,
+			model: options.model,
+			systemPrompt: options.systemPrompt,
+			messages: options.messages,
+			thinking: options.thinking,
+			signal: options.signal,
+		});
+
+		while (true) {
+			const { value, done } = await streamGen.next();
+			if (done) break;
+			fullContent += value;
+			yield value;
+		}
+
+		return { content: fullContent };
+	} catch (err) {
+		const streamError = err as Error | DOMException;
+		if (streamError instanceof DOMException && streamError.name === "AbortError") {
+			return { content: fullContent, aborted: true };
+		}
+		const errorMessage = streamError instanceof Error ? streamError.message : String(streamError);
+		return { content: fullContent, error: errorMessage };
+	}
+}
+
+// ─── streamLlmResponse ───────────────────────────────────────────────
+
 export async function* streamLlmResponse(options: StreamLlmOptions): AsyncGenerator<string, StreamLlmResult, unknown> {
 	const stream = options.llmClient.stream({
 		model: options.model,

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -12,7 +12,12 @@ import { parseSkillFrontmatter } from "../skills/parser.js";
 import type { ToolRegistry } from "../tools/registry.js";
 import { escapeXml } from "../utils/xml.js";
 import { AgentObservability } from "./agent-observability.js";
-import { type StreamLlmResult, streamLlmResponse } from "./agent-utils.js";
+import {
+	type StreamFinalAnswerResult,
+	type StreamLlmResult,
+	streamFinalAnswer,
+	streamLlmResponse,
+} from "./agent-utils.js";
 import { buildContextStats, type PrepareContextResult, prepareContext } from "./context-budget.js";
 import { ConversationManager } from "./conversation.js";
 import type { ContextStats } from "./memory.js";
@@ -592,34 +597,41 @@ export class Agent {
 					console.log(`\n[Loop detected - requesting final answer from LLM]`);
 				}
 
-				try {
-					const streamGen = streamLlmResponse({
-						llmClient,
-						model: modelName,
-						systemPrompt: this._systemPrompt,
-						messages,
-						thinking: effectiveThinking,
-						signal: options?.signal,
-					});
+				// Use streamFinalAnswer to eliminate the duplicate stream-creation +
+				// iteration + catch pattern. The helper yields content strings and
+				// returns a StreamFinalAnswerResult with the full content or error.
+				const finalGen = streamFinalAnswer({
+					llmClient,
+					model: modelName,
+					systemPrompt: this._systemPrompt,
+					messages,
+					thinking: effectiveThinking,
+					signal: options?.signal,
+				});
 
-					while (true) {
-						const { value, done } = await streamGen.next();
-						if (done) break;
-						yield {
-							content: value,
-							iterations: iteration + 1,
-							done: false,
-							contextStats: updateStats(),
-						};
+				let finalResult: StreamFinalAnswerResult;
+				while (true) {
+					const { value, done } = await finalGen.next();
+					if (done) {
+						finalResult = value;
+						break;
 					}
-				} catch (streamError) {
-					if (streamError instanceof DOMException && streamError.name === "AbortError") {
-						throw streamError;
-					}
-					const errorMessage = streamError instanceof Error ? streamError.message : String(streamError);
+					yield {
+						content: value,
+						iterations: iteration + 1,
+						done: false,
+						contextStats: updateStats(),
+					};
+				}
+
+				if (finalResult.aborted) {
+					throw new DOMException("Aborted", "AbortError");
+				}
+
+				if (finalResult.error) {
 					this._obsWrapper.markFailed();
 					yield {
-						content: `\n\nError during LLM stream: ${errorMessage}`,
+						content: `\n\nError during LLM stream: ${finalResult.error}`,
 						iterations: iteration + 1,
 						done: true,
 						contextStats: updateStats(),

--- a/test/core/agent-utils-stream.test.ts
+++ b/test/core/agent-utils-stream.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { streamLlmResponse } from "../../src/core/agent-utils.js";
+import type { StreamFinalAnswerResult } from "../../src/core/agent-utils.js";
+import { streamFinalAnswer, streamLlmResponse } from "../../src/core/agent-utils.js";
 import type { ModelCapabilities } from "../../src/providers/capabilities.js";
 import type {
 	ChatOptions,
@@ -323,5 +324,191 @@ describe("streamLlmResponse", () => {
 		expect(result?.toolCalls).toHaveLength(2);
 		expect(result?.toolCalls[0]?.name).toBe("glob");
 		expect(result?.toolCalls[1]?.name).toBe("read_file");
+	});
+});
+
+describe("streamFinalAnswer", () => {
+	const baseMessages: Message[] = [{ role: "user", content: "hello" }];
+
+	it("should yield content strings and return full content", async () => {
+		const client = mockClient([{ content: "Hello ", done: false }, { content: "world!", done: false }, { done: true }]);
+
+		const gen = streamFinalAnswer({
+			llmClient: client,
+			model: "test-model",
+			systemPrompt: "You are helpful",
+			messages: baseMessages,
+		});
+
+		const contents: string[] = [];
+		let result: StreamFinalAnswerResult | undefined;
+		while (true) {
+			const { value, done } = await gen.next();
+			if (done) {
+				result = value;
+				break;
+			}
+			contents.push(value);
+		}
+
+		expect(contents).toEqual(["Hello ", "world!"]);
+		expect(result?.content).toBe("Hello world!");
+		expect(result.error).toBeUndefined();
+		expect(result.aborted).toBeUndefined();
+	});
+
+	it("should return empty content for an empty stream", async () => {
+		const client = mockClient([{ done: true }]);
+
+		const gen = streamFinalAnswer({
+			llmClient: client,
+			model: "test-model",
+			systemPrompt: "You are helpful",
+			messages: baseMessages,
+		});
+
+		let result: StreamFinalAnswerResult | undefined;
+		while (true) {
+			const { value, done } = await gen.next();
+			if (done) {
+				result = value;
+				break;
+			}
+		}
+
+		expect(result?.content).toBe("");
+		expect(result.error).toBeUndefined();
+	});
+
+	it("should not pass tools to the underlying stream", async () => {
+		let capturedTools: ToolDefinition[] | undefined;
+		const client: LLMClient = {
+			async chat() {
+				return { content: "mock", finishReason: "stop" };
+			},
+			async *stream(options: ChatOptions): AsyncGenerator<StreamChunk, void, unknown> {
+				capturedTools = options.tools;
+				yield { done: true };
+			},
+			async getCapabilities() {
+				return {
+					modelName: "mock",
+					supportsTools: true,
+					supportsStreaming: true,
+					supportsSystemPrompt: true,
+					supportsToolStreaming: true,
+					supportsThinking: false,
+					contextWindow: 128000,
+					maxOutputTokens: 4096,
+					isVerified: false,
+					source: "fallback",
+				};
+			},
+		};
+
+		const gen = streamFinalAnswer({
+			llmClient: client,
+			model: "test-model",
+			systemPrompt: "You are helpful",
+			messages: baseMessages,
+		});
+		await gen.next();
+
+		expect(capturedTools).toBeUndefined();
+	});
+
+	it("should catch non-Abort errors and return them in the result", async () => {
+		const client: LLMClient = {
+			async chat() {
+				return { content: "mock", finishReason: "stop" };
+			},
+			async *stream(): AsyncGenerator<StreamChunk, void, unknown> {
+				yield { content: "partial", done: false };
+				throw new Error("LLM connection failed");
+			},
+			async getCapabilities() {
+				return {
+					modelName: "mock",
+					supportsTools: true,
+					supportsStreaming: true,
+					supportsSystemPrompt: true,
+					supportsToolStreaming: true,
+					supportsThinking: false,
+					contextWindow: 128000,
+					maxOutputTokens: 4096,
+					isVerified: false,
+					source: "fallback",
+				};
+			},
+		};
+
+		const gen = streamFinalAnswer({
+			llmClient: client,
+			model: "test-model",
+			systemPrompt: "You are helpful",
+			messages: baseMessages,
+		});
+
+		const contents: string[] = [];
+		let result: StreamFinalAnswerResult | undefined;
+		while (true) {
+			const { value, done } = await gen.next();
+			if (done) {
+				result = value;
+				break;
+			}
+			contents.push(value);
+		}
+
+		expect(contents).toEqual(["partial"]);
+		expect(result?.content).toBe("partial");
+		expect(result?.error).toBe("LLM connection failed");
+		expect(result.aborted).toBeUndefined();
+	});
+
+	it("should mark aborted=true for AbortError without throwing", async () => {
+		const client: LLMClient = {
+			async chat() {
+				return { content: "mock", finishReason: "stop" };
+			},
+			async *stream(): AsyncGenerator<StreamChunk, void, unknown> {
+				yield { content: "partial", done: false };
+				throw new DOMException("Aborted", "AbortError");
+			},
+			async getCapabilities() {
+				return {
+					modelName: "mock",
+					supportsTools: true,
+					supportsStreaming: true,
+					supportsSystemPrompt: true,
+					supportsToolStreaming: true,
+					supportsThinking: false,
+					contextWindow: 128000,
+					maxOutputTokens: 4096,
+					isVerified: false,
+					source: "fallback",
+				};
+			},
+		};
+
+		const gen = streamFinalAnswer({
+			llmClient: client,
+			model: "test-model",
+			systemPrompt: "You are helpful",
+			messages: baseMessages,
+		});
+
+		let result: StreamFinalAnswerResult | undefined;
+		while (true) {
+			const { value, done } = await gen.next();
+			if (done) {
+				result = value;
+				break;
+			}
+		}
+
+		expect(result?.aborted).toBe(true);
+		expect(result?.error).toBeUndefined();
+		expect(result?.content).toBe("partial");
 	});
 });


### PR DESCRIPTION
## What

Extract a `streamFinalAnswer()` async generator + `StreamFinalAnswerResult` / `StreamFinalAnswerOptions` types into `src/core/agent-utils.ts`. Replace the ~25-line duplicate loop-detection block in `Agent.runStream()` with a call to the new helper. Add 5 unit tests in `test/core/agent-utils-stream.test.ts`.

**Files changed (3):**
- `src/core/agent-utils.ts` — added `streamFinalAnswer()`, `StreamFinalAnswerResult`, `StreamFinalAnswerOptions`
- `src/core/agent.ts` — replaced duplicate stream-iteration logic with `streamFinalAnswer()` call
- `test/core/agent-utils-stream.test.ts` — 5 new tests

## Why

The loop-detection final-answer path in `runStream()` duplicated the `streamLlmResponse()` + `while(true) { gen.next() }` + `AbortError catch` pattern from the main loop. This is the second of two extraction candidates from the architecture review — the first (`streamLlmResponse` itself) was already merged. The duplication made the loop-detection block hard to read and test in isolation.

## How

- `streamFinalAnswer()` is an async generator that wraps `streamLlmResponse()` in **no-tools mode** (final answers must not produce tool-call artifacts)
- It yields content strings to the caller, accumulates the full text, and returns a `StreamFinalAnswerResult { content, error?, aborted? }`
- Non-Abort errors are **caught** and returned in the result — the caller retains control of observability and error-chunk yielding
- `AbortError` sets `aborted: true` and the caller re-throws it
- The caller (`runStream`) now has 3 clean steps: iterate → check aborted → check error

**Design decision:** The helper returns a result object rather than yielding error chunks directly, so the caller retains ownership of the observability span and error-chunk shape. This keeps the seam clean — `streamFinalAnswer` owns stream iteration, `runStream` owns observability.

## Checklist

- [x] Tests added or updated (5 new tests)
- [x] No breaking changes (internal refactor, no public API change)
- [ ] Documentation updated (internal refactor, no user-facing docs needed)

## Validation

- 1,234 tests pass
- Typecheck clean
- Lint clean (227 files)
- Code review passed (all 6 checklist items verified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for streaming final answers without tool calls.
  * Final answers now provide accumulated content and clearer completion status.

* **Bug Fixes**
  * Improved handling of streaming errors, including partial responses.
  * Aborted requests are now distinguished from other streaming failures.

* **Tests**
  * Added coverage for streamed content, empty responses, tool exclusion, errors, and cancellations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->