### PR TITLE
refactor(core): extract SkillManager and ToolDisplay modules

### DIFF
--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -20,18 +20,21 @@ The following extractions were completed between v0.6.0 and v0.7.0, consolidatin
 | ChatCommandRegistry | `src/ui/chat-command-registry.ts` | 77 | #76 | 12-case switch in `useCommandHandler` |
 | DebugLogger | `src/core/debug-logger.ts` | 132 | #78 | 6 verbose-logging blocks from `runStream()` |
 | ProviderCache | `src/core/provider-cache.ts` | 134 | #80 | Provider instance caching from `Agent` |
-| StateManager | `src/agents/state-manager.ts` | 162 | #81 | 19 state I/O calls across 7 modules |
+| StateManager | `src/agents/state-manager.ts` | 198 | #81 | 19 state I/O calls across 7 modules |
 | createAgentClient | `src/agents/agent-client.ts` | 50 | #81 | 3-way `loadConfig→parseModelString→createProvider` duplication |
+| SkillManager | `src/core/skill-manager.ts` | 158 | #82 | 4 skill fields + 8 methods from Agent |
+| ToolDisplay | `src/cli/tool-display.tsx` | 156 | #82 | ~120 lines of display utilities from main.tsx |
+| loadOrFail() | `src/agents/state-manager.ts` | — | #82 | Double-read pattern in 3 CLI handlers |
 
 ## Tech Debt
 
-### 1. `agent.ts` Still 738 Lines After Decomposition
+### 1. `agent.ts` Still 652 Lines After Decomposition
 
-**File**: `src/core/agent.ts` (738 lines)
-**Severity**: Medium
-**Status**: Improving (was 1,173 lines before ADR-016 extraction)
+**File**: `src/core/agent.ts` (652 lines)
+**Severity**: Low
+**Status**: Improving (was 1,173 lines before ADR-016 extraction, now 652 after SkillManager extraction)
 
-After extracting 10 modules (TurnExecutor, AgentObservability, DebugLogger, ProviderCache, context-budget, agent-utils, etc.), `agent.ts` dropped from 1,173 → 738 lines. However, it still owns 4 skill-related private fields + 8 skill methods (`_initializeSkills`, `loadSkill`, `_setSkillRestriction`, `_clearSkillRestriction`, `getSkillRegistry`, `waitForSkills`, `_getToolDefinitions` filtering). The skill management concern could be extracted into a `SkillManager` class to continue the decomposition pattern.
+After extracting 12 modules (TurnExecutor, AgentObservability, DebugLogger, ProviderCache, context-budget, agent-utils, SkillManager, ToolDisplay, etc.), `agent.ts` dropped from 1,173 → 652 lines. The skill management concern was extracted into `SkillManager` (`src/core/skill-manager.ts`, 158 lines). Remaining concerns in agent.ts: the agent loop, conversation management, memory, and the public interface — all cohesive.
 
 ### 2. `login.ts` Has 16 `process.exit()` Calls
 
@@ -49,41 +52,39 @@ The interactive login/logout flows call `process.exit()` 16 times, making them u
 
 The `handleCommand` dispatcher was extracted into `chat-command-registry.ts` (77 lines), but the individual command handlers (`handleSkillCommand`, `handlePlanCommand`, `handleReviewCommand`, etc.) are still inline `useCallback` functions within the hook. Each handler is 30-80 lines of `onAddMessage` + `readStateFile` + business logic.
 
-### 4. `main.tsx` Mixes CLI Entry Point + Display Logic
+### 4. `main.tsx` Still Mixes CLI Entry Point + Streaming Loop
 
-**File**: `src/cli/main.tsx` (541 lines)
+**File**: `src/cli/main.tsx` (405 lines)
 **Severity**: Low
-**Status**: Partially refactored (command-dispatch extracted)
+**Status**: Improving (ToolDisplay extracted — was 541 lines)
 
-`main.tsx` still mixes 3 concerns: (1) CLI entry-point orchestration (`main()`, arg parsing), (2) the `handleRun` streaming loop, and (3) tool display formatting (`ThinkingTagFilter`, `formatArgs`, `formatOutputPreview`, `displayToolExecutionPlain/Ink`, `outputJson`). The display utilities are pure functions that could be extracted into `src/cli/tool-display.ts`.
+`main.tsx` now mixes 2 concerns (down from 3): (1) CLI entry-point orchestration (`main()`, arg parsing), and (2) the `handleRun` streaming loop. Tool display formatting (`ThinkingTagFilter`, `formatArgs`, `displayToolExecution`, `outputJson`) was extracted into `src/cli/tool-display.tsx` (156 lines). The remaining streaming loop in `handleRun` is ~90 lines and tightly coupled to the CLI entry point — further extraction would require a `RunHandler` abstraction, which is speculative at this point.
 
-### 5. State File I/O Double-Read in CLI Handlers
+### 5. State File I/O — Resolved by `loadOrFail()`
 
 **Files**: `src/cli/handlers/plan.ts`, `src/cli/handlers/agent.ts`, `src/ui/hooks/useCommandHandler.ts`
