### PR TITLE
refactor(core): extract ProviderCache from Agent

### DIFF
--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -1,9 +1,9 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { loadAgentsMd } from "../config/loader.js";
-import type { ObservabilityConfig, ProviderConfig, ThinkingConfig } from "../config/schema.js";
+import type { ObservabilityConfig, ThinkingConfig } from "../config/schema.js";
 import type { McpManager } from "../mcp/manager.js";
-import { createProvider, parseModelString } from "../providers/factory.js";
+import { parseModelString } from "../providers/factory.js";
 import { detectProvider } from "../providers/model-registry.js";
 import type { LLMClient, Message, TokenUsage, ToolDefinition } from "../providers/types.js";
 import { getEmbeddedSkillContent } from "../skills/builtin-registry.js";
@@ -22,6 +22,7 @@ import { buildContextStats, type PrepareContextResult, prepareContext } from "./
 import { ConversationManager } from "./conversation.js";
 import type { ContextStats } from "./memory.js";
 import { MemoryStore } from "./memory.js";
+import { ProviderCache, type ProviderConfigs } from "./provider-cache.js";
 import { TurnExecutor } from "./turn-executor.js";
 
 // Re-export for backward compatibility — other modules and tests import
@@ -42,17 +43,9 @@ export function redactApiKey(key?: string): string {
 	return `${key.slice(0, 4)}...REDACTED`;
 }
 
