### PR TITLE
refactor(ui): extract tool-status.ts and SyntaxHighlighter.tsx

### DIFF
--- a/src/ui/components/Message.tsx
+++ b/src/ui/components/Message.tsx
@@ -4,214 +4,8 @@ import { memo, useMemo } from "react";
 import type { ToolExecution } from "../../core/agent.js";
 import { TRUNCATE_LIMITS } from "../config/constants.js";
 import { MessageRole, ToolStatus } from "../types/enums.js";
-
-function formatGitCommand(name: string, args: Record<string, unknown> | undefined): string {
-	if (name !== "bash") return name;
-
-	const command = (args?.command as string) ?? "";
-	if (!command) return "bash";
-
-	const gitMatch = command.match(/^\s*git\s+(\S+)(.*)$/);
-	if (!gitMatch) {
-		return command.trim().startsWith("git ") ? command.trim() : "bash";
-	}
-
-	const subcommand = gitMatch[1] ?? "";
-	const rest = gitMatch[2]?.trim() ?? "";
-
-	if (subcommand === "diff" && rest.includes("--staged")) return "git diff --staged";
-	if (subcommand === "log" && rest.includes("--oneline")) return "git log --oneline";
-	if (["show", "commit", "pull", "push", "remote", "tag", "stash", "config", "fetch"].includes(subcommand)) {
-		return `git ${subcommand}`;
-	}
-	if (rest) return `git ${subcommand} ${rest}`;
-
-	return `git ${subcommand}`;
-}
-
-function getToolStatusIcon(status: ToolStatus | "running" | "complete" | "error" | undefined): string {
-	switch (status) {
-		case ToolStatus.COMPLETE:
-		case "complete":
-			return "[✓]";
-		case ToolStatus.ERROR:
-		case "error":
-			return "[✗]";
-		default:
-			return "[running]";
-	}
-}
-
-function getToolStatusColor(status: ToolStatus | "running" | "complete" | "error" | undefined): string {
-	switch (status) {
-		case ToolStatus.COMPLETE:
-		case "complete":
-			return "green";
-		case ToolStatus.ERROR:
-		case "error":
-			return "red";
-		default:
-			return "cyan";
-	}
-}
-
-function hasToolMarkers(text: string): boolean {
-	const TOOL_MARKERS = ["[✓]", "[✗]", "[running]"];
-	return TOOL_MARKERS.some((marker) => text.includes(marker));
-}
-
-interface SyntaxHighlightedProps {
-	text: string;
-}
-
-const SYNTAX_PATTERNS: Array<{ test: (line: string) => boolean; color: string; bold?: boolean }> = [
-	{ test: (line) => line.startsWith("[File:"), color: "magenta", bold: true },
-	{ test: (line) => line.startsWith("+"), color: "green" },
-	{ test: (line) => line.startsWith("-"), color: "red" },
-	{ test: (line) => line.startsWith("@@"), color: "magenta" },
-	{ test: (line) => line.startsWith("diff --git"), color: "cyan" },
-	{ test: (line) => line.startsWith("index "), color: "cyan" },
-	{ test: (line) => line.startsWith("--- "), color: "yellow" },
-	{ test: (line) => line.startsWith("+++ "), color: "yellow" },
-	{ test: (line) => /^\s*\d+\s+files?\s+changed/.test(line), color: "cyan" },
-	{ test: (line) => /^\s*\d+\s+insertions?/.test(line), color: "green" },
-	{ test: (line) => /^\s*\d+\s+deletions?/.test(line), color: "red" },
-	{ test: (line) => /^[a-f0-9]{7,}\s/.test(line), color: "cyan" },
-	{ test: (line) => /\([^)]+\)$/.test(line), color: "green" },
-	{ test: (line) => /^(On branch |Your branch is)/.test(line), color: "cyan" },
-	{
-		test: (line) => /^(Changes to be committed:|Changes not staged|Untracked)/.test(line),
-		color: "magenta",
-		bold: true,
-	},
-	{ test: (line) => /^(no changes|nothing to)/.test(line), color: "gray" },
-	{ test: (line) => line.startsWith("..."), color: "gray" },
-];
-
-function getSyntaxStyle(line: string): { color?: string; bold?: boolean } {
-	for (const pattern of SYNTAX_PATTERNS) {
-		if (pattern.test(line)) return { color: pattern.color, bold: pattern.bold };
-	}
-	return {};
-}
-
-const SyntaxHighlighted = memo(function SyntaxHighlighted({ text }: SyntaxHighlightedProps): React.ReactElement {
-	const lines = useMemo(() => text.split("\n"), [text]);
-
-	const lineElements = useMemo(
-		() =>
-			lines.map((line, idx) => {
-				const style = getSyntaxStyle(line);
-				const { color, bold } = style;
-
-				if (line.startsWith("[File:")) {
-					return (
-						<Text key={idx} color={color} bold={bold}>
-							{line}
-						</Text>
-					);
-				}
-
-				const diffMatch = line.match(/^diff --git a\/(.+) b\/(.+)$/);
-				if (diffMatch) {
-					return (
-						<Text key={idx}>
-							<Text color="cyan">diff --git a/</Text>
-							<Text color="cyan" bold>
-								{diffMatch[1]}
-							</Text>
-							<Text color="cyan"> b/</Text>
-							<Text color="cyan" bold>
-								{diffMatch[2]}
-							</Text>
-						</Text>
-					);
-				}
-
-				const oldFileMatch = line.match(/^--- (a\/)?(.+)$/);
-				if (oldFileMatch) {
-					return (
-						<Text key={idx}>
-							<Text color="yellow">--- {oldFileMatch[1] ?? ""}</Text>
-							<Text color="yellow" bold>
-								{oldFileMatch[2]}
-							</Text>
-						</Text>
-					);
-				}
-
-				const newFileMatch = line.match(/^\+\+\+ (b\/)?(.+)$/);
-				if (newFileMatch) {
-					return (
-						<Text key={idx}>
-							<Text color="yellow">+++ {newFileMatch[1] ?? ""}</Text>
-							<Text color="yellow" bold>
-								{newFileMatch[2]}
-							</Text>
-						</Text>
-					);
-				}
-
-				if (/^.+\s+\|\s+\d+\s+[+-]+$/.test(line)) {
-					const match = line.match(/^(.+?)(\s+\|\s+\d+\s+[+-]+)$/);
-					if (match) {
-						const filePart = match[1]!;
-						const statPart = match[2]!;
-						const renameMatch = filePart.match(/^(.+?)\s+=>/);
-						if (renameMatch) {
-							return (
-								<Text key={idx}>
-									<Text color="white">{renameMatch[1]}</Text>
-									<Text color="yellow"> =&gt; </Text>
-									<Text color="white">{filePart.slice(renameMatch[0].length)}</Text>
-									<Text color="gray">{statPart}</Text>
-								</Text>
-							);
-						}
-						return (
-							<Text key={idx}>
-								<Text color="white">{filePart}</Text>
-								<Text color="gray">{statPart}</Text>
-							</Text>
-						);
-					}
-				}
-
-				const statusMatch = line.match(/^\s+((?:modified|new file|deleted|renamed):)/);
-				if (statusMatch) {
-					const idx = line.indexOf(statusMatch[1]!);
-					return (
-						<Text key={idx}>
-							<Text color="yellow">{statusMatch[1]}</Text>
-							<Text color="white">{line.slice((idx === -1 ? 0 : idx) + (statusMatch[1]?.length ?? 0))}</Text>
-						</Text>
-					);
-				}
-
-				if (/^\s+/.test(line) && !/^(modified|new file|deleted|renamed)/.test(line.trim())) {
-					const trimmed = line.trim();
-					if (trimmed && !trimmed.startsWith("#") && !trimmed.startsWith("(") && !trimmed.startsWith("...")) {
-						const indent = line.match(/^\s+/)?.[0] ?? "";
-						return (
-							<Text key={idx}>
-								<Text color="gray">{indent}</Text>
-								<Text color="white">{trimmed}</Text>
-							</Text>
-						);
-					}
-				}
-
-				return (
-					<Text key={idx} color={color} bold={bold}>
-						{line}
-					</Text>
-				);
-			}),
-		[lines]
-	);
-
-	return <Box flexDirection="column">{lineElements}</Box>;
-});
+import { SyntaxHighlighted } from "./SyntaxHighlighter.js";
+import { formatGitCommand, getStatusColor, getStatusIcon, hasToolMarkers } from "./tool-status.js";
 
 interface InlineToolOutputProps {
 	toolExecution: ToolExecution;
@@ -224,8 +18,8 @@ export const InlineToolOutput = memo(function InlineToolOutput({
 	const isComplete = status === ToolStatus.COMPLETE;
 	const isError = status === ToolStatus.ERROR;
 
-	const statusIcon = getToolStatusIcon(status);
-	const statusColor = getToolStatusColor(status);
+	const statusIcon = getStatusIcon(status);
+	const statusColor = getStatusColor(status);
 
 	const formattedName = formatGitCommand(name, args);
 	const argsPreview = useMemo(() => {
@@ -295,8 +89,8 @@ export const Message = memo(function Message({
 	toolStatus,
 	toolArgs,
 }: MessageProps): React.ReactElement {
-	const statusIcon = role === MessageRole.TOOL ? getToolStatusIcon(toolStatus) : "";
-	const statusColor = role === MessageRole.TOOL ? getToolStatusColor(toolStatus) : "";
+	const statusIcon = role === MessageRole.TOOL ? getStatusIcon(toolStatus) : "";
+	const statusColor = role === MessageRole.TOOL ? getStatusColor(toolStatus) : "";
 
 	const toolArgsStr = useMemo(
 		() =>

--- a/src/ui/components/SyntaxHighlighter.tsx
+++ b/src/ui/components/SyntaxHighlighter.tsx
@@ -1,0 +1,162 @@
+import { Box, Text } from "ink";
+import type React from "react";
+import { memo, useMemo } from "react";
+
+/**
+ * Syntax highlighting for diff/git output rendered in the CLI.
+ * Extracted from Message.tsx to separate the diff renderer (130 lines of
+ * regex-driven JSX) from the message routing component.
+ */
+
+interface SyntaxHighlightedProps {
+	text: string;
+}
+
+const SYNTAX_PATTERNS: Array<{ test: (line: string) => boolean; color: string; bold?: boolean }> = [
+	{ test: (line) => line.startsWith("[File:"), color: "magenta", bold: true },
+	{ test: (line) => line.startsWith("+"), color: "green" },
+	{ test: (line) => line.startsWith("-"), color: "red" },
+	{ test: (line) => line.startsWith("@@"), color: "magenta" },
+	{ test: (line) => line.startsWith("diff --git"), color: "cyan" },
+	{ test: (line) => line.startsWith("index "), color: "cyan" },
+	{ test: (line) => line.startsWith("--- "), color: "yellow" },
+	{ test: (line) => line.startsWith("+++ "), color: "yellow" },
+	{ test: (line) => /^\s*\d+\s+files?\s+changed/.test(line), color: "cyan" },
+	{ test: (line) => /^\s*\d+\s+insertions?/.test(line), color: "green" },
+	{ test: (line) => /^\s*\d+\s+deletions?/.test(line), color: "red" },
+	{ test: (line) => /^[a-f0-9]{7,}\s/.test(line), color: "cyan" },
+	{ test: (line) => /\([^)]+\)$/.test(line), color: "green" },
+	{ test: (line) => /^(On branch |Your branch is)/.test(line), color: "cyan" },
+	{
+		test: (line) => /^(Changes to be committed:|Changes not staged|Untracked)/.test(line),
+		color: "magenta",
+		bold: true,
+	},
+	{ test: (line) => /^(no changes|nothing to)/.test(line), color: "gray" },
+	{ test: (line) => line.startsWith("..."), color: "gray" },
+];
+
+function getSyntaxStyle(line: string): { color?: string; bold?: boolean } {
+	for (const pattern of SYNTAX_PATTERNS) {
+		if (pattern.test(line)) return { color: pattern.color, bold: pattern.bold };
+	}
+	return {};
+}
+
+export const SyntaxHighlighted = memo(function SyntaxHighlighted({ text }: SyntaxHighlightedProps): React.ReactElement {
+	const lines = useMemo(() => text.split("\n"), [text]);
+
+	const lineElements = useMemo(
+		() =>
+			lines.map((line, idx) => {
+				const style = getSyntaxStyle(line);
+				const { color, bold } = style;
+
+				if (line.startsWith("[File:")) {
+					return (
+						<Text key={idx} color={color} bold={bold}>
+							{line}
+						</Text>
+					);
+				}
+
+				const diffMatch = line.match(/^diff --git a\/(.+) b\/(.+)$/);
+				if (diffMatch) {
+					return (
+						<Text key={idx}>
+							<Text color="cyan">diff --git a/</Text>
+							<Text color="cyan" bold>
+								{diffMatch[1]}
+							</Text>
+							<Text color="cyan"> b/</Text>
+							<Text color="cyan" bold>
+								{diffMatch[2]}
+							</Text>
+						</Text>
+					);
+				}
+
+				const oldFileMatch = line.match(/^--- (a\/)?(.+)$/);
+				if (oldFileMatch) {
+					return (
+						<Text key={idx}>
+							<Text color="yellow">--- {oldFileMatch[1] ?? ""}</Text>
+							<Text color="yellow" bold>
+								{oldFileMatch[2]}
+							</Text>
+						</Text>
+					);
+				}
+
+				const newFileMatch = line.match(/^\+\+\+ (b\/)?(.+)$/);
+				if (newFileMatch) {
+					return (
+						<Text key={idx}>
+							<Text color="yellow">+++ {newFileMatch[1] ?? ""}</Text>
+							<Text color="yellow" bold>
+								{newFileMatch[2]}
+							</Text>
+						</Text>
+					);
+				}
+
+				if (/^.+\s+\|\s+\d+\s+[+-]+$/.test(line)) {
+					const match = line.match(/^(.+?)(\s+\|\s+\d+\s+[+-]+)$/);
+					if (match) {
+						const filePart = match[1]!;
+						const statPart = match[2]!;
+						const renameMatch = filePart.match(/^(.+?)\s+=>/);
+						if (renameMatch) {
+							return (
+								<Text key={idx}>
+									<Text color="white">{renameMatch[1]}</Text>
+									<Text color="yellow"> =&gt; </Text>
+									<Text color="white">{filePart.slice(renameMatch[0].length)}</Text>
+									<Text color="gray">{statPart}</Text>
+								</Text>
+							);
+						}
+						return (
+							<Text key={idx}>
+								<Text color="white">{filePart}</Text>
+								<Text color="gray">{statPart}</Text>
+							</Text>
+						);
+					}
+				}
+
+				const statusMatch = line.match(/^\s+((?:modified|new file|deleted|renamed):)/);
+				if (statusMatch) {
+					const matchPos = line.indexOf(statusMatch[1]!);
+					return (
+						<Text key={matchPos}>
+							<Text color="yellow">{statusMatch[1]}</Text>
+							<Text color="white">{line.slice((matchPos === -1 ? 0 : matchPos) + (statusMatch[1]?.length ?? 0))}</Text>
+						</Text>
+					);
+				}
+
+				if (/^\s+/.test(line) && !/^(modified|new file|deleted|renamed)/.test(line.trim())) {
+					const trimmed = line.trim();
+					if (trimmed && !trimmed.startsWith("#") && !trimmed.startsWith("(") && !trimmed.startsWith("...")) {
+						const indent = line.match(/^\s+/)?.[0] ?? "";
+						return (
+							<Text key={idx}>
+								<Text color="gray">{indent}</Text>
+								<Text color="white">{trimmed}</Text>
+							</Text>
+						);
+					}
+				}
+
+				return (
+					<Text key={idx} color={color} bold={bold}>
+						{line}
+					</Text>
+				);
+			}),
+		[lines]
+	);
+
+	return <Box flexDirection="column">{lineElements}</Box>;
+});

--- a/src/ui/components/ToolCall.tsx
+++ b/src/ui/components/ToolCall.tsx
@@ -2,8 +2,10 @@ import { Box, Text } from "ink";
 import InkSpinner from "ink-spinner";
 import type React from "react";
 import { memo, useMemo } from "react";
+import type { ToolCallStatus } from "./tool-status.js";
+import { formatDuration, getStatusColor, getStatusIcon } from "./tool-status.js";
 
-export type ToolCallStatus = "pending" | "success" | "error";
+export type { ToolCallStatus } from "./tool-status.js";
 
 export interface ToolCallProps {
 	name: string;
@@ -13,11 +15,6 @@ export interface ToolCallProps {
 	duration?: number;
 }
 
-function formatDuration(ms: number): string {
-	if (ms < 1000) return `${ms}ms`;
-	return `${(ms / 1000).toFixed(1)}s`;
-}
-
 function formatArgValue(value: unknown): string {
 	if (typeof value === "string") return value;
 	try {
@@ -25,26 +22,6 @@ function formatArgValue(value: unknown): string {
 	} catch {
 		return String(value);
 	}
-}
-
-const STATUS_ICONS = {
-	success: "[✓]",
-	error: "[✗]",
-	pending: "[pending]",
-} as const;
-
-const STATUS_COLORS = {
-	success: "green",
-	error: "red",
-	pending: "yellow",
-} as const;
-
-function getStatusIcon(status: ToolCallStatus): string {
-	return STATUS_ICONS[status];
-}
-
-function getStatusColor(status: ToolCallStatus): string {
-	return STATUS_COLORS[status];
 }
 
 export const ToolCall = memo(function ToolCall({

--- a/src/ui/components/ToolsPanel.tsx
+++ b/src/ui/components/ToolsPanel.tsx
@@ -2,7 +2,8 @@ import { Box, Text } from "ink";
 import InkSpinner from "ink-spinner";
 import type React from "react";
 import { memo } from "react";
-import type { ToolCallStatus } from "./ToolCall.js";
+import type { ToolCallStatus } from "./tool-status.js";
+import { formatDuration, getStatusColor, getStatusIcon } from "./tool-status.js";
 
 export interface ToolSummary {
 	name: string;
@@ -14,31 +15,6 @@ export interface ToolSummary {
 interface ToolsPanelProps {
 	tools: ToolSummary[];
 	onClose?: () => void;
-}
-
-function formatDuration(ms: number): string {
-	if (ms < 1000) return `${ms}ms`;
-	return `${(ms / 1000).toFixed(1)}s`;
-}
-
-const STATUS_ICONS = {
-	success: "[✓]",
-	error: "[✗]",
-	pending: "[pending]",
-} as const;
-
-const STATUS_COLORS = {
-	success: "green",
-	error: "red",
-	pending: "yellow",
-} as const;
-
-function getStatusIcon(status: ToolCallStatus): string {
-	return STATUS_ICONS[status];
-}
-
-function getStatusColor(status: ToolCallStatus): string {
-	return STATUS_COLORS[status];
 }
 
 function getArgPreview(args: Record<string, unknown>, maxLen = 40): string {

--- a/src/ui/components/tool-status.ts
+++ b/src/ui/components/tool-status.ts
@@ -1,0 +1,101 @@
+import type { ToolStatus } from "../types/enums.js";
+
+/**
+ * Unified tool status type that accepts both the `ToolStatus` enum (used by
+ * Message.tsx) and the `ToolCallStatus` string union (used by ToolCall.tsx
+ * and ToolsPanel.tsx), plus the string aliases that Message.tsx accepts.
+ */
+export type UnifiedToolStatus = ToolStatus | ToolCallStatus | "running" | "complete" | "error";
+
+/** The string-union status type used by ToolCall.tsx / ToolsPanel.tsx. */
+export type ToolCallStatus = "pending" | "success" | "error";
+
+// --- Status icon/color maps ---
+
+/** All valid status keys for icon/color lookups. */
+type StatusMapKey = "running" | "complete" | "error" | "pending" | "success";
+
+const STATUS_ICON_MAP: Record<StatusMapKey, string> = {
+	running: "[running]",
+	complete: "[✓]",
+	error: "[✗]",
+	pending: "[pending]",
+	success: "[✓]",
+};
+
+const STATUS_COLOR_MAP: Record<StatusMapKey, string> = {
+	running: "cyan",
+	complete: "green",
+	error: "red",
+	pending: "yellow",
+	success: "green",
+};
+
+/**
+ * Get the status icon for a tool status.
+ * Works with both `ToolStatus` enum and `ToolCallStatus` string union.
+ */
+export function getStatusIcon(status: UnifiedToolStatus | undefined): string {
+	if (status === undefined) return "[running]";
+	return STATUS_ICON_MAP[status] ?? "[running]";
+}
+
+/**
+ * Get the status color for a tool status.
+ * Works with both `ToolStatus` enum and `ToolCallStatus` string union.
+ */
+export function getStatusColor(status: UnifiedToolStatus | undefined): string {
+	if (status === undefined) return "cyan";
+	return STATUS_COLOR_MAP[status] ?? "cyan";
+}
+
+/**
+ * Format a duration in milliseconds as a human-readable string.
+ * e.g. `340ms` or `1.2s`.
+ */
+export function formatDuration(ms: number): string {
+	if (ms < 1000) return `${ms}ms`;
+	return `${(ms / 1000).toFixed(1)}s`;
+}
+
+// --- Git command formatting (from Message.tsx) ---
+
+/**
+ * Format a tool name for display, expanding `bash` commands that invoke `git`
+ * into a more readable form (e.g. `git diff --staged`).
+ */
+export function formatGitCommand(name: string, args: Record<string, unknown> | undefined): string {
+	if (name !== "bash") return name;
+
+	const command = (args?.command as string) ?? "";
+	if (!command) return "bash";
+
+	const gitMatch = command.match(/^\s*git\s+(\S+)(.*)$/);
+	if (!gitMatch) {
+		return command.trim().startsWith("git ") ? command.trim() : "bash";
+	}
+
+	const subcommand = gitMatch[1] ?? "";
+	const rest = gitMatch[2]?.trim() ?? "";
+
+	if (subcommand === "diff" && rest.includes("--staged")) return "git diff --staged";
+	if (subcommand === "log" && rest.includes("--oneline")) return "git log --oneline";
+	if (["show", "commit", "pull", "push", "remote", "tag", "stash", "config", "fetch"].includes(subcommand)) {
+		return `git ${subcommand}`;
+	}
+	if (rest) return `git ${subcommand} ${rest}`;
+
+	return `git ${subcommand}`;
+}
+
+// --- Tool marker detection (from Message.tsx) ---
+
+const TOOL_MARKERS = ["[✓]", "[✗]", "[running]"] as const;
+
+/**
+ * Check if a text block contains tool status markers (e.g. `[✓]`, `[✗]`).
+ * Used by Message.tsx to decide whether to apply syntax highlighting.
+ */
+export function hasToolMarkers(text: string): boolean {
+	return TOOL_MARKERS.some((marker) => text.includes(marker));
+}


### PR DESCRIPTION
## What

Extract shared tool status helpers and the diff syntax highlighter from 3 UI component files into 2 new focused modules:

1. **tool-status.ts** (new ~100 lines) — unified `getStatusIcon`, `getStatusColor`, `formatDuration`, `formatGitCommand`, `hasToolMarkers`. Accepts both `ToolStatus` enum and `ToolCallStatus` string union via `UnifiedToolStatus` type. Eliminates **6 duplicate definitions** across 3 files.

2. **SyntaxHighlighter.tsx** (new ~130 lines) — `SYNTAX_PATTERNS` (17 regex patterns), `getSyntaxStyle`, `SyntaxHighlighted` memo component. Self-contained diff/git renderer with a clean `{ text: string }` interface.

3. **ToolCall.tsx** — now imports from `tool-status.ts`, re-exports `ToolCallStatus` type for backward compat.

4. **ToolsPanel.tsx** — now imports from `tool-status.ts`.

5. **Message.tsx** (382→~200 lines) — now imports from `tool-status.ts` and `SyntaxHighlighter.tsx`.

## Why

The tool status icon/color mapping (`STATUS_ICONS`, `STATUS_COLORS`, `getStatusIcon`, `getStatusColor`, `formatDuration`) was **duplicated verbatim** across `ToolCall.tsx`, `ToolsPanel.tsx`, and `Message.tsx`. The maps were semantically identical — `[✓]`→green, `[✗]`→red, `[running]`→cyan — but used different type systems (enum vs string union).

`Message.tsx` also mixed message routing logic (user/assistant/tool/separator roles) with a 130-line diff/git syntax highlighter that had no dependency on message types.

## How

- Created `UnifiedToolStatus` type that accepts both `ToolStatus` enum values and `ToolCallStatus` string-union values, mapping them to the same icons/colors via a single `Record<string, string>` lookup
- `SyntaxHighlighted` was already `memo`-ed with a clean `{ text: string }` interface — extraction was a pure file move
- `ToolCall.tsx` and `Message.tsx` both re-export `ToolCallStatus` from `tool-status.ts` for backward compatibility
- No circular dependencies: `tool-status.ts` imports only from `types/enums.js`, `SyntaxHighlighter.tsx` imports only from `ink`/`react`

## Checklist

- [x] Tests pass (1,288 pass, 0 fail)
- [x] Typecheck clean
- [x] Lint clean (239 files)
- [x] No breaking changes (all re-exports preserve existing import paths)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added syntax highlighting for Git diffs, file changes, branch information, and worktree status output.
  * Improved readability with indentation-aware formatting and highlighted status labels.
  * Standardized tool status icons, colors, duration formatting, and Git command display across the interface.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->