-**Severity**: Low
-**Status**: Merged (PR #81) — residual double-read remains
+**Severity**: Resolved
+**Status**: Merged (PR #82) — `loadOrFail()` eliminates double-read
 
-The `StateManager` class (`src/agents/state-manager.ts`, 162 lines) consolidates 19 state I/O calls across 7 modules (plan-agent, explore-agent, build-agent, handlers/plan, handlers/review, handlers/agent, useCommandHandler). The `createAgentClient` factory (`src/agents/agent-client.ts`, 50 lines) eliminates the 3-way `loadConfig → parseModelString → createProvider` duplication. However, 3 CLI handlers still do a `readStateFile()` existence check before creating a `StateManager` — a double-read trade-off to preserve original error messages for tests. This could be resolved by adding a `loadOrFail()` method to StateManager (Architecture Review Round 4, Candidate #5).
+The `StateManager` class (`src/agents/state-manager.ts`, 198 lines) consolidates 19 state I/O calls across 7 modules. The `loadOrFail()` method returns a discriminated union (`{ success: true, state } | { success: false, error, code }`) that lets CLI handlers replace the double-read pattern (`readStateFile()` check + `loadOrCreate()`) with a single call. Error messages preserved for backward compatibility. The `_state` unused variable (concern #6) was also eliminated — `loadOrFail()` returns the result inline.
 
-### 6. `_state` Unused Variable in useCommandHandler.ts
+### 6. ~~`_state` Unused Variable in useCommandHandler.ts~~ — Resolved
 
-**File**: `src/ui/hooks/useCommandHandler.ts` (line 306)
-**Severity**: Low
-**Status**: Linter-suppressed (renamed to `_state`)
+**Status**: Resolved by `loadOrFail()` extraction (PR #82)
 
-The StateManager refactor left an unused `const _state = await mgr.loadOrCreate()` — all access goes through `mgr.getPlan()` and `mgr.getBuildSteps()`. The linter renamed it with the `_` prefix to suppress the warning, but the assignment should be removed entirely (`await mgr.loadOrCreate();` without `const`).
+The unused `const _state = await mgr.loadOrCreate()` was eliminated when `loadOrFail()` replaced the double-read pattern. The variable is no longer present.
 
 ## Next Deepening Opportunities (Architecture Review Round 4)
 
-| # | Candidate | Strength | Target |
-|---|-----------|----------|--------|
-| 1 | Extract SkillManager from Agent | Strong | `agent.ts` 738→~640 |
-| 2 | Extract Tool Display from `main.tsx` | Strong | `main.tsx` 541→~420 |
-| 3 | Extract Login Flow Controller from `login.ts` | Worth exploring | `login.ts` 604→~350 |
-| 4 | Extract Command Handlers from `useCommandHandler` | Worth exploring | 458→~150 |
-| 5 | Add `loadOrFail()` to StateManager | Quick win | Eliminates double-read in 3 handlers |
+| # | Candidate | Strength | Status | Target |
+|---|-----------|----------|--------|--------|
+| 1 | Extract SkillManager from Agent | Strong | ✅ Done (#82) | `agent.ts` 738→652 |
+| 2 | Extract Tool Display from `main.tsx` | Strong | ✅ Done (#82) | `main.tsx` 541→405 |
+| 3 | Extract Login Flow Controller from `login.ts` | Worth exploring | Design validated (grilling) | `login.ts` 604→~100 |
+| 4 | Extract Command Handlers from `useCommandHandler` | Worth exploring | Not started | 452→~150 |
+| 5 | Add `loadOrFail()` to StateManager | Quick win | ✅ Done (#82) | Eliminates double-read |
 
-**Recommended order**: #1 + #2 in parallel (both mechanical, no dependencies) → #5 (quick win) → #3 (design decision) → #4 (larger extraction)
+**Next candidates**: #3 (Login Flow Controller — design validated, ready to implement) → #4 (Command Handlers extraction)
 
 **Note**: The codebase has only 1 `TODO` comment in `src/` (a display label in `useCommandHandler.ts`, not a tech debt marker). No `FIXME`, `HACK`, or `XXX` markers exist.
 

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -9,7 +9,7 @@ tiny-coding-agent/
 ├── tsconfig.json            # TypeScript config (strict, NodeNext)
 ├── biome.json               # Linter + formatter
 ├── bun.lock                 # Bun lockfile
-├── src/                     # Source code (139 files, ~20k lines)
+├── src/                     # Source code (141 files, ~20k lines)
 │   ├── agents/              # Multi-agent system (plan, build, explore)
 │   ├── cli/                 # CLI interface + command handlers
 │   ├── config/              # Configuration schema + loading
@@ -35,12 +35,13 @@ tiny-coding-agent/
 
 | File | Lines | Purpose |
 |------|-------|---------|
-| `agent.ts` | 738 | Agent class — orchestrates the LLM conversation loop |
+| `agent.ts` | 652 | Agent class — orchestrates the LLM conversation loop |
 | `memory.ts` | 422 | MemoryStore — user-initiated memory storage + retrieval |
 | `agent-observability.ts` | 326 | AgentObservability — span/timer management wrapper |
 | `context-budget.ts` | 276 | prepareContext() — context window budgeting + memory merge |
 | `turn-executor.ts` | 236 | TurnExecutor — one LLM call + tool batch execution |
 | `agent-utils.ts` | 228 | streamLlmResponse(), streamFinalAnswer(), isLooping() |
+| `skill-manager.ts` | 158 | SkillManager — skill discovery, loading, tool restriction |
 | `provider-cache.ts` | 134 | ProviderCache — LLM client cache with eviction |
 | `debug-logger.ts` | 132 | DebugLogger — verbose logging (no-op when disabled) |
 | `conversation.ts` | — | ConversationManager — history persistence |
@@ -51,12 +52,14 @@ tiny-coding-agent/
 
 | File | Lines | Purpose |
 |------|-------|---------|
-| `build-agent.ts` | 461 | Build executor — parses plan, executes steps |
+| `build-agent.ts` | 401 | Build executor — parses plan, executes steps |
 | `codebase-explorer.ts` | 381 | Filesystem exploration (shallow + deep modes) |
 | `plan-grammar.ts` | 437 | Plan markdown parser → phases/steps AST |
+| `state-manager.ts` | 198 | StateManager — state file lifecycle (loadOrCreate, loadOrFail, save) |
 | `explore-agent.ts` | 234 | Codebase analysis agent |
 | `plan-agent.ts` | 231 | Plan generation agent |
 | `step-executor.ts` | 217 | StepExecutor — retry/skip/abort flow |
+| `agent-client.ts` | 50 | createAgentClient() — LLM client factory for agents |
 | `state.ts` | — | State file I/O with file locking + rotation |
 | `types.ts` | — | StateFile, AgentPhase, AgentStatus types |
 
@@ -64,7 +67,8 @@ tiny-coding-agent/
 
 | File | Lines | Purpose |
 |------|-------|---------|
-| `main.tsx` | 541 | Entry point — main(), handleRun(), handleInteractiveChat() |
+| `main.tsx` | 405 | Entry point — main(), handleRun(), handleInteractiveChat() |
+| `tool-display.tsx` | 156 | ThinkingTagFilter, formatArgs, displayToolExecution, outputJson |
 | `command-dispatch.ts` | 265 | Command dispatch table (pre/post config) |
 | `shared.ts` | 280 | parseArgs(), createLLMClient(), setupTools(), createAgent() |
 | `prompt.ts` | — | readline prompt helpers (prompt, promptHidden) |
@@ -107,7 +111,7 @@ tiny-coding-agent/
 
 | File | Lines | Purpose |
 |------|-------|---------|
-| `hooks/useCommandHandler.ts` | 458 | Slash command dispatcher (/help, /model, /plan, etc.) |
+| `hooks/useCommandHandler.ts` | 452 | Slash command dispatcher (/help, /model, /plan, etc.) |
 | `components/Message.tsx` | 382 | Message rendering (markdown, code blocks) |
 | `components/ModelPicker.tsx` | 380 | Model selection UI |
 | `contexts/ChatContext.tsx` | 303 | Chat state management |
@@ -121,7 +125,7 @@ tiny-coding-agent/
 |------|-------|---------|
 | `loader.ts` | 324 | loadConfig(), getConfigPath(), createDefaultConfig() |
 | `schema.ts` | 247 | Zod-validated Config interface + schemas |
-| `config-io.ts` | — | readConfigFile(), writeConfigFile() (YAML/JSON) |
+| `config-io.ts` | 87 | readConfigFile(), writeConfigFile() (YAML/JSON) |
 
 ### `src/hooks/` — Lifecycle Hooks (ADR-015)
 

--- a/src/agents/build-agent.ts
+++ b/src/agents/build-agent.ts
@@ -6,6 +6,7 @@ import { fileTools } from "../tools/file-tools.js";
 import { ToolRegistry } from "../tools/registry.js";
 import { createAgentClient } from "./agent-client.js";
 import { type Step as GrammarStep, type Plan, parse as parsePlanGrammar } from "./plan-grammar.js";
+import { DEFAULT_STATE_FILE } from "./state.js";
 import { StateManager } from "./state-manager.js";
 import { StepExecutor } from "./step-executor.js";
 
@@ -188,7 +189,7 @@ function createBuildRegistry(): ToolRegistry {
 }
 
 export async function buildAgent(planContent: string, options?: BuildAgentOptions): Promise<BuildAgentResult> {
-	const stateFilePath = options?.stateFilePath || ".tiny-state.json";
+	const stateFilePath = options?.stateFilePath || DEFAULT_STATE_FILE;
 	const dryRun = options?.dryRun ?? false;
 	const verbose = options?.verbose ?? false;
 

--- a/src/agents/explore-agent.ts
+++ b/src/agents/explore-agent.ts
@@ -1,6 +1,7 @@
 import type { Message } from "../providers/types.js";
 import { createAgentClient } from "./agent-client.js";
 import { CodebaseExplorer } from "./codebase-explorer.js";
+import { DEFAULT_STATE_FILE } from "./state.js";
 import { StateManager } from "./state-manager.js";
 
 export interface ExploreAgentOptions {
@@ -84,7 +85,7 @@ export async function exploreAgent(
 	taskDescription: string,
 	options?: ExploreAgentOptions
 ): Promise<ExploreAgentResult> {
-	const stateFilePath = options?.stateFilePath || ".tiny-state.json";
+	const stateFilePath = options?.stateFilePath || DEFAULT_STATE_FILE;
 	const depth = options?.depth || "shallow";
 	const verbose = options?.verbose || false;
 

--- a/src/agents/plan-agent.ts
+++ b/src/agents/plan-agent.ts
@@ -5,6 +5,7 @@ import type { Message } from "../providers/types.js";
 import { createAgentClient } from "./agent-client.js";
 import { CodebaseExplorer } from "./codebase-explorer.js";
 import { exampleOutput } from "./plan-grammar.js";
+import { DEFAULT_STATE_FILE } from "./state.js";
 import { StateManager } from "./state-manager.js";
 
 export interface PlanAgentOptions {
@@ -89,7 +90,7 @@ ${generatePrd ? "Generate a comprehensive PRD based on the implementation plan."
 }
 
 export async function planAgent(taskDescription: string, options?: PlanAgentOptions): Promise<PlanResult> {
-	const stateFilePath = options?.stateFilePath || ".tiny-state.json";
+	const stateFilePath = options?.stateFilePath || DEFAULT_STATE_FILE;
 	const generatePrd = options?.generatePrd || false;
 	const verbose = options?.verbose || false;
 

--- a/src/agents/state-manager.ts
+++ b/src/agents/state-manager.ts
@@ -9,6 +9,11 @@
  * The interface is the test surface: loadOrCreate() → updatePhase() /
  * mergeResult() / addError() → save(). No caller needs to construct
  * StateFile boilerplate or know about the file-locking internals.
+ *
+ * For read-only CLI commands that need to fail when the state file is
+ * missing (instead of creating a fresh one), use loadOrFail() — it
+ * returns a discriminated union so callers can map errors to their own
+ * user-facing messages without a double-read.
  */
 
 import { readStateFile, type StateResult, writeStateFile } from "./state.js";
@@ -25,6 +30,11 @@ export interface StateManagerOptions {
 	/** Extra parameters to include in auto-created metadata. */
 	parameters?: Record<string, unknown>;
 }
+
+/** Result of {@link StateManager.loadOrFail} — discriminates read errors from "not found". */
+export type LoadOrFailResult =
+	| { success: true; state: StateFile }
+	| { success: false; error: string; code: "read_error" | "not_found" };
 
 export class StateManager {
 	private _filePath: string;
@@ -143,6 +153,32 @@ export class StateManager {
 		this.updatePhase(phase, "failed");
 		this.addError(phase, message, details);
 		await this.save();
+	}
+
+	/**
+	 * Load the state file, or return an error result if it doesn't exist
+	 * or can't be read. Unlike {@link loadOrCreate}, this never creates a
+	 * fresh state — it's for read-only CLI commands that need to surface
+	 * "not found" errors to the user.
+	 *
+	 * Caches the result so subsequent calls are idempotent within a single
+	 * StateManager instance.
+	 */
+	async loadOrFail(): Promise<LoadOrFailResult> {
+		if (this._state) {
+			return { success: true, state: this._state };
+		}
+
+		const result = await readStateFile(this._filePath, { ignoreMissing: true });
+		if (!result.success) {
+			return { success: false, error: result.error ?? "Unknown read error", code: "read_error" };
+		}
+		if (!result.data) {
+			return { success: false, error: `No state file found at: ${this._filePath}`, code: "not_found" };
+		}
+
+		this._state = result.data;
+		return { success: true, state: this._state };
 	}
 
 	/** Get the plan text from the state, if present. */

--- a/src/agents/state-manager.ts
+++ b/src/agents/state-manager.ts
@@ -17,6 +17,11 @@
  */
 
 import { readStateFile, type StateResult, writeStateFile } from "./state.js";
+
+// Re-export for backward compatibility — CLI handlers and agents import
+// DEFAULT_STATE_FILE from state-manager.js (the module they already depend on).
+export { DEFAULT_STATE_FILE } from "./state.js";
+
 import type { AgentPhase, AgentResult, AgentStatus, BuildResult, StateError, StateFile } from "./types.js";
 
 const DEFAULT_AGENT_NAME = "tiny-agent";

--- a/src/agents/state.ts
+++ b/src/agents/state.ts
@@ -2,6 +2,8 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { StateFile } from "./types.js";
 
+export const DEFAULT_STATE_FILE = ".tiny-state.json";
+
 const MAX_STATE_FILE_SIZE = 10 * 1024 * 1024;
 const MAX_ARCHIVE_COUNT = 5;
 const LOCK_FILE_SUFFIX = ".lock";

--- a/src/cli/handlers/agent.ts
+++ b/src/cli/handlers/agent.ts
@@ -1,11 +1,9 @@
 import { buildAgent } from "../../agents/build-agent.js";
 import { exploreAgent } from "../../agents/explore-agent.js";
 import { planAgent } from "../../agents/plan-agent.js";
-import { StateManager } from "../../agents/state-manager.js";
+import { DEFAULT_STATE_FILE, StateManager } from "../../agents/state-manager.js";
 import type { HookConfig } from "../../hooks/types.js";
 import type { CliOptions } from "../shared.js";
-
-const DEFAULT_STATE_FILE = ".tiny-state.json";
 
 export async function handleAgent(
 	command: string,

--- a/src/cli/handlers/agent.ts
+++ b/src/cli/handlers/agent.ts
@@ -1,7 +1,6 @@
 import { buildAgent } from "../../agents/build-agent.js";
 import { exploreAgent } from "../../agents/explore-agent.js";
 import { planAgent } from "../../agents/plan-agent.js";
-import { readStateFile } from "../../agents/state.js";
 import { StateManager } from "../../agents/state-manager.js";
 import type { HookConfig } from "../../hooks/types.js";
 import type { CliOptions } from "../shared.js";
@@ -48,15 +47,13 @@ export async function handleAgent(
 			console.log(`Build command received`);
 			console.log(`State file: ${stateFile}`);
 
-			const stateResult = await readStateFile(stateFile, { ignoreMissing: true });
-			if (!stateResult.success) {
-				console.error(`Error: Could not read state file: ${stateResult.error}`);
+			const mgr = new StateManager(stateFile);
+			const loadResult = await mgr.loadOrFail();
+			if (!loadResult.success) {
+				console.error(`Error: Could not read state file: ${loadResult.error}`);
 				console.error("Please run 'tiny-agent plan' first to generate a plan.");
 				process.exit(1);
 			}
-
-			const mgr = new StateManager(stateFile);
-			await mgr.loadOrCreate();
 			const plan = mgr.getPlan();
 			if (!plan) {
 				console.error("Error: No plan found in state file.");

--- a/src/cli/handlers/plan.ts
+++ b/src/cli/handlers/plan.ts
@@ -1,8 +1,6 @@
 import { parse as parsePlanGrammar } from "../../agents/plan-grammar.js";
-import { StateManager } from "../../agents/state-manager.js";
+import { DEFAULT_STATE_FILE, StateManager } from "../../agents/state-manager.js";
 import type { CliOptions } from "../shared.js";
-
-const DEFAULT_STATE_FILE = ".tiny-state.json";
 
 interface TaskStatus {
 	stepNumber: number;

--- a/src/cli/handlers/plan.ts
+++ b/src/cli/handlers/plan.ts
@@ -1,5 +1,4 @@
 import { parse as parsePlanGrammar } from "../../agents/plan-grammar.js";
-import { readStateFile } from "../../agents/state.js";
 import { StateManager } from "../../agents/state-manager.js";
 import type { CliOptions } from "../shared.js";
 
@@ -37,22 +36,18 @@ export async function handlePlan(_config: unknown, args: string[], options: CliO
 		process.exit(2);
 	}
 
-	// Check if the state file actually exists on disk — StateManager's
-	// loadOrCreate() creates a fresh state if the file is missing, which
-	// would mask the "not found" error for the user.
-	const stateResult = await readStateFile(stateFile, { ignoreMissing: true });
-	if (!stateResult.success) {
-		console.error(`Error reading state file: ${stateResult.error}`);
-		process.exit(1);
-	}
-	if (!stateResult.data) {
-		console.error(`No state file found at: ${stateFile}`);
-		console.error("Run 'tiny-agent plan <task>' to generate a plan first.");
-		process.exit(1);
-	}
-
 	const mgr = new StateManager(stateFile);
-	const state = await mgr.loadOrCreate();
+	const loadResult = await mgr.loadOrFail();
+	if (!loadResult.success) {
+		if (loadResult.code === "read_error") {
+			console.error(`Error reading state file: ${loadResult.error}`);
+		} else {
+			console.error(`No state file found at: ${stateFile}`);
+			console.error("Run 'tiny-agent plan <task>' to generate a plan first.");
+		}
+		process.exit(1);
+	}
+	const state = loadResult.state;
 
 	if (subcommand === "show") {
 		if (state.results?.plan?.plan) {

--- a/src/cli/handlers/review.ts
+++ b/src/cli/handlers/review.ts
@@ -10,15 +10,13 @@
  * updated plan is saved back to the state file.
  */
 
-import { StateManager } from "../../agents/state-manager.js";
+import { DEFAULT_STATE_FILE, StateManager } from "../../agents/state-manager.js";
 import { readConfigFile } from "../../config/config-io.js";
 import { getConfigPath } from "../../config/loader.js";
 import { buildRegistry, hasHooks, runHooks } from "../../hooks/manager.js";
 import { PLANNOTATOR_PRESET } from "../../hooks/presets.js";
 import type { HookConfig, HookEvent } from "../../hooks/types.js";
 import type { CliOptions } from "../shared.js";
-
-const DEFAULT_STATE_FILE = ".tiny-state.json";
 
 export async function handleReview(_config: unknown, args: string[], options: CliOptions): Promise<void> {
 	const stateFile = options.stateFile || DEFAULT_STATE_FILE;

--- a/src/cli/handlers/state.ts
+++ b/src/cli/handlers/state.ts
@@ -1,8 +1,7 @@
 import { existsSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
+import { DEFAULT_STATE_FILE } from "../../agents/state-manager.js";
 import type { CliOptions } from "../shared.js";
-
-const DEFAULT_STATE_FILE = ".tiny-state.json";
 
 export async function handleState(_config: unknown, args: string[], options: CliOptions): Promise<void> {
 	const stateFile = options.stateFile || DEFAULT_STATE_FILE;

--- a/src/cli/main.tsx
+++ b/src/cli/main.tsx
@@ -1,152 +1,16 @@
-import { render } from "ink";
 import { loadConfig } from "../config/loader.js";
 import { getEnabledProviders, getProviderDisplayName } from "../ui/components/ModelPicker.js";
-import { ToolOutput } from "../ui/components/ToolOutput.js";
 import { statusLineManager } from "../ui/index.js";
 import { StatusType } from "../ui/types/enums.js";
 import { isJsonMode, setJsonMode, setNoColor, shouldUseInk } from "../ui/utils.js";
 import { dispatchCommand, dispatchPreConfig, registerMainHandlers } from "./command-dispatch.js";
 import { handleUpgrade } from "./handlers/upgrade.js";
 import { type CliOptions, createAgent, parseArgs } from "./shared.js";
+import { displayToolExecution, outputJson, ThinkingTagFilter } from "./tool-display.js";
 
-const TOOL_PREVIEW_LINES = Number.parseInt(process.env.TINY_AGENT_TOOL_PREVIEW_LINES ?? "6", 10);
-
-export class ThinkingTagFilter {
-	private buffer = "";
-	private pendingContent = "";
-
-	filter(chunk: string): string {
-		if (this.pendingContent.length > 0) {
-			chunk = this.pendingContent + chunk;
-			this.pendingContent = "";
-		}
-		this.buffer += chunk;
-		let result = "";
-		let lastIndex = 0;
-
-		while (true) {
-			const startIdx = this.buffer.indexOf("<thinking>", lastIndex);
-			if (startIdx === -1) {
-				break;
-			}
-
-			const endIdx = this.buffer.indexOf("</thinking>", startIdx + 11);
-			if (endIdx === -1) {
-				const contentBefore = this.buffer.slice(lastIndex, startIdx);
-				if (contentBefore.length > 0) {
-					result += `${contentBefore}\n`;
-				}
-				this.pendingContent = this.buffer.slice(startIdx);
-				this.buffer = "";
-				return result;
-			}
-
-			const contentBefore = this.buffer.slice(lastIndex, startIdx);
-			result += contentBefore;
-			const afterEnd = this.buffer.slice(endIdx + 11);
-			if (contentBefore.length > 0 && afterEnd.length > 0 && !afterEnd.startsWith("<thinking>")) {
-				result += "\n";
-			}
-			lastIndex = endIdx + 11;
-		}
-
-		result += this.buffer.slice(lastIndex);
-		this.buffer = "";
-		return result;
-	}
-
-	flush(): string {
-		const remaining = this.buffer;
-		this.buffer = "";
-		this.pendingContent = "";
-		return remaining;
-	}
-}
-
-export function formatArgs(args: Record<string, unknown> | undefined): string {
-	if (!args || Object.keys(args).length === 0) return "";
-	const entries = Object.entries(args)
-		.filter(([, v]) => v !== undefined)
-		.map(([k, v]) => {
-			const str = typeof v === "string" ? v : JSON.stringify(v);
-			if (str.length >= 80) {
-				if (k === "content") {
-					return `${k}=\n${str.slice(0, 80)}\n... (${str.length - 80} more chars)`;
-				}
-				return `${k}=${str.slice(0, 80)}...`;
-			}
-			return `${k}=${str}`;
-		});
-	return entries.length > 0 ? ` (${entries.join(", ")})` : "";
-}
-
-type ToolExecutionDisplay = {
-	name: string;
-	status: "running" | "complete" | "error";
-	args?: Record<string, unknown>;
-	output?: string;
-	error?: string;
-};
-
-function formatOutputPreview(output: string): string {
-	const lines = output.split("\n");
-	const preview =
-		lines.length > TOOL_PREVIEW_LINES ? `${lines.slice(0, TOOL_PREVIEW_LINES).join("\n")}\n  ...` : output;
-	return `  │ ${preview.split("\n").join("\n  │ ")}\n`;
-}
-
-function toolExecutionHeader(te: ToolExecutionDisplay, symbol: string): string {
-	const argsStr = formatArgs(te.args);
-	return `  [${symbol}] ${te.name}${argsStr}\n`;
-}
-
-function displayToolExecutionPlain(te: ToolExecutionDisplay): void {
-	const isRunning = te.status === "running";
-	const isComplete = te.status === "complete";
-	const isError = te.status === "error";
-
-	if (isRunning) {
-		process.stdout.write(toolExecutionHeader(te, ""));
-		return;
-	}
-
-	const symbol = isComplete ? "✓" : isError ? "✗" : "";
-	process.stdout.write(toolExecutionHeader(te, symbol));
-
-	const outputToShow = isComplete ? te.output : isError ? te.error : undefined;
-	if (outputToShow) {
-		process.stdout.write(formatOutputPreview(outputToShow));
-	}
-}
-
-function displayToolExecutionInk(te: ToolExecutionDisplay): void {
-	if (te.status === "running") {
-		return;
-	}
-	const success = te.status === "complete";
-	const { unmount } = render(
-		<ToolOutput name={te.name} success={success} output={te.output} error={te.error} args={te.args} />
-	);
-	unmount();
-}
-
-function displayToolExecution(te: ToolExecutionDisplay, useInk: boolean): void {
-	if (useInk) {
-		displayToolExecutionInk(te);
-	} else {
-		displayToolExecutionPlain(te);
-	}
-}
-
-interface JsonOutput {
-	type: "user" | "assistant" | "tool";
-	content: string;
-	toolName?: string;
-}
-
-function outputJson(data: JsonOutput): void {
-	console.log(JSON.stringify(data));
-}
+// Re-export for backward compatibility — tests import ThinkingTagFilter
+// and formatArgs from main.tsx. The canonical home is now tool-display.ts.
+export { formatArgs, ThinkingTagFilter } from "./tool-display.js";
 
 async function readStdin(): Promise<string> {
 	if (process.stdin.isTTY) return "";
@@ -267,7 +131,7 @@ async function handleRun(config: ReturnType<typeof loadConfig>, args: string[], 
 						process.stdout.write("\n  Tools:\n");
 					}
 					for (const te of chunk.toolExecutions) {
-						displayToolExecution(te, useInk);
+						displayToolExecution(te);
 					}
 				}
 			}

--- a/src/cli/tool-display.tsx
+++ b/src/cli/tool-display.tsx
@@ -102,19 +102,15 @@ function toolExecutionHeader(te: ToolExecutionDisplay, symbol: string): string {
 }
 
 function displayToolExecutionPlain(te: ToolExecutionDisplay): void {
-	const isRunning = te.status === "running";
-	const isComplete = te.status === "complete";
-	const isError = te.status === "error";
-
-	if (isRunning) {
+	if (te.status === "running") {
 		process.stdout.write(toolExecutionHeader(te, ""));
 		return;
 	}
 
-	const symbol = isComplete ? "✓" : isError ? "✗" : "";
+	const symbol = te.status === "complete" ? "✓" : "✗";
 	process.stdout.write(toolExecutionHeader(te, symbol));
 
-	const outputToShow = isComplete ? te.output : isError ? te.error : undefined;
+	const outputToShow = te.status === "complete" ? te.output : te.error;
 	if (outputToShow) {
 		process.stdout.write(formatOutputPreview(outputToShow));
 	}

--- a/src/cli/tool-display.tsx
+++ b/src/cli/tool-display.tsx
@@ -1,0 +1,156 @@
+import { render } from "ink";
+import { ToolOutput } from "../ui/components/ToolOutput.js";
+import { shouldUseInk } from "../ui/utils.js";
+
+const TOOL_PREVIEW_LINES = Number.parseInt(process.env.TINY_AGENT_TOOL_PREVIEW_LINES ?? "6", 10);
+
+/**
+ * ThinkingTagFilter — filters `<thinking>` tags from streaming content.
+ * Handles partial tag boundaries across chunk boundaries.
+ *
+ * Extracted from main.tsx to make the partial-tag edge cases unit-testable
+ * without importing the full CLI entry point.
+ */
+export class ThinkingTagFilter {
+	private buffer = "";
+	private pendingContent = "";
+
+	filter(chunk: string): string {
+		if (this.pendingContent.length > 0) {
+			chunk = this.pendingContent + chunk;
+			this.pendingContent = "";
+		}
+		this.buffer += chunk;
+		let result = "";
+		let lastIndex = 0;
+
+		while (true) {
+			const startIdx = this.buffer.indexOf("<thinking>", lastIndex);
+			if (startIdx === -1) {
+				break;
+			}
+
+			const endIdx = this.buffer.indexOf("</thinking>", startIdx + 11);
+			if (endIdx === -1) {
+				const contentBefore = this.buffer.slice(lastIndex, startIdx);
+				if (contentBefore.length > 0) {
+					result += `${contentBefore}\n`;
+				}
+				this.pendingContent = this.buffer.slice(startIdx);
+				this.buffer = "";
+				return result;
+			}
+
+			const contentBefore = this.buffer.slice(lastIndex, startIdx);
+			result += contentBefore;
+			const afterEnd = this.buffer.slice(endIdx + 11);
+			if (contentBefore.length > 0 && afterEnd.length > 0 && !afterEnd.startsWith("<thinking>")) {
+				result += "\n";
+			}
+			lastIndex = endIdx + 11;
+		}
+
+		result += this.buffer.slice(lastIndex);
+		this.buffer = "";
+		return result;
+	}
+
+	flush(): string {
+		const remaining = this.buffer;
+		this.buffer = "";
+		this.pendingContent = "";
+		return remaining;
+	}
+}
+
+/** Format tool call arguments as a compact string for display. */
+export function formatArgs(args: Record<string, unknown> | undefined): string {
+	if (!args || Object.keys(args).length === 0) return "";
+	const entries = Object.entries(args)
+		.filter(([, v]) => v !== undefined)
+		.map(([k, v]) => {
+			const str = typeof v === "string" ? v : JSON.stringify(v);
+			if (str.length >= 80) {
+				if (k === "content") {
+					return `${k}=\n${str.slice(0, 80)}\n... (${str.length - 80} more chars)`;
+				}
+				return `${k}=${str.slice(0, 80)}...`;
+			}
+			return `${k}=${str}`;
+		});
+	return entries.length > 0 ? ` (${entries.join(", ")})` : "";
+}
+
+export type ToolExecutionDisplay = {
+	name: string;
+	status: "running" | "complete" | "error";
+	args?: Record<string, unknown>;
+	output?: string;
+	error?: string;
+};
+
+function formatOutputPreview(output: string): string {
+	const lines = output.split("\n");
+	const preview =
+		lines.length > TOOL_PREVIEW_LINES ? `${lines.slice(0, TOOL_PREVIEW_LINES).join("\n")}\n  ...` : output;
+	return `  │ ${preview.split("\n").join("\n  │ ")}\n`;
+}
+
+function toolExecutionHeader(te: ToolExecutionDisplay, symbol: string): string {
+	const argsStr = formatArgs(te.args);
+	return `  [${symbol}] ${te.name}${argsStr}\n`;
+}
+
+function displayToolExecutionPlain(te: ToolExecutionDisplay): void {
+	const isRunning = te.status === "running";
+	const isComplete = te.status === "complete";
+	const isError = te.status === "error";
+
+	if (isRunning) {
+		process.stdout.write(toolExecutionHeader(te, ""));
+		return;
+	}
+
+	const symbol = isComplete ? "✓" : isError ? "✗" : "";
+	process.stdout.write(toolExecutionHeader(te, symbol));
+
+	const outputToShow = isComplete ? te.output : isError ? te.error : undefined;
+	if (outputToShow) {
+		process.stdout.write(formatOutputPreview(outputToShow));
+	}
+}
+
+function displayToolExecutionInk(te: ToolExecutionDisplay): void {
+	if (te.status === "running") {
+		return;
+	}
+	const success = te.status === "complete";
+	const { unmount } = render(
+		<ToolOutput name={te.name} success={success} output={te.output} error={te.error} args={te.args} />
+	);
+	unmount();
+}
+
+/**
+ * Display a tool execution in the terminal — either as plain text or
+ * rendered via Ink, depending on the terminal capabilities.
+ */
+export function displayToolExecution(te: ToolExecutionDisplay, useInk?: boolean): void {
+	const ink = useInk ?? shouldUseInk();
+	if (ink) {
+		displayToolExecutionInk(te);
+	} else {
+		displayToolExecutionPlain(te);
+	}
+}
+
+export interface JsonOutput {
+	type: "user" | "assistant" | "tool";
+	content: string;
+	toolName?: string;
+}
+
+/** Output a JSON-encoded message for programmatic consumption (--json mode). */
+export function outputJson(data: JsonOutput): void {
+	console.log(JSON.stringify(data));
+}

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -1,16 +1,11 @@
-import * as fs from "node:fs/promises";
-import * as path from "node:path";
 import { loadAgentsMd } from "../config/loader.js";
 import type { ObservabilityConfig, ThinkingConfig } from "../config/schema.js";
 import type { McpManager } from "../mcp/manager.js";
 import { parseModelString } from "../providers/factory.js";
 import { detectProvider } from "../providers/model-registry.js";
-import type { LLMClient, Message, TokenUsage, ToolDefinition } from "../providers/types.js";
-import { getEmbeddedSkillContent } from "../skills/builtin-registry.js";
-import { discoverSkills, generateSkillsPrompt, getBuiltinSkillsDir, type SkillMetadata } from "../skills/index.js";
-import { parseSkillFrontmatter } from "../skills/parser.js";
+import type { LLMClient, Message, TokenUsage } from "../providers/types.js";
+import { getBuiltinSkillsDir, type SkillMetadata } from "../skills/index.js";
 import type { ToolRegistry } from "../tools/registry.js";
-import { escapeXml } from "../utils/xml.js";
 import { AgentObservability } from "./agent-observability.js";
 import {
 	type StreamFinalAnswerResult,
@@ -24,6 +19,7 @@ import { DebugLogger } from "./debug-logger.js";
 import type { ContextStats } from "./memory.js";
 import { MemoryStore } from "./memory.js";
 import { ProviderCache, type ProviderConfigs } from "./provider-cache.js";
+import { SkillManager } from "./skill-manager.js";
 import { TurnExecutor } from "./turn-executor.js";
 
 // Re-export for backward compatibility — other modules and tests import
@@ -144,10 +140,7 @@ export class Agent {
 	private _trackContextUsage: boolean;
 	private _thinking?: ThinkingConfig;
 	private _conversationManager!: ConversationManager;
-	private _skills: Map<string, SkillMetadata> = new Map();
-	private _skillsInitialized: boolean = false;
-	private _skillsInitPromise?: Promise<void>;
-	private _activeSkillAllowedTools: string[] | undefined;
+	private _skillManager: SkillManager;
 	private _mcpManager?: McpManager;
 	private _obsWrapper: AgentObservability;
 	private _turnExecutor: TurnExecutor;
@@ -181,39 +174,13 @@ export class Agent {
 			}
 		}
 
+		this._skillManager = new SkillManager(effectiveSystemPrompt);
+		this._skillManager.initialize(options.skillDirectories ?? [], getBuiltinSkillsDir());
 		this._systemPrompt = effectiveSystemPrompt;
-
-		this._skillsInitPromise = this._initializeSkills(
-			options.skillDirectories ?? [],
-			getBuiltinSkillsDir(),
-			effectiveSystemPrompt
-		);
 
 		if (options.memoryFile) {
 			this._memoryStore = new MemoryStore({ filePath: options.memoryFile });
 		}
-	}
-
-	private async _initializeSkills(skillDirectories: string[], builtinDir: string, systemPrompt: string): Promise<void> {
-		if (this._skillsInitPromise) {
-			return this._skillsInitPromise;
-		}
-
-		this._skillsInitPromise = (async () => {
-			if (this._skillsInitialized) return;
-
-			const discoveredSkills = await discoverSkills(skillDirectories, builtinDir);
-			for (const skill of discoveredSkills) {
-				this._skills.set(skill.name, skill);
-			}
-			const skillsPrompt = generateSkillsPrompt(discoveredSkills);
-			if (skillsPrompt) {
-				this._systemPrompt = `${systemPrompt}\n\n${skillsPrompt}`;
-			}
-			this._skillsInitialized = true;
-		})();
-
-		return this._skillsInitPromise;
 	}
 
 	startChatSession(): void {
@@ -230,11 +197,10 @@ export class Agent {
 		runtimeConfig?: RuntimeConfig,
 		options?: { signal?: AbortSignal }
 	): AsyncGenerator<AgentStreamChunk, void, unknown> {
-		if (this._skillsInitPromise) {
-			await this._skillsInitPromise;
-		}
+		await this._skillManager.waitForSkills();
+		this._systemPrompt = this._skillManager.systemPrompt;
 
-		this._clearSkillRestriction();
+		this._skillManager.clearRestriction();
 
 		// --- Observability: begin request ----------------------------------
 		const providerName = this._providerCache.getProviderName(runtimeConfig?.model ?? model);
@@ -285,7 +251,13 @@ export class Agent {
 		const systemTokens = ctxResult.systemTokens;
 		const maxContextTokens = ctxResult.stats.maxContextTokens;
 
-		const tools = this._getToolDefinitions();
+		const tools = this._skillManager.filterTools(
+			this._toolRegistry.list().map((tool) => ({
+				name: tool.name,
+				description: tool.description,
+				parameters: tool.parameters,
+			}))
+		);
 
 		const providerTypeForDetails = detectProvider(effectiveModel);
 		this._debug.logRequestDetails({
@@ -592,7 +564,7 @@ export class Agent {
 	}
 
 	getSkillRegistry(): Map<string, SkillMetadata> {
-		return this._skills;
+		return this._skillManager.getRegistry();
 	}
 
 	getMemoryStore(): MemoryStore | undefined {
@@ -617,64 +589,21 @@ export class Agent {
 	}
 
 	async waitForSkills(): Promise<void> {
-		if (!this._skillsInitPromise) return;
-		await this._skillsInitPromise;
+		await this._skillManager.waitForSkills();
 	}
 
 	async loadSkill(
 		skillName: string
 	): Promise<{ content: string; wrappedContent: string; allowedTools?: string[] } | null> {
-		const skillMetadata = this._skills.get(skillName);
-		if (!skillMetadata) return null;
-
-		try {
-			let content: string;
-			let baseDir = ".";
-
-			if (skillMetadata.location.startsWith("builtin://")) {
-				const embeddedContent = getEmbeddedSkillContent(skillName);
-				if (!embeddedContent) {
-					throw new Error(`Built-in skill content not found: ${skillName}`);
-				}
-				content = embeddedContent;
-			} else {
-				content = await fs.readFile(skillMetadata.location, "utf-8");
-				baseDir = path.dirname(skillMetadata.location);
-			}
-
-			let allowedTools: string[] | undefined;
-			try {
-				const parsed = parseSkillFrontmatter(content);
-				allowedTools = parsed.frontmatter.allowedTools;
-			} catch {
-				console.warn(`[WARN] Could not parse frontmatter for skill: ${skillName}`);
-			}
-
-			if (allowedTools) {
-				this._setSkillRestriction(allowedTools);
-			} else {
-				this._clearSkillRestriction();
-			}
-
-			const escapedContent = escapeXml(content);
-			const wrappedContent = `<loaded_skill name="${skillName}" base_dir="${baseDir}">\n${escapedContent}\n</loaded_skill>`;
-
-			return { content, wrappedContent, allowedTools };
-		} catch (err) {
-			const error = err as NodeJS.ErrnoException;
-			if (error.code === "ENOENT") {
-				throw new Error(`Skill file not found: ${skillMetadata.location}`);
-			}
-			throw new Error(`Error reading skill: ${error.message}`);
-		}
+		return this._skillManager.loadSkill(skillName);
 	}
 
 	_setSkillRestriction(allowedTools: string[] | undefined): void {
-		this._activeSkillAllowedTools = allowedTools;
+		this._skillManager.setRestriction(allowedTools);
 	}
 
 	_clearSkillRestriction(): void {
-		this._activeSkillAllowedTools = undefined;
+		this._skillManager.clearRestriction();
 	}
 
 	async healthCheck(): Promise<HealthStatus> {
@@ -691,7 +620,7 @@ export class Agent {
 				ready: false,
 				issues,
 				providerCount: this._providerCache.size,
-				skillCount: this._skills.size,
+				skillCount: this._skillManager.count,
 				memoryEnabled: !!this._memoryStore,
 				mcpServers: this._mcpManager?.getServerStatus() ?? [],
 			};
@@ -701,7 +630,7 @@ export class Agent {
 			ready: true,
 			issues,
 			providerCount: this._providerCache.size,
-			skillCount: this._skills.size,
+			skillCount: this._skillManager.count,
 			memoryEnabled: !!this._memoryStore,
 			mcpServers: this._mcpManager?.getServerStatus() ?? [],
 		};
@@ -719,20 +648,5 @@ export class Agent {
 			process.removeAllListeners("SIGTERM");
 			process.removeAllListeners("SIGINT");
 		}
-	}
-
-	private _getToolDefinitions(): ToolDefinition[] {
-		const allTools = this._toolRegistry.list().map((tool) => ({
-			name: tool.name,
-			description: tool.description,
-			parameters: tool.parameters,
-		}));
-
-		if (!this._activeSkillAllowedTools?.length) {
-			return allTools;
-		}
-
-		const allowedSet = new Set(this._activeSkillAllowedTools);
-		return allTools.filter((tool) => allowedSet.has(tool.name));
 	}
 }

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -615,19 +615,8 @@ export class Agent {
 			issues.push("Provider configs empty");
 		}
 
-		if (issues.length > 0) {
-			return {
-				ready: false,
-				issues,
-				providerCount: this._providerCache.size,
-				skillCount: this._skillManager.count,
-				memoryEnabled: !!this._memoryStore,
-				mcpServers: this._mcpManager?.getServerStatus() ?? [],
-			};
-		}
-
 		return {
-			ready: true,
+			ready: issues.length === 0,
 			issues,
 			providerCount: this._providerCache.size,
 			skillCount: this._skillManager.count,

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -1,0 +1,158 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { ToolDefinition } from "../providers/types.js";
+import { getEmbeddedSkillContent } from "../skills/builtin-registry.js";
+import { discoverSkills, generateSkillsPrompt, type SkillMetadata } from "../skills/index.js";
+import { parseSkillFrontmatter } from "../skills/parser.js";
+import { escapeXml } from "../utils/xml.js";
+
+/**
+ * SkillManager — deep module for skill discovery, initialization, loading,
+ * and tool restriction. Extracted from Agent (ADR-016 decomposition) to
+ * separate the skill management concern from the agent loop.
+ *
+ * The interface is the test surface: construct a SkillManager with a
+ * builtin dir + optional custom directories, call initialize(), then
+ * loadSkill(name) or filterTools(allTools) — no LLM client or tool
+ * registry needed for testing.
+ */
+export class SkillManager {
+	private _skills: Map<string, SkillMetadata> = new Map();
+	private _initialized: boolean = false;
+	private _initPromise?: Promise<void>;
+	private _activeAllowedTools: string[] | undefined;
+	private _systemPrompt: string;
+
+	constructor(systemPrompt: string) {
+		this._systemPrompt = systemPrompt;
+	}
+
+	/**
+	 * Discover and load skills from the given directories. Augments the
+	 * system prompt with a skills listing. Returns a promise that resolves
+	 * when initialization is complete — safe to call multiple times.
+	 */
+	initialize(skillDirectories: string[], builtinDir: string): Promise<void> {
+		if (this._initPromise) {
+			return this._initPromise;
+		}
+
+		this._initPromise = (async () => {
+			if (this._initialized) return;
+
+			const discoveredSkills = await discoverSkills(skillDirectories, builtinDir);
+			for (const skill of discoveredSkills) {
+				this._skills.set(skill.name, skill);
+			}
+			const skillsPrompt = generateSkillsPrompt(discoveredSkills);
+			if (skillsPrompt) {
+				this._systemPrompt = `${this._systemPrompt}\n\n${skillsPrompt}`;
+			}
+			this._initialized = true;
+		})();
+
+		return this._initPromise;
+	}
+
+	/** Wait for skill initialization to complete. */
+	async waitForSkills(): Promise<void> {
+		if (!this._initPromise) return;
+		await this._initPromise;
+	}
+
+	/** Get the (possibly augmented) system prompt after skill initialization. */
+	get systemPrompt(): string {
+		return this._systemPrompt;
+	}
+
+	/** Get the skill registry map (name → metadata). */
+	getRegistry(): Map<string, SkillMetadata> {
+		return this._skills;
+	}
+
+	/** Number of discovered skills. */
+	get count(): number {
+		return this._skills.size;
+	}
+
+	/**
+	 * Load a skill by name: read its content (from disk or embedded),
+	 * parse frontmatter for allowed tools, set the tool restriction,
+	 * and return the content + XML-wrapped version.
+	 */
+	async loadSkill(
+		skillName: string
+	): Promise<{ content: string; wrappedContent: string; allowedTools?: string[] } | null> {
+		const skillMetadata = this._skills.get(skillName);
+		if (!skillMetadata) return null;
+
+		try {
+			let content: string;
+			let baseDir = ".";
+
+			if (skillMetadata.location.startsWith("builtin://")) {
+				const embeddedContent = getEmbeddedSkillContent(skillName);
+				if (!embeddedContent) {
+					throw new Error(`Built-in skill content not found: ${skillName}`);
+				}
+				content = embeddedContent;
+			} else {
+				content = await fs.readFile(skillMetadata.location, "utf-8");
+				baseDir = path.dirname(skillMetadata.location);
+			}
+
+			let allowedTools: string[] | undefined;
+			try {
+				const parsed = parseSkillFrontmatter(content);
+				allowedTools = parsed.frontmatter.allowedTools;
+			} catch {
+				console.warn(`[WARN] Could not parse frontmatter for skill: ${skillName}`);
+			}
+
+			if (allowedTools) {
+				this.setRestriction(allowedTools);
+			} else {
+				this.clearRestriction();
+			}
+
+			const escapedContent = escapeXml(content);
+			const wrappedContent = `<loaded_skill name="${skillName}" base_dir="${baseDir}">\n${escapedContent}\n</loaded_skill>`;
+
+			return { content, wrappedContent, allowedTools };
+		} catch (err) {
+			const error = err as NodeJS.ErrnoException;
+			if (error.code === "ENOENT") {
+				throw new Error(`Skill file not found: ${skillMetadata.location}`);
+			}
+			throw new Error(`Error reading skill: ${error.message}`);
+		}
+	}
+
+	/** Restrict available tools to the given allowlist. */
+	setRestriction(allowedTools: string[] | undefined): void {
+		this._activeAllowedTools = allowedTools;
+	}
+
+	/** Clear any tool restriction — all tools become available. */
+	clearRestriction(): void {
+		this._activeAllowedTools = undefined;
+	}
+
+	/** Whether a tool restriction is currently active. */
+	get hasRestriction(): boolean {
+		return !!this._activeAllowedTools?.length;
+	}
+
+	/**
+	 * Filter a list of tool definitions to only those allowed by the
+	 * current skill restriction. If no restriction is active, returns
+	 * all tools unchanged.
+	 */
+	filterTools(allTools: ToolDefinition[]): ToolDefinition[] {
+		if (!this._activeAllowedTools?.length) {
+			return allTools;
+		}
+		const allowedSet = new Set(this._activeAllowedTools);
+		return allTools.filter((tool) => allowedSet.has(tool.name));
+	}
+}

--- a/src/ui/hooks/useCommandHandler.ts
+++ b/src/ui/hooks/useCommandHandler.ts
@@ -1,5 +1,4 @@
 import { useCallback } from "react";
-import { readStateFile } from "../../agents/state.js";
 import { StateManager } from "../../agents/state-manager.js";
 import { formatProviderStatus } from "../../cli/handlers/login.js";
 import { readConfigFile } from "../../config/config-io.js";
@@ -140,17 +139,12 @@ export function useCommandHandler({
 			const subcommand = args.trim().toLowerCase() || "show";
 			const stateFile = DEFAULT_STATE_FILE;
 
-			// Check if the state file actually exists on disk — StateManager's
-			// loadOrCreate() creates a fresh state if the file is missing, which
-			// would mask the "not found" error for the user.
-			const stateResult = await readStateFile(stateFile, { ignoreMissing: true });
-			if (!stateResult.success || !stateResult.data) {
+			const mgr = new StateManager(stateFile);
+			const loadResult = await mgr.loadOrFail();
+			if (!loadResult.success) {
 				onAddMessage(MessageRole.ASSISTANT, "No state file found. Run 'tiny-agent plan <task>' first.");
 				return;
 			}
-
-			const mgr = new StateManager(stateFile);
-			const _state = await mgr.loadOrCreate();
 
 			if (subcommand === "show") {
 				const plan = mgr.getPlan();

--- a/src/ui/hooks/useCommandHandler.ts
+++ b/src/ui/hooks/useCommandHandler.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { StateManager } from "../../agents/state-manager.js";
+import { DEFAULT_STATE_FILE, StateManager } from "../../agents/state-manager.js";
 import { formatProviderStatus } from "../../cli/handlers/login.js";
 import { readConfigFile } from "../../config/config-io.js";
 import { getConfigPath } from "../../config/loader.js";
@@ -11,8 +11,6 @@ import type { McpManager } from "../../mcp/manager.js";
 import { generateHelpText, resolveCommandAlias } from "../chat-command-registry.js";
 import type { Command } from "../components/CommandMenu.js";
 import { MessageRole } from "../types/enums.js";
-
-const DEFAULT_STATE_FILE = ".tiny-state.json";
 
 interface UseCommandHandlerProps {
 	onAddMessage: (role: MessageRole, content: string) => void;

--- a/test/core/agent.test.ts
+++ b/test/core/agent.test.ts
@@ -302,14 +302,17 @@ describe("Agent", () => {
 			agent._setSkillRestriction(["read"]);
 
 			// Get tool definitions - should only contain 'read'
-			const agentPrivate = agent as unknown as {
-				_activeSkillAllowedTools: string[] | undefined;
+			const agentSkill = agent as unknown as {
+				_skillManager: {
+					hasRestriction: boolean;
+					filterTools: (tools: { name: string }[]) => { name: string }[];
+				};
 				_toolRegistry: ToolRegistry;
-				_getToolDefinitions(): ReturnType<typeof import("../../src/core/agent.js").Agent.prototype._getToolDefinitions>;
 			};
-			expect(agentPrivate._activeSkillAllowedTools).toEqual(["read"]);
+			expect(agentSkill._skillManager.hasRestriction).toBe(true);
 
-			const toolDefs = agentPrivate._getToolDefinitions();
+			const allTools = agentSkill._toolRegistry.list().map((tool) => ({ name: tool.name }));
+			const toolDefs = agentSkill._skillManager.filterTools(allTools);
 
 			expect(toolDefs.length).toBe(1);
 			const firstTool = toolDefs[0];
@@ -340,17 +343,21 @@ describe("Agent", () => {
 				execute: async () => ({ success: true, output: "command output" }),
 			});
 
-			const agentPrivate = agent as unknown as {
-				_activeSkillAllowedTools: string[] | undefined;
-				_getToolDefinitions(): ReturnType<typeof import("../../src/core/agent.js").Agent.prototype._getToolDefinitions>;
+			const agentSkill = agent as unknown as {
+				_skillManager: {
+					hasRestriction: boolean;
+					filterTools: (tools: { name: string }[]) => { name: string }[];
+				};
+				_toolRegistry: ToolRegistry;
 			};
-			expect(agentPrivate._activeSkillAllowedTools).toBeUndefined();
+			expect(agentSkill._skillManager.hasRestriction).toBe(false);
 
 			// Get tool definitions - should contain all tools
-			const toolDefs = agentPrivate._getToolDefinitions();
+			const allTools = agentSkill._toolRegistry.list().map((tool) => ({ name: tool.name }));
+			const toolDefs = agentSkill._skillManager.filterTools(allTools);
 
 			expect(toolDefs.length).toBe(2);
-			expect(toolDefs.map((t) => t.name).sort()).toEqual(["bash", "read"]);
+			expect(toolDefs.map((tool) => tool.name).sort()).toEqual(["bash", "read"]);
 		});
 
 		it("should clear restriction when _clearSkillRestriction is called", async () => {
@@ -380,17 +387,21 @@ describe("Agent", () => {
 			agent._setSkillRestriction(["read"]);
 			agent._clearSkillRestriction();
 
-			const agentPrivate = agent as unknown as {
-				_activeSkillAllowedTools: string[] | undefined;
-				_getToolDefinitions(): ReturnType<typeof import("../../src/core/agent.js").Agent.prototype._getToolDefinitions>;
+			const agentSkill = agent as unknown as {
+				_skillManager: {
+					hasRestriction: boolean;
+					filterTools: (tools: { name: string }[]) => { name: string }[];
+				};
+				_toolRegistry: ToolRegistry;
 			};
-			expect(agentPrivate._activeSkillAllowedTools).toBeUndefined();
+			expect(agentSkill._skillManager.hasRestriction).toBe(false);
 
 			// Get tool definitions - should contain all tools
-			const toolDefs = agentPrivate._getToolDefinitions();
+			const allTools = agentSkill._toolRegistry.list().map((tool) => ({ name: tool.name }));
+			const toolDefs = agentSkill._skillManager.filterTools(allTools);
 
 			expect(toolDefs.length).toBe(2);
-			expect(toolDefs.map((t) => t.name).sort()).toEqual(["bash", "read"]);
+			expect(toolDefs.map((tool) => tool.name).sort()).toEqual(["bash", "read"]);
 		});
 
 		it("should clear restriction at start of runStream", async () => {
@@ -410,17 +421,21 @@ describe("Agent", () => {
 				execute: async () => ({ success: true, output: "file content" }),
 			});
 
-			const agentPrivate = agent as unknown as {
-				_activeSkillAllowedTools: string[] | undefined;
-				_getToolDefinitions(): ReturnType<typeof import("../../src/core/agent.js").Agent.prototype._getToolDefinitions>;
+			const agentSkill = agent as unknown as {
+				_skillManager: {
+					hasRestriction: boolean;
+					filterTools: (tools: { name: string }[]) => { name: string }[];
+				};
+				_toolRegistry: ToolRegistry;
 			};
 
 			// Set a restriction
 			agent._setSkillRestriction(["read"]);
-			expect(agentPrivate._activeSkillAllowedTools).toEqual(["read"]);
+			expect(agentSkill._skillManager.hasRestriction).toBe(true);
 
 			// Verify restriction is set
-			let toolDefs = agentPrivate._getToolDefinitions();
+			const allTools = agentSkill._toolRegistry.list().map((tool) => ({ name: tool.name }));
+			let toolDefs = agentSkill._skillManager.filterTools(allTools);
 			expect(toolDefs.length).toBe(1);
 
 			// Start a new runStream - this should clear the restriction
@@ -428,8 +443,8 @@ describe("Agent", () => {
 			}
 
 			// After runStream, restriction should be cleared
-			expect(agentPrivate._activeSkillAllowedTools).toBeUndefined();
-			toolDefs = agentPrivate._getToolDefinitions();
+			expect(agentSkill._skillManager.hasRestriction).toBe(false);
+			toolDefs = agentSkill._skillManager.filterTools(allTools);
 			expect(toolDefs.length).toBe(1);
 		});
 	});


### PR DESCRIPTION
## What

Extract two deep modules to separate concerns from Agent and main.tsx:

1. **SkillManager** (`src/core/skill-manager.ts`, new 158 lines) — owns skill discovery, initialization, loading, and tool restriction. Extracted from Agent (4 fields + 8 methods). Agent now delegates to `_skillManager`.

2. **ToolDisplay** (`src/cli/tool-display.tsx`, new 152 lines) — owns `ThinkingTagFilter`, `formatArgs`, `displayToolExecution`, `outputJson`. Extracted from main.tsx (~120 lines of display utilities). main.tsx re-exports `ThinkingTagFilter` and `formatArgs` for backward compatibility.

### Also included (from architecture review round 4)

3. **`loadOrFail()` on StateManager** (commit a02bad7) — New public API method + `LoadOrFailResult` discriminated union that returns `{ success: true, state }` or `{ success: false, error, code: "read_error" | "not_found" }`. Eliminates the double-read pattern (readStateFile existence check + loadOrCreate) in 3 CLI handlers (`plan.ts`, `agent.ts`, `useCommandHandler.ts`). Architecture candidate #5, bundled here because it touches the same handler files.

4. **Simplify cleanups** (commit da8e52e) — Collapsed `healthCheck()` duplicate return blocks into single return with `ready: issues.length === 0`. Removed 3 intermediate boolean variables + unreachable dead code in `displayToolExecutionPlain()`.

### Signature change note

`displayToolExecution(te, useInk: boolean)` → `displayToolExecution(te, useInk?: boolean)` — the second parameter is now optional, defaulting to `shouldUseInk()` internally. The call site in `main.tsx` was updated from `displayToolExecution(te, useInk)` to `displayToolExecution(te)`. Behavior is identical (the caller already computed `useInk = shouldUseInk()`), but the function now encapsulates the terminal-capability detection rather than receiving it from the caller.

## Why

Architecture Review Round 4 identified these as the top 2 strong candidates:

- **SkillManager**: Agent owned 4 skill-related private fields + 8 skill methods that are a completely separate concern from the agent loop. Skill logic was untestable without constructing a full Agent with an LLM client and tool registry. Now SkillManager can be unit-tested independently.

- **ToolDisplay**: main.tsx mixed 3 concerns — CLI entry-point orchestration, the `handleRun` streaming loop, and tool display formatting. The display utilities (especially `ThinkingTagFilter` with its partial-tag boundary edge cases) were untestable through their current interface.

- **loadOrFail()**: 3 CLI handlers each did `readStateFile(..., { ignoreMissing: true })` for an existence check, then `StateManager.loadOrCreate()` (which reads the file again). The double-read was a documented trade-off (CONCERNS.md #5). `loadOrFail()` does a single read and returns a discriminated union so callers can map `read_error` vs `not_found` to their own user-facing messages.

## How

- SkillManager class with interface: `initialize()` → `waitForSkills()` → `loadSkill(name)` → `filterTools(allTools)` → `clearRestriction()`
- Agent constructor creates SkillManager, calls `initialize()`, and delegates all skill operations
- `_getToolDefinitions()` private method removed from Agent — replaced with inline `_skillManager.filterTools()` call
- ToolDisplay module contains all display utilities + `ThinkingTagFilter` class
- main.tsx imports and re-exports for backward compatibility
- 4 test cases in `agent.test.ts` updated to use `_skillManager.hasRestriction` and `_skillManager.filterTools` instead of removed `_activeSkillAllowedTools` and `_getToolDefinitions()`
- `loadOrFail()` returns a discriminated union — handlers check `loadResult.code === "read_error"` for I/O errors vs `"not_found"` for missing files
- Error messages preserved for backward compatibility with existing tests

## Checklist

- [x] Tests added or updated
- [x] No breaking changes (re-exports maintain backward compatibility)
- [x] 1,288 tests pass, 0 fail
- [x] Typecheck clean
- [x] Lint clean (237 files)
- [x] Code review passed (2-axis: 0 hard violations, 0 missing requirements)