-export interface ProviderConfigs {
-	openai?: ProviderConfig;
-	anthropic?: ProviderConfig;
-	ollama?: ProviderConfig;
-	ollamaCloud?: ProviderConfig;
-	openrouter?: ProviderConfig;
-	opencode?: ProviderConfig;
-	zai?: ProviderConfig;
-	clinepass?: ProviderConfig;
-	qwencloud?: ProviderConfig;
-}
+// Re-export ProviderConfigs for backward compatibility — tests and other
+// modules import it from agent.ts. The canonical home is now provider-cache.ts.
+export type { ProviderConfigs } from "./provider-cache.js";
 
 export interface AgentOptions {
 	maxIterations?: number;
@@ -137,11 +130,8 @@ export function isValidToolCall(text: string): boolean {
 }
 
 export class Agent {
-	private _defaultLlmClient: LLMClient;
+	private _providerCache: ProviderCache;
 	private _providerConfigs?: ProviderConfigs;
-	private _providerCache: Map<string, { client: LLMClient; timestamp: number; healthy: boolean }> = new Map();
-	private static readonly DEFAULT_PROVIDER_CACHE_SIZE = 10;
-	private _providerCacheMaxSize: number;
 	private _toolRegistry: ToolRegistry;
 	private _maxIterations: number;
 	private _systemPrompt: string;
@@ -162,9 +152,8 @@ export class Agent {
 	private _turnExecutor: TurnExecutor;
 
 	constructor(llmClient: LLMClient, toolRegistry: ToolRegistry, options: AgentOptions = {}) {
-		this._defaultLlmClient = llmClient;
 		this._providerConfigs = options.providerConfigs;
-		this._providerCacheMaxSize = options.providerCacheSize ?? Agent.DEFAULT_PROVIDER_CACHE_SIZE;
+		this._providerCache = new ProviderCache(llmClient, options.providerConfigs, options.providerCacheSize);
 		this._toolRegistry = toolRegistry;
 		this._maxIterations = options.maxIterations ?? 20;
 		this._verbose = options.verbose ?? false;
@@ -224,69 +213,6 @@ export class Agent {
 		return this._skillsInitPromise;
 	}
 
-	private _evictOldestCacheEntry(): void {
-		let oldestKey: string | null = null;
-		let oldestTimestamp = Infinity;
-		for (const [key, entry] of this._providerCache.entries()) {
-			if (entry.timestamp < oldestTimestamp) {
-				oldestTimestamp = entry.timestamp;
-				oldestKey = key;
-			}
-		}
-		if (oldestKey) {
-			this._providerCache.delete(oldestKey);
-		}
-	}
-
-	private _getLlmClientForModel(model: string): LLMClient {
-		if (!this._providerConfigs) return this._defaultLlmClient;
-
-		const providerType = detectProvider(model);
-		const cached = this._providerCache.get(providerType);
-
-		if (cached?.healthy) {
-			cached.timestamp = Date.now();
-			return cached.client;
-		}
-
-		if (cached && !cached.healthy) {
-			this._providerCache.delete(providerType);
-		}
-
-		try {
-			const client = createProvider({
-				model,
-				provider: providerType,
-				providers: this._providerConfigs,
-			});
-
-			if (this._providerCache.size >= this._providerCacheMaxSize) {
-				this._evictOldestCacheEntry();
-			}
-
-			// Cache the new client as healthy
-			this._providerCache.set(providerType, { client, timestamp: Date.now(), healthy: true });
-			return client;
-		} catch (err) {
-			// Mark existing cache entry as unhealthy if it exists
-			const existing = this._providerCache.get(providerType);
-			if (existing) {
-				existing.healthy = false;
-			}
-			console.warn(`[Agent] Failed to create provider for ${providerType}, falling back to default: ${err}`);
-			return this._defaultLlmClient;
-		}
-	}
-
-	/** Detect the provider name for a model string, for log/span attributes. */
-	private _providerNameFor(model: string): string {
-		try {
-			return detectProvider(model);
-		} catch {
-			return "unknown";
-		}
-	}
-
 	startChatSession(): void {
 		this._conversationManager.startSession();
 	}
@@ -308,14 +234,14 @@ export class Agent {
 		this._clearSkillRestriction();
 
 		// --- Observability: begin request ----------------------------------
-		const providerName = this._providerNameFor(runtimeConfig?.model ?? model);
+		const providerName = this._providerCache.getProviderName(runtimeConfig?.model ?? model);
 		const obsCtx = { provider: providerName, model: runtimeConfig?.model ?? model };
 		this._obsWrapper.beginRequest(userPrompt, obsCtx);
 		// -------------------------------------------------------------------
 
 		const effectiveModel = runtimeConfig?.model ?? model;
 		const effectiveThinking = runtimeConfig?.thinking ?? this._thinking;
-		const llmClient = this._getLlmClientForModel(effectiveModel);
+		const llmClient = this._providerCache.getClientForModel(effectiveModel);
 
 		const { model: modelName } = parseModelString(effectiveModel);
 
@@ -784,10 +710,8 @@ export class Agent {
 	async healthCheck(): Promise<HealthStatus> {
 		const issues: string[] = [];
 
-		if (!this._defaultLlmClient) {
-			issues.push("No default LLM client configured");
-		}
-
+		// The default LLM client is always provided in the constructor, so
+		// we only flag an issue when provider configs are explicitly empty.
 		if (this._providerConfigs && Object.keys(this._providerConfigs).length === 0) {
 			issues.push("Provider configs empty");
 		}

--- a/src/core/provider-cache.ts
+++ b/src/core/provider-cache.ts
@@ -1,0 +1,134 @@
+import type { ProviderConfig } from "../config/schema.js";
+import { createProvider } from "../providers/factory.js";
+import { detectProvider } from "../providers/model-registry.js";
+import type { LLMClient } from "../providers/types.js";
+
+/**
+ * Provider configuration map — keyed by provider type.
+ * Moved here from agent.ts; re-exported from agent.ts for backward compat.
+ */
+export interface ProviderConfigs {
+	openai?: ProviderConfig;
+	anthropic?: ProviderConfig;
+	ollama?: ProviderConfig;
+	ollamaCloud?: ProviderConfig;
+	openrouter?: ProviderConfig;
+	opencode?: ProviderConfig;
+	zai?: ProviderConfig;
+	clinepass?: ProviderConfig;
+	qwencloud?: ProviderConfig;
+}
+
+interface CacheEntry {
+	client: LLMClient;
+	timestamp: number;
+	healthy: boolean;
+}
+
+const DEFAULT_CACHE_SIZE = 10;
+
+/**
+ * Encapsulates the provider client cache — previously inline fields and
+ * methods on the Agent class (`_defaultLlmClient`, `_providerCache` Map,
+ * `_providerCacheMaxSize`, `_evictOldestCacheEntry`, `_getLlmClientForModel`,
+ * `_providerNameFor`).
+ *
+ * The cache maps a provider type string (e.g. "openai", "anthropic") to a
+ * cached LLMClient instance. When a model is requested, the provider type
+ * is detected via `detectProvider()`, the cache is checked, and a new client
+ * is created via `createProvider()` on miss. Unhealthy entries are evicted,
+ * and the cache has a max size with oldest-first eviction.
+ */
+export class ProviderCache {
+	private readonly _defaultClient: LLMClient;
+	private readonly _providerConfigs?: ProviderConfigs;
+	private readonly _maxSize: number;
+	private readonly _cache: Map<string, CacheEntry> = new Map();
+
+	constructor(defaultClient: LLMClient, providerConfigs?: ProviderConfigs, maxSize?: number) {
+		this._defaultClient = defaultClient;
+		this._providerConfigs = providerConfigs;
+		this._maxSize = maxSize ?? DEFAULT_CACHE_SIZE;
+	}
+
+	/** Number of entries currently in the cache. */
+	get size(): number {
+		return this._cache.size;
+	}
+
+	/**
+	 * Get the LLM client for a model string. If provider configs are set,
+	 * detects the provider type, checks the cache, and creates a new client
+	 * on miss. Falls back to the default client when no configs are set or
+	 * when provider creation fails.
+	 */
+	getClientForModel(model: string): LLMClient {
+		if (!this._providerConfigs) return this._defaultClient;
+
+		const providerType = detectProvider(model);
+		const cached = this._cache.get(providerType);
+
+		if (cached?.healthy) {
+			cached.timestamp = Date.now();
+			return cached.client;
+		}
+
+		if (cached && !cached.healthy) {
+			this._cache.delete(providerType);
+		}
+
+		try {
+			const client = createProvider({
+				model,
+				provider: providerType,
+				providers: this._providerConfigs,
+			});
+
+			if (this._cache.size >= this._maxSize) {
+				this._evictOldest();
+			}
+
+			this._cache.set(providerType, {
+				client,
+				timestamp: Date.now(),
+				healthy: true,
+			});
+			return client;
+		} catch (err) {
+			const existing = this._cache.get(providerType);
+			if (existing) {
+				existing.healthy = false;
+			}
+			console.warn(`[ProviderCache] Failed to create provider for ${providerType}, falling back to default: ${err}`);
+			return this._defaultClient;
+		}
+	}
+
+	/**
+	 * Detect the provider name for a model string, for log/span attributes.
+	 * Wraps `detectProvider` with a try/catch so an unknown model string
+	 * doesn't throw — returns "unknown" instead.
+	 */
+	getProviderName(model: string): string {
+		try {
+			return detectProvider(model);
+		} catch {
+			return "unknown";
+		}
+	}
+
+	/** Evict the oldest cache entry (lowest timestamp). */
+	private _evictOldest(): void {
+		let oldestKey: string | null = null;
+		let oldestTimestamp = Infinity;
+		for (const [key, entry] of this._cache.entries()) {
+			if (entry.timestamp < oldestTimestamp) {
+				oldestTimestamp = entry.timestamp;
+				oldestKey = key;
+			}
+		}
+		if (oldestKey) {
+			this._cache.delete(oldestKey);
+		}
+	}
+}

--- a/test/core/agent-fallback.test.ts
+++ b/test/core/agent-fallback.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { Agent } from "../../src/core/agent.js";
+import { ProviderCache } from "../../src/core/provider-cache.js";
 import type { ChatOptions, ChatResponse, LLMClient, StreamChunk } from "../../src/providers/types.js";
 import { ToolRegistry } from "../../src/tools/registry.js";
 
@@ -27,69 +28,43 @@ class MockLLMClient implements LLMClient {
 }
 
 describe("Agent - Provider Fallback Behavior", () => {
-	describe("_getLlmClientForModel() fallback", () => {
+	describe("ProviderCache.getClientForModel() fallback", () => {
 		it("should use default client when provider configs are not provided", () => {
 			const defaultClient = new MockLLMClient();
-			const registry = new ToolRegistry();
-			const agent = new Agent(defaultClient, registry);
+			const cache = new ProviderCache(defaultClient);
 
-			const client = (
-				agent as unknown as {
-					_getLlmClientForModel(model: string): LLMClient;
-				}
-			)._getLlmClientForModel("gpt-4");
+			const client = cache.getClientForModel("gpt-4");
 
 			expect(client).toBe(defaultClient);
 		});
 
 		it("should use default client when provider configs are empty object", () => {
 			const defaultClient = new MockLLMClient();
-			const registry = new ToolRegistry();
-			const agent = new Agent(defaultClient, registry, {
-				providerConfigs: {},
-			});
+			const cache = new ProviderCache(defaultClient, {});
 
-			const client = (
-				agent as unknown as {
-					_getLlmClientForModel(model: string): LLMClient;
-				}
-			)._getLlmClientForModel("gpt-4");
+			const client = cache.getClientForModel("gpt-4");
 
 			expect(client).toBe(defaultClient);
 		});
 
 		it("should use default client when detectProvider returns unknown type", () => {
 			const defaultClient = new MockLLMClient();
-			const registry = new ToolRegistry();
-			const agent = new Agent(defaultClient, registry);
+			const cache = new ProviderCache(defaultClient);
 
-			const client = (
-				agent as unknown as {
-					_getLlmClientForModel(model: string): LLMClient;
-				}
-			)._getLlmClientForModel("unknown-model-123");
+			const client = cache.getClientForModel("unknown-model-123");
 
 			expect(client).toBe(defaultClient);
 		});
 
 		it("should not add to provider cache when using default client", () => {
 			const defaultClient = new MockLLMClient();
-			const registry = new ToolRegistry();
-			const agent = new Agent(defaultClient, registry);
+			const cache = new ProviderCache(defaultClient);
 
-			const agentPrivate = agent as unknown as {
-				_providerCache: Map<string, { client: LLMClient; timestamp: number }>;
-			};
+			expect(cache.size).toBe(0);
 
-			expect(agentPrivate._providerCache.size).toBe(0);
+			cache.getClientForModel("gpt-4");
 
-			(
-				agent as unknown as {
-					_getLlmClientForModel(model: string): LLMClient;
-				}
-			)._getLlmClientForModel("gpt-4");
-
-			expect(agentPrivate._providerCache.size).toBe(0);
+			expect(cache.size).toBe(0);
 		});
 	});
 

--- a/test/core/provider-cache.test.ts
+++ b/test/core/provider-cache.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { ProviderCache } from "../../src/core/provider-cache.js";
+import type { ChatOptions, ChatResponse, LLMClient, StreamChunk } from "../../src/providers/types.js";
+
+class MockLLMClient implements LLMClient {
+	async chat(_options: ChatOptions): Promise<ChatResponse> {
+		return { content: "Mock response", finishReason: "stop" };
+	}
+
+	async *stream(_options: ChatOptions): AsyncGenerator<StreamChunk, void, unknown> {
+		yield { content: "Mock response", done: false };
+		yield { done: true };
+	}
+
+	async getCapabilities(_model: string) {
+		return {
+			maxTokens: 100000,
+			supportsStreaming: true,
+			supportsTools: true,
+			modelName: "mock-model",
+			supportsSystemPrompt: true,
+			supportsToolStreaming: false,
+			supportsThinking: false,
+		};
+	}
+}
+
+describe("ProviderCache", () => {
+	const defaultClient = new MockLLMClient();
+
+	describe("getClientForModel", () => {
+		it("should return default client when no provider configs are set", () => {
+			const cache = new ProviderCache(defaultClient);
+
+			const client = cache.getClientForModel("gpt-4o");
+
+			expect(client).toBe(defaultClient);
+		});
+
+		it("should return default client when provider configs are empty", () => {
+			const cache = new ProviderCache(defaultClient, {});
+
+			const client = cache.getClientForModel("gpt-4o");
+
+			// detectProvider("gpt-4o") = "openai", but no openai config →
+			// createProvider throws → fallback to default
+			expect(client).toBe(defaultClient);
+		});
+
+		it("should return default client for unknown model string", () => {
+			const cache = new ProviderCache(defaultClient);
+
+			const client = cache.getClientForModel("unknown-model-xyz");
+
+			expect(client).toBe(defaultClient);
+		});
+
+		it("should not add to cache when using default client (no configs)", () => {
+			const cache = new ProviderCache(defaultClient);
+
+			expect(cache.size).toBe(0);
+
+			cache.getClientForModel("gpt-4o");
+
+			expect(cache.size).toBe(0);
+		});
+	});
+
+	describe("getProviderName", () => {
+		it("should detect openai provider for gpt-4o", () => {
+			const cache = new ProviderCache(defaultClient);
+
+			expect(cache.getProviderName("gpt-4o")).toBe("openai");
+		});
+
+		it("should detect anthropic provider for claude-sonnet-4", () => {
+			const cache = new ProviderCache(defaultClient);
+
+			expect(cache.getProviderName("claude-sonnet-4")).toBe("anthropic");
+		});
+
+		it("should detect ollama provider for qwen3-coder", () => {
+			const cache = new ProviderCache(defaultClient);
+
+			expect(cache.getProviderName("qwen3-coder")).toBe("ollama");
+		});
+
+		it("should return a non-empty string for empty model", () => {
+			const cache = new ProviderCache(defaultClient);
+
+			// detectProvider("") returns "ollama" as default, not "unknown"
+			const result = cache.getProviderName("");
+			expect(result).toBeTruthy();
+		});
+
+		it("should not throw for invalid model strings", () => {
+			const cache = new ProviderCache(defaultClient);
+
+			expect(() => cache.getProviderName("")).not.toThrow();
+			expect(() => cache.getProviderName("!!!invalid!!!")).not.toThrow();
+		});
+	});
+
+	describe("size getter", () => {
+		it("should start at zero", () => {
+			const cache = new ProviderCache(defaultClient);
+
+			expect(cache.size).toBe(0);
+		});
+
+		it("should remain zero when no configs are set", () => {
+			const cache = new ProviderCache(defaultClient);
+
+			cache.getClientForModel("gpt-4o");
+			cache.getClientForModel("claude-sonnet-4");
+
+			expect(cache.size).toBe(0);
+		});
+	});
+
+	describe("fallback behavior", () => {
+		it("should log a warning when provider creation fails", () => {
+			const warnSpy = spyOn(console, "warn").mockReturnValue(undefined);
+			const cache = new ProviderCache(defaultClient, {});
+
+			// detectProvider("gpt-4o") = "openai", createProvider will throw
+			// because the configs object is empty (no openai config)
+			cache.getClientForModel("gpt-4o");
+
+			expect(warnSpy).toHaveBeenCalled();
+			const output = warnSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+			expect(output).toContain("ProviderCache");
+			expect(output).toContain("falling back to default");
+
+			warnSpy.mockRestore();
+		});
+
+		it("should return the same default client instance on fallback", () => {
+			const cache = new ProviderCache(defaultClient, {});
+
+			const client1 = cache.getClientForModel("gpt-4o");
+			const client2 = cache.getClientForModel("claude-sonnet-4");
+
+			expect(client1).toBe(defaultClient);
+			expect(client2).toBe(defaultClient);
+		});
+	});
+});


### PR DESCRIPTION
## What

Extract the provider client cache (Map, maxSize, eviction, health-tracking, provider-name detection) from `Agent` into a `ProviderCache` class in `src/core/provider-cache.ts`.

**Files changed (4):**
- `src/core/provider-cache.ts` (new) — `ProviderCache` class with `getClientForModel()`, `getProviderName()`, `size` getter, private `_evictOldest()`. `ProviderConfigs` interface moved here.
- `src/core/agent.ts` — Removed 4 private fields (`_defaultLlmClient`, `_providerCache` Map, `_providerCacheMaxSize`, `DEFAULT_PROVIDER_CACHE_SIZE`) + 3 methods (`_evictOldestCacheEntry`, `_getLlmClientForModel`, `_providerNameFor`). Added `_providerCache: ProviderCache` field. `ProviderConfigs` re-exported for backward compat. `createProvider` import removed (now only in provider-cache.ts).
- `test/core/provider-cache.test.ts` (new) — 13 tests: no-config fallback, provider name detection (openai/anthropic/ollama), cache size, fallback warning logging, same-default-client-on-fallback.
- `test/core/agent-fallback.test.ts` — 4 tests updated to test `ProviderCache.getClientForModel()` directly instead of reaching into Agent private methods via `as unknown as` — better isolation.

## Why

`Agent` was the #1 hot spot (1173 lines, 4 recent changes). The provider cache logic — cache Map, eviction, health-tracking, provider-name detection — was inline private state and methods with no independent test surface. Extracting it into `ProviderCache` gives it a clean interface (`getClientForModel`, `getProviderName`, `size`) that can be tested with a mock default client, without constructing a full `Agent`.

This is part of the agent decomposition documented in ADR-016 (deletion test + type-only imports pattern).

## How

- `ProviderCache` constructor takes `(defaultClient, providerConfigs?, maxSize?)` — matches how Agent previously held these as private fields
- `getClientForModel(model)` detects provider type, checks cache, creates new client on miss, falls back to default on failure — same logic as the old `_getLlmClientForModel`
- `getProviderName(model)` wraps `detectProvider` with try/catch — same as the old `_providerNameFor`
- `ProviderConfigs` interface moved to `provider-cache.ts`, imported AND re-exported from `agent.ts` (both needed: import for local scope, re-export for external consumers)
- `agent-fallback.test.ts` updated to test `ProviderCache` directly instead of `agent._getLlmClientForModel()` — better isolation, no `as unknown as` casting

## Checklist

- [x] Tests added or updated (13 new + 4 updated)
- [x] No breaking changes (all 1,263 existing tests pass)
- [x] Typecheck clean, lint clean
- [x] Code reviewed