### PR TITLE
docs(adr): add Code Mode design doc (ADR-019)

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,165 +1,72 @@
 # Architecture
 
-## System Overview
-
-Tiny Coding Agent is a CLI-based AI coding assistant built with TypeScript, Bun, and Ink (React for terminal). It follows a layered architecture with clear separation between the agent loop, provider abstraction, tool system, and CLI/UI layers.
+## System Layers
 
 ```
-┌─────────────────────────────────────────────────────┐
-│                    CLI / UI Layer                     │
-│  src/cli/ (main.tsx, command-dispatch, handlers)     │
-│  src/ui/  (Ink React components, hooks, contexts)    │
-├─────────────────────────────────────────────────────┤
-│                   Agent System Layer                   │
-│  src/agents/ (plan, build, explore, state, grammar)   │
-│  src/core/   (agent loop, memory, context, tokens)    │
-├─────────────────────────────────────────────────────┤
-│                  Cross-Cutting Layer                   │
-│  src/providers/  (LLM clients + factory)              │
-│  src/tools/      (tool registry + built-in tools)     │
-│  src/skills/     (skill discovery + loading)          │
-│  src/mcp/        (MCP client + manager)               │
-│  src/hooks/      (lifecycle hooks + presets)          │
-│  src/observability/ (telemetry, logging, cost)        │
-├─────────────────────────────────────────────────────┤
-│                    Config Layer                        │
-│  src/config/ (schema, loader, config-io)              │
-└─────────────────────────────────────────────────────┘
+User (CLI or Chat)
+    │
+    ▼
+┌─────────────────────┐
+│    CLI Layer        │  main.tsx → command-dispatch → handlers
+│  (Ink React UI)     │
+└─────────┬───────────┘
+          │
+┌─────────▼───────────┐
+│   Agent Loop        │  Agent.runStream() → LLM calls → Tool execution
+│  (Core Harness)     │
+└─────────┬───────────┘
+          │
+┌─────────▼───────────┐
+│   Provider Layer    │  LLMClient abstraction — 10+ providers
+│  (API clients)      │
+└─────────┬───────────┘
+          │
+┌─────────▼───────────┐
+│   Tool System       │  ToolRegistry → Bash, File, Search, MCP
+│  (Execution)        │
+└─────────────────────┘
 ```
 
-## Entry Point
+## Key Design Patterns
 
-`index.ts` → `src/cli/index.ts` → `src/cli/main.tsx` → `main()`
+### 1. Provider Abstraction
+- Common `LLMClient` interface in `src/providers/types.ts`
+- `ProviderCache` manages client instances with LRU eviction
+- `ToolDefinition` and `Message` types are shared across providers
+- `detectProvider()` maps model strings to provider implementations
 
-The `main()` function:
-1. Parses CLI args (`src/cli/shared.ts` → `parseArgs()`)
-2. Dispatches pre-config commands (login, logout) before `loadConfig()`
-3. Loads config (`src/config/loader.ts` → `loadConfig()`)
-4. Dispatches the main command via `src/cli/command-dispatch.ts`
+### 2. Agent Loop (runStream)
+- Async generator yielding `AgentStreamChunk` objects
+- Each iteration: stream LLM response → collect tool calls → execute tools → append results → repeat
+- Loop detection via `isLooping()` in agent-utils.ts
+- Context budgeting via `prepareContext()` and `buildContextStats()` in context-budget.ts
+- Skill system prompt augmentation via SkillManager
 
-## Agent Loop (ADR-016 Decomposition)
+### 3. Tool System
+- `ToolRegistry` — central registry with dry-run mode and dangerous-tool confirmation
+- `TurnExecutor` — executes one iteration's tool calls, handles retry/skip/abort
+- Confirmation system for dangerous operations (write, edit, delete, bash-destructive)
+- Tools can be registered statically (file-tools, bash) or dynamically (MCP servers)
 
-The `Agent` class (`src/core/agent.ts`, 738 lines) orchestrates the LLM conversation loop. After ADR-016, it was decomposed into 10 focused modules:
+### 4. Memory System
+- `MemoryStore` — in-memory with file persistence, LRU eviction by count or tokens
+- `SignalHandlerManager` — flushes stores on SIGTERM/SIGINT
+- Memories are injected into context via `prepareContext()` in context-budget.ts
 
-| Module | File | Lines | Responsibility |
-|--------|------|-------|----------------|
-| Agent | `src/core/agent.ts` | 738 | Orchestrator — owns conversation, skills, public interface |
-| TurnExecutor | `src/core/turn-executor.ts` | 236 | One LLM call + tool batch execution |
-| AgentObservability | `src/core/agent-observability.ts` | 326 | Span/timer management, telemetry wrapper |
-| agent-utils | `src/core/agent-utils.ts` | 228 | `streamLlmResponse()`, `streamFinalAnswer()`, `isLooping()` |
-| context-budget | `src/core/context-budget.ts` | 276 | `prepareContext()`, `buildContextStats()` |
-| DebugLogger | `src/core/debug-logger.ts` | 132 | Verbose logging (no-op when disabled) |
-| ProviderCache | `src/core/provider-cache.ts` | 134 | LLM client cache with eviction + health tracking |
-| ConversationManager | `src/core/conversation.ts` | — | Conversation history persistence |
-| MemoryStore | `src/core/memory.ts` | 422 | User-initiated memory storage + retrieval |
-| CodebaseExplorer | `src/agents/codebase-explorer.ts` | 381 | Filesystem exploration for plan/explore agents |
+### 5. CLI / Ink UI
+- `main.tsx` — entry point with command parsing and Ink-based rendering
+- Chat mode uses Ink React components: ChatLayout, MessageList, ModelPicker, etc.
+- `command-dispatch.ts` — centralized command routing
+- Help text in `help-text.ts`
 
-### Agent Loop Flow (`Agent.runStream()`)
+### 6. Hooks System
+- Lifecycle hooks (e.g. plannotator) for pre-build/pre-execute workflows
+- Hook registry and execution in `src/hooks/`
 
-```
-runStream(prompt, model)
-  │
-  ├── await skills initialization
-  ├── observability: beginRequest()
-  ├── prepareContext() → context-budget.ts
-  │     ├── memory retrieval (if enabled)
-  │     └── context window budgeting
-  │
-  └── for each iteration (max 20):
-        ├── streamLlmResponse() → agent-utils.ts
-        │     └── yields content chunks + returns tool calls
-        ├── if no tool calls → yield final answer, return
-        ├── TurnExecutor.executeTurn() → turn-executor.ts
-        │     └── runs tools, returns results + error recovery
-        ├── if loop detected → streamFinalAnswer() → agent-utils.ts
-        └── update context stats
-```
-
-## Multi-Agent System (ADR-011)
-
-Three specialized agents coordinate via a shared state file (`.tiny-state.json`):
-
-| Agent | File | Purpose |
-|-------|------|---------|
-| Plan Agent | `src/agents/plan-agent.ts` | Generates implementation plans from task descriptions |
-| Build Agent | `src/agents/build-agent.ts` | Executes plan steps with tool calls |
-| Explore Agent | `src/agents/explore-agent.ts` | Read-only codebase analysis |
-
-### State Management
-
-- **State File**: `.tiny-state.json` (JSON with file locking + rotation)
-- **Types**: `src/agents/types.ts` — `StateFile`, `AgentPhase`, `AgentStatus`, `AgentResult`
-- **I/O**: `src/agents/state.ts` — `readStateFile()`, `writeStateFile()` with lock files
-- **Plan Grammar**: `src/agents/plan-grammar.ts` — parses plan markdown into phases/steps
-- **Step Execution**: `src/agents/step-executor.ts` — `StepExecutor` class for retry/skip/abort flow
-
-### Agent Communication Flow
-
-```
-planAgent(task) → writes plan to state file
-buildAgent(plan) → reads plan, executes steps, writes results to state file
-exploreAgent(task) → reads codebase, writes findings to state file
-```
-
-## Provider Abstraction (ADR-002)
-
-All LLM providers implement the `LLMClient` interface (`src/providers/types.ts`):
-
-```typescript
-interface LLMClient {
-  chat(params: ChatParams): Promise<ChatResponse>;
-  chatStream(params: ChatParams): AsyncGenerator<string>;
-}
-```
-
-- **Factory**: `createProvider({model, provider, providers})` in `src/providers/factory.ts`
-- **Model Registry**: `detectProvider(model)` in `src/providers/model-registry.ts` — auto-detects provider from model string prefix
-- **9 providers**: OpenAI, Anthropic, Ollama, Ollama Cloud, OpenRouter, OpenCode, Z.AI, ClinePass, QwenCloud
-- **GatewayOpenAIProvider**: Not used (ADR-012 — held back by 30% threshold rule)
-
-## Tool System (ADR-005)
-
-- **Registry**: `ToolRegistry` class in `src/tools/registry.ts` — register, list, execute
-- **Interface**: `Tool` interface in `src/tools/types.ts` — name, description, parameters, execute
-- **Built-in tools**: file operations, bash, grep, glob, web search, skill loading
-- **Plugin loading**: `src/tools/plugin-loader.ts` — dynamically loads tool plugins
-- **Confirmation**: `src/tools/confirmation.ts` — user confirmation for dangerous tools (ADR-009)
-- **MCP tools**: Auto-registered from MCP servers with `mcp_` prefix
-
-## Skill System
-
-- **Discovery**: `discoverSkills(directories, builtinDir)` in `src/skills/loader.ts`
-- **Parsing**: `parseSkillFrontmatter(content)` in `src/skills/parser.ts` — YAML frontmatter
-- **Built-in**: `src/skills/builtin-registry.ts` — embedded skills (code-simplifier)
-- **Loading**: `Agent.loadSkill(name)` — reads file, wraps in XML, restricts tools
-- **Embedded content**: `src/skills/embedded-content.ts` — generated at build time
-
-## Config System
-
-- **Schema**: `src/config/schema.ts` — Zod-validated `Config` interface
-- **Loader**: `src/config/loader.ts` — `loadConfig()`, `getConfigPath()`, `createDefaultConfig()`
-- **Config I/O**: `src/config/config-io.ts` — `readConfigFile()`, `writeConfigFile()` with YAML/JSON dispatch
-- **Location**: `~/.tiny-agent/config.yaml`
-
-## Observability Layer
-
-- **Telemetry**: `src/observability/telemetry.ts` — OpenTelemetry spans + timers
-- **Logging**: `src/observability/logger.ts` — structured JSON logging
-- **Cost**: `src/observability/cost.ts` — token cost estimation
-- **Redaction**: `src/observability/redact.ts` — API key masking
-- **Langfuse**: `src/observability/langfuse.ts` — optional LLM observability platform
-
-## Key ADRs
-
-| ADR | Title | Key Decision |
-|-----|-------|-------------|
-| ADR-001 | Project Architecture | Layered architecture with clear separation |
-| ADR-002 | LLM Provider Abstraction | Unified `LLMClient` interface |
-| ADR-004 | Context Management | Handoff/pickup pattern for context budget |
-| ADR-005 | Tool System Design | Tool interface + registry pattern |
-| ADR-010 | Ink CLI Integration | React-based terminal UI |
-| ADR-011 | Multi-Agent System | Plan/Build/Explore agents with shared state file |
-| ADR-012 | GatewayOpenAIProvider | No shared base class (30% threshold rule) |
-| ADR-014 | Login Command | Top-level command, literal key storage |
-| ADR-015 | Lifecycle Hooks | External command spawning at lifecycle events |
-| ADR-016 | Agent Decomposition | Extract focused modules via deletion test + type-only imports |
+## Module Depth (ADR-016)
+The codebase has undergone 5 rounds of architecture deepening (14 extractions):
+- Agent decomposed into: agent-utils, context-budget, debug-logger, provider-cache, skill-manager, turn-executor, agent-observability
+- CLI decomposed into: command-dispatch, tool-display, chat-command-registry, help-text
+- Login decomposed into: login-shared, login-flow
+- Build decomposed into: plan-converter, step-executor
+- UI extracted: tool-status, SyntaxHighlighter

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,189 +1,45 @@
 # Technical Concerns
 
-## Recently Resolved (PRs #61–#81)
-
-The following extractions were completed between v0.6.0 and v0.7.0, consolidating duplicated patterns into deep modules:
-
-| Module | File | Lines | PR | Eliminates |
-|--------|------|-------|-----|------------|
-| Config I/O | `src/config/config-io.ts` | 87 | #61 | 3-way config read/write duplication |
-| CLI Prompt Helper | `src/cli/prompt.ts` | — | #62 | 3-way readline duplication |
-| TurnExecutor | `src/core/turn-executor.ts` | 236 | #63 | Tool dispatch from `runStream()` |
-| createAgent factory | `src/cli/shared.ts` | — | #64 | Duplicated agent construction in CLI |
-| StepExecutor | `src/agents/step-executor.ts` | 217 | #65 | Build-agent step execution logic |
-| AgentObservability | `src/core/agent-observability.ts` | 326 | #71 | 46 cross-cutting telemetry calls |
-| streamLlmResponse | `src/core/agent-utils.ts` | 228 | #74 | Duplicate stream pattern |
-| streamFinalAnswer | `src/core/agent-utils.ts` | — | #74 | Loop-detection final-answer block |
-| ContextBudget | `src/core/context-budget.ts` | 276 | #72, #77 | Context budgeting from `memory.ts` |
-| CommandDispatcher | `src/cli/command-dispatch.ts` | 265 | #72 | CLI command dispatch table from `main.tsx` |
-| CodebaseExplorer | `src/agents/codebase-explorer.ts` | 381 | — | 4 duplicate `ToolRegistry` instances |
-| ChatCommandRegistry | `src/ui/chat-command-registry.ts` | 77 | #76 | 12-case switch in `useCommandHandler` |
-| DebugLogger | `src/core/debug-logger.ts` | 132 | #78 | 6 verbose-logging blocks from `runStream()` |
-| ProviderCache | `src/core/provider-cache.ts` | 134 | #80 | Provider instance caching from `Agent` |
-| StateManager | `src/agents/state-manager.ts` | 198 | #81 | 19 state I/O calls across 7 modules |
-| createAgentClient | `src/agents/agent-client.ts` | 50 | #81 | 3-way `loadConfig→parseModelString→createProvider` duplication |
-| SkillManager | `src/core/skill-manager.ts` | 158 | #82 | 4 skill fields + 8 methods from Agent |
-| ToolDisplay | `src/cli/tool-display.tsx` | 156 | #82 | ~120 lines of display utilities from main.tsx |
-| loadOrFail() | `src/agents/state-manager.ts` | — | #82 | Double-read pattern in 3 CLI handlers |
-
-## Tech Debt
-
-### 1. `agent.ts` Still 652 Lines After Decomposition
-
-**File**: `src/core/agent.ts` (652 lines)
-**Severity**: Low
-**Status**: Improving (was 1,173 lines before ADR-016 extraction, now 652 after SkillManager extraction)
-
-After extracting 12 modules (TurnExecutor, AgentObservability, DebugLogger, ProviderCache, context-budget, agent-utils, SkillManager, ToolDisplay, etc.), `agent.ts` dropped from 1,173 → 652 lines. The skill management concern was extracted into `SkillManager` (`src/core/skill-manager.ts`, 158 lines). Remaining concerns in agent.ts: the agent loop, conversation management, memory, and the public interface — all cohesive.
-
-### 2. `login.ts` Has 16 `process.exit()` Calls
-
-**File**: `src/cli/handlers/login.ts` (604 lines)
-**Severity**: Medium
-**Status**: Documented in ADR-014
-
-The interactive login/logout flows call `process.exit()` 16 times, making them untestable without spawning a process. The pure functions (`applyProviderToConfig`, `removeApiKeyFromConfig`, `formatProviderStatus`) are well-extracted and tested, but the interactive flows (`loginProvider`, `logoutProvider`, `loginInteractive`, `logoutInteractive`) are not unit-testable.
-
-### 3. `useCommandHandler.ts` 458 Lines with Inline Command Handlers
-
-**File**: `src/ui/hooks/useCommandHandler.ts` (458 lines)
-**Severity**: Low
-**Status**: Partially refactored (ChatCommandRegistry extracted)
-
-The `handleCommand` dispatcher was extracted into `chat-command-registry.ts` (77 lines), but the individual command handlers (`handleSkillCommand`, `handlePlanCommand`, `handleReviewCommand`, etc.) are still inline `useCallback` functions within the hook. Each handler is 30-80 lines of `onAddMessage` + `readStateFile` + business logic.
-
-### 4. `main.tsx` Still Mixes CLI Entry Point + Streaming Loop
-
-**File**: `src/cli/main.tsx` (405 lines)
-**Severity**: Low
-**Status**: Improving (ToolDisplay extracted — was 541 lines)
-
-`main.tsx` now mixes 2 concerns (down from 3): (1) CLI entry-point orchestration (`main()`, arg parsing), and (2) the `handleRun` streaming loop. Tool display formatting (`ThinkingTagFilter`, `formatArgs`, `displayToolExecution`, `outputJson`) was extracted into `src/cli/tool-display.tsx` (156 lines). The remaining streaming loop in `handleRun` is ~90 lines and tightly coupled to the CLI entry point — further extraction would require a `RunHandler` abstraction, which is speculative at this point.
-
-### 5. State File I/O — Resolved by `loadOrFail()`
-
-**Files**: `src/cli/handlers/plan.ts`, `src/cli/handlers/agent.ts`, `src/ui/hooks/useCommandHandler.ts`
-**Severity**: Resolved
-**Status**: Merged (PR #82) — `loadOrFail()` eliminates double-read
-
-The `StateManager` class (`src/agents/state-manager.ts`, 198 lines) consolidates 19 state I/O calls across 7 modules. The `loadOrFail()` method returns a discriminated union (`{ success: true, state } | { success: false, error, code }`) that lets CLI handlers replace the double-read pattern (`readStateFile()` check + `loadOrCreate()`) with a single call. Error messages preserved for backward compatibility. The `_state` unused variable (concern #6) was also eliminated — `loadOrFail()` returns the result inline.
-
-### 6. ~~`_state` Unused Variable in useCommandHandler.ts~~ — Resolved
-
-**Status**: Resolved by `loadOrFail()` extraction (PR #82)
-
-The unused `const _state = await mgr.loadOrCreate()` was eliminated when `loadOrFail()` replaced the double-read pattern. The variable is no longer present.
-
-## Next Deepening Opportunities (Architecture Review Round 4)
-
-| # | Candidate | Strength | Status | Target |
-|---|-----------|----------|--------|--------|
-| 1 | Extract SkillManager from Agent | Strong | ✅ Done (#82) | `agent.ts` 738→652 |
-| 2 | Extract Tool Display from `main.tsx` | Strong | ✅ Done (#82) | `main.tsx` 541→405 |
-| 3 | Extract Login Flow Controller from `login.ts` | Worth exploring | Design validated (grilling) | `login.ts` 604→~100 |
-| 4 | Extract Command Handlers from `useCommandHandler` | Worth exploring | Not started | 452→~150 |
-| 5 | Add `loadOrFail()` to StateManager | Quick win | ✅ Done (#82) | Eliminates double-read |
-
-**Next candidates**: #3 (Login Flow Controller — design validated, ready to implement) → #4 (Command Handlers extraction)
-
-**Note**: The codebase has only 1 `TODO` comment in `src/` (a display label in `useCommandHandler.ts`, not a tech debt marker). No `FIXME`, `HACK`, or `XXX` markers exist.
-
-## Security
-
-### API Key Storage
-
-**Status**: Documented in ADR-014
-**Risk**: Low (mitigated)
-
-API keys are stored literally in `~/.tiny-agent/config.yaml` with `0o600` file permissions. The login flow suggests using environment variables (`${VAR_NAME}` syntax) as a more secure alternative. The config loader resolves env-var references at load time.
-
-### Command Injection Prevention
-
-**Files**: `test/security/command-injection.test.ts`, `test/security/bash-env.test.ts`
-**Status**: Tested
-
-The bash tool has security tests for command injection prevention and environment variable sanitization. The `src/tools/bash-tool.ts` implementation includes validation and confirmation prompts (ADR-009).
-
-### Path Traversal Prevention
-
-**Files**: `test/security/file-validation.test.ts`
-**Status**: Tested
-
-File tools validate paths to prevent directory traversal attacks. The `src/tools/gitignore.ts` module respects `.gitignore` patterns.
-
-### API Key Redaction in Logs
-
-**File**: `src/observability/redact.ts`
-**Status**: Tested
-
-API keys are redacted in structured logs and telemetry. The `redactApiKey()` function masks keys as `XXXX...REDACTED`.
-
-## Performance
-
-### Token Counting Overhead
-
-**File**: `src/core/tokens.ts`
-**Impact**: Low
-
-Token counting via `tiktoken` is used for context budgeting. The `prepareContext()` function in `src/core/context-budget.ts` counts tokens for system prompt, memory, and conversation messages to fit within the context window. This is done once per `runStream()` call, not per chunk.
-
-### State File I/O Double-Read
-
-**Files**: `src/cli/handlers/plan.ts`, `src/cli/handlers/agent.ts`, `src/ui/hooks/useCommandHandler.ts`
-**Impact**: Negligible
-
-CLI handlers read the state file twice: once for the existence check (`readStateFile()`) and once via `StateManager.loadOrCreate()` (which calls `readStateFile()` internally). This is a trade-off for preserving error messages. The state file is small JSON (~1-10 KB), so the overhead is negligible.
-
-### Provider Cache Eviction
-
-**File**: `src/core/provider-cache.ts`
-**Impact**: Low
-
-The `ProviderCache` has a max size with LRU eviction (default configurable). Cache hits avoid re-creating LLM clients for the same provider. The `_evictOldest()` method removes the least recently used client when the cache is full.
-
-## Fragile Areas
-
-### Plan Grammar Parser
-
-**File**: `src/agents/plan-grammar.ts` (437 lines)
-**Risk**: Medium
-
-The plan grammar parser uses regex-based parsing to extract phases and steps from markdown plan text. It supports two shapes (phase-form and flat-form) and has legacy sub-bullet handling in `buildFlatFormSteps()`. Changes to the plan format require updating both the parser and the `planToBuildSteps()` converter in `build-agent.ts`.
-
-### Ink CLI Rendering
-
-**Files**: `src/ui/` (all components)
-**Risk**: Low
-
-The UI uses Ink (React for terminal). Components are tested via `test/cli/main.test.tsx` but Ink rendering is inherently terminal-dependent. The `ThinkingTagFilter` class in `main.tsx` filters `<thinking>` tags from streaming content and has edge cases with partial tag boundaries.
-
-### Embedded Skills Generation
-
-**File**: `src/skills/embedded-content.ts` (generated)
-**Risk**: Low
-
-This file is generated at build time by `scripts/generate-embedded-skills.ts` and excluded from linting. Changes to skill content require regenerating this file via `bun run generate:skills`.
-
-### Model Registry Provider Detection
-
-**File**: `src/providers/model-registry.ts`
-**Risk**: Low
-
-The `detectProvider()` function maps model string prefixes to provider types. Adding a new provider requires updating the registry patterns. The ClinePass provider (ADR-013) uses live model lookup from `baseUrl` as an alternative to static registry patterns.
-
-## Missing Features / Gaps
-
-### No Coverage Thresholds
-
-The project has 1,288 tests across 80 files but no configured coverage thresholds. Coverage depends on the test-per-module pattern rather than measured line/branch coverage.
-
-### No E2E Browser Testing
-
-The CLI is terminal-based (Ink), so there are no browser tests. The `test/e2e/agent-loop.test.ts` file tests the agent loop end-to-end with a mock LLM client.
-
-### `generateBuildActionsFromPlan` Uses LLM for JSON Parsing
-
-**File**: `src/agents/build-agent.ts` (function `generateBuildActionsFromPlan`)
-**Risk**: Low
-
-This function asks the LLM to generate build actions as JSON, then parses the response with a regex match (`content.match(/\[[\s\S]*\]/)`) and `JSON.parse()`. If the LLM returns malformed JSON, the function silently returns an empty array. This is a known limitation of LLM-based code generation.
+## Pre-existing Test Failures (~66)
+Environment-dependent failures across security sandbox, shell env filtering, config override, and explore agent tests. These fail on clean `main` and are not caused by recent changes. See `TESTING.md` for categories.
+
+## Largest Source Files (Round 6 candidates)
+| File | Lines | Concern |
+|------|-------|---------|
+| `src/core/agent.ts` | 643 | Still largest despite 5 rounds of extraction |
+| `src/ui/hooks/useCommandHandler.ts` | 450 | ChatCommandRegistry extracted, handler logic remains |
+| `src/tools/file-tools.ts` | 449 | Multi-tool module, untested areas |
+| `src/agents/plan-grammar.ts` | 437 | Grammar parser/validator — untouched |
+| `src/core/memory.ts` | 422 | SignalHandlerManager extracted, still 422 lines |
+| `src/ui/components/ModelPicker.tsx` | 380 | ~200 lines static model data mixed with logic |
+| `src/providers/anthropic.ts` | 370 | Provider implementation |
+
+## Typecheck Issue
+- `error TS2688: Cannot find type definition file for '@types/bun'` — pre-existing on this machine. `@types/bun` not resolved correctly. Does not affect CI.
+
+## Biome Config Staleness
+- `biome.json` uses schema `2.3.12` but CLI is `2.5.4` — 2 pre-existing infos on every run
+- The `recommended` linter field is deprecated; should migrate to `preset`
+- Run `biome migrate` to fix
+
+## Architecture Debt (Resolved)
+- ✅ Agent.ts decomposed from 950→643 lines (Rounds 1-5)
+- ✅ main.tsx decomposed from 541→288 lines
+- ✅ login.ts decomposed from 604→~100 lines
+- ✅ tool status helpers unified across 3 files
+- ✅ plan parsing extracted from build-agent.ts
+- ✅ Syntax highlighting extracted from Message.tsx
+- ⏳ signal-handler-manager.ts (PR #87, draft — last Round 5 extraction pending merge)
+
+## ByteByteGo Optimization Opportunities (Issue #86)
+- ✅ **Stable prompt prefix** — tools sorted alphabetically (commit `939207d`)
+- 🔲 **Incremental context** — send only new tool output + response ID
+- 🔲 **Deferred tool discovery** — lazy MCP tool registration
+- 🔲 **Code mode** — parallel tool execution via model-written JS
+
+## Single TODO in Source
+```
+src/ui/hooks/useCommandHandler.ts:194
+`**TODO** (${pendingSteps.length} pending)\n\n${todoList}`
+```
+This is a feature TODO display in the chat UI, not a code debt item.

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,232 +1,53 @@
 # Coding Conventions
 
 ## Imports & Naming
+- **Node built-ins**: `import * as fs from "node:fs/promises"` (with `node:` prefix)
+- **External deps**: `import OpenAI from "openai"`
+- **Internal modules**: `import type { Tool } from "./types.js"` (with `.js` extension)
+- **Type-only imports**: Use `import type { ... }` explicitly (required by `verbatimModuleSyntax`)
+- **Files**: kebab-case (`file-tools.ts`, `signal-handler-manager.ts`)
+- **Types/Classes**: PascalCase (`MemoryStore`, `ToolRegistry`, `BuildStep`)
+- **Variables/Functions**: camelCase (`getStatusIcon`, `parsePlanToSteps`)
+- **Constants**: SCREAMING_SNAKE_CASE (`SAVE_DEBOUNCE_MS`, `STATUS_ICON_MAP`)
+- **Private members**: `_prefix` (`_memories`, `_saveTimeout`)
 
-```typescript
-import * as fs from "node:fs/promises"; // Node builtins with node: prefix
-import OpenAI from "openai"; // External deps
-import type { Tool } from "./types.js"; // Internal: .js extension, type-only with `import type`
-import { ToolRegistry } from "@/tools/registry.js"; // Path alias @/* → ./src/*
-```
+## Strings & Values
+- **Double quotes** for strings (`"text"`)
+- **`let`** only when reassigning; prefer `const`
+- **`??`** for nullish coalescing defaults (`options.timeout ?? 60000`)
 
-### Naming Rules
-
-| Category | Convention | Example |
-|----------|-----------|---------|
-| Files | kebab-case | `file-tools.ts`, `agent-observability.ts` |
-| Classes/Types/Interfaces | PascalCase | `ToolRegistry`, `StateManager`, `LLMClient` |
-| Functions/Variables | camelCase | `loadConfig`, `createProvider` |
-| Constants | SCREAMING_SNAKE_CASE | `DEFAULT_STATE_FILE`, `MAX_STATE_FILE_SIZE` |
-| Private members | `_prefix` | `_providerCache`, `_toolRegistry` |
-| Enum values | PascalCase | `MessageRole.ASSISTANT`, `StatusType.READY` |
-
-### TypeScript Rules (enforced by tsconfig)
-
-- `strict: true` — strict mode
-- `verbatimModuleSyntax` — requires explicit `import type` for types
-- `noUncheckedIndexedAccess` — accessing indexed types requires validation
-- `noImplicitOverride` — override methods must use `override` keyword
-- `let` only when reassigning; `const` by default
-- `??` for nullish coalescing defaults (not `||`)
-
-## Strings & Quotes
-
-```typescript
-const message = "text"; // Double quotes (enforced by Biome)
-const timeout = args.timeout ?? 60000; // ?? for nullish defaults
-```
+## React / Ink
+- Function components with TypeScript interfaces for props
+- `memo` for performance-sensitive components
+- Avoid class components
+- Prefer hooks for stateful logic
 
 ## Error Handling
-
-Return structured results, never throw for expected failures:
-
-```typescript
-// ✅ Correct — structured result
-async function fetchData(url: string): Promise<Result<Data>> {
-  try {
-    const response = await fetch(url);
-    if (!response.ok) return { success: false, error: `HTTP ${response.status}` };
-    return { success: true, data: await response.json() };
-  } catch (err) {
-    return { success: false, error: (err as Error).message };
-  }
-}
-
-// ❌ Wrong — throwing for expected failure
-async function fetchData(url: string): Promise<Data> {
-  const response = await fetch(url);
-  if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  return response.json();
-}
-```
-
-### Error Codes
-
-Use specific `NodeJS.ErrnoException` codes: `ENOENT`, `EACCES`, `EISDIR`, `ENOTDIR`.
-
-```typescript
-try {
-  await fs.readFile(filePath, "utf-8");
-} catch (err) {
-  const error = err as NodeJS.ErrnoException;
-  if (error.code === "ENOENT") {
-    return { success: false, error: `File not found: ${filePath}` };
-  }
-  return { success: false, error: error.message };
-}
-```
-
-## React & JSX (Ink CLI)
-
-The project uses Ink (React for CLI) for terminal UI components.
-
-```typescript
-import React from "react";
-import { Box, Text } from "ink";
-
-interface Props {
-  message: string;
-}
-
-export const Message: React.FC<Props> = ({ message }) => (
-  <Box><Text>{message}</Text></Box>
-);
-```
-
-- Function components with TypeScript interfaces for props
-- No class components
-- Hooks: `useCallback`, `useContext`, `useState`
-- Context providers: `ChatContext`, `StatusLineContext`, `ToastContext`
+- Return structured results, never throw for expected failures:
+  ```typescript
+  return { success: false, error: `File not found: ${filePath}` };
+  ```
+- Use specific error codes: `ENOENT`, `EACCES`, `EISDIR`, `ENOTDIR`
 
 ## Async Patterns
-
-```typescript
-async function fetchData(url: string): Promise<Result<Data>> {
-  try {
-    const response = await fetch(url);
-    if (!response.ok) return { success: false, error: `HTTP ${response.status}` };
-    return { success: true, data: await response.json() };
-  } catch (err) {
-    return { success: false, error: (err as Error).message };
-  }
-}
-```
-
-### Async Generators (Streaming)
-
-The agent loop uses `while(true) + gen.next()` (not `for-await`) to access the generator's return value:
-
-```typescript
-const streamGen = streamLlmResponse({ ... });
-while (true) {
-  const { value, done } = await streamGen.next();
-  if (done) {
-    const result = value as StreamLlmResult;
-    break;
-  }
-  // value is a content string
-  yield { content: value, ... };
-}
-```
-
-## Validation (Zod)
-
-Runtime validation for configs and tool inputs:
-
-```typescript
-import { z } from "zod";
-
-export const providerConfigSchema = z.object({
-  apiKey: z.string().optional(),
-  baseUrl: z.string().optional(),
-});
-
-export const configSchema = z.object({
-  defaultModel: z.string(),
-  providers: z.record(z.string(), providerConfigSchema).optional(),
-  // ...
-});
-```
-
-- Use `satisfies` for type narrowing with validation
-- Config validated on load via `validateConfig()`
-
-## Module Decomposition Pattern (ADR-016)
-
-When extracting modules from a monolith:
-
-1. **Deletion test** — would deleting the module concentrate complexity, or just move it?
-2. **Type-only imports** — use `import type` to break circular dependencies
-3. **Re-exports** for backward compatibility — `export { X } from "./new-module.js"`
-4. **No-op pattern** for optional features — `DebugLogger`/`AgentObservability` have zero overhead when disabled
-
-```typescript
-// Re-export for backward compatibility
-export { isLooping, streamLlmResponse } from "./agent-utils.js";
-export type { ProviderConfigs } from "./provider-cache.js";
-```
+- Use `async/await` throughout
+- Prefer `Promise.all` for concurrent operations
+- Generator-based streaming with `async function*`
 
 ## Tidying Practices
+- **Guard clauses**: Move preconditions to top, return early
+- **Helper variables**: Extract complex expressions
+- **Dead code**: Delete unused code
+- **Normalize symmetries**: Use consistent patterns
 
-- **Guard Clauses**: Move preconditions to top, return early
-- **Helper Variables**: Extract complex expressions
-- **Dead Code**: Delete unused code
-- **Normalize Symmetries**: Use consistent patterns across similar modules
+## Module Decomposition (ADR-016)
+- Extract well-defined concerns into their own modules
+- Use type-only imports to break circular dependencies
+- Re-export types/functions from original module for backward compatibility
+- Prefer mechanical extraction over design refactoring
 
-## Linting & Formatting (Biome)
-
-| Setting | Value |
-|---------|-------|
-| Indentation | Tabs (width 2) |
-| Line width | 120 characters |
-| Quotes | Double |
-| Semicolons | Enabled |
-| Trailing commas | ES5 |
-| Import organization | Automatic |
-
-### Disabled Rules
-
-- `noNonNullAssertion` — non-null assertions (`!`) allowed
-- `noNonNullAssertedOptionalChain` — `?.` + `!` allowed
-- `noArrayIndexKey` — array index as key allowed
-- `noAssignInExpressions` — assignment in expressions allowed
-
-## Git Conventions
-
-### Commit Messages (Commitizen)
-
-```
-<type>(<scope>): <subject>
-
-[optional body]
-
-[optional footer]
-```
-
-Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert`
-
-### Pre-commit Hooks (Husky)
-
-- Runs `bun run lint` and `bun run format` before commit
-- Version generation + embedded skills regeneration on commit
-
-## Configuration File Format
-
-```yaml
-# ~/.tiny-agent/config.yaml
-defaultModel: openai/gpt-4o
-providers:
-  openai:
-    apiKey: ${OPENAI_API_KEY}  # env-var reference (recommended)
-  ollama:
-    baseUrl: http://localhost:11434
-memoryFile: ~/.tiny-agent/memories.json
-maxContextTokens: 32000
-hooks:
-  - name: plannotator-review
-    event: post-plan-generate
-    command: plannotator
-    args: ["--review"]
-    inputMode: stdin
-    enabled: true
-```
+## Testing
+- Framework: `bun:test` with `describe`, `it`, `expect`
+- Test files co-located or in `test/` mirroring `src/` structure
+- Clean up resources in `beforeEach`/`afterEach`
+- Test behavior, not implementation details

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,137 +1,44 @@
 # External Integrations
 
 ## LLM Providers
+| Provider | Package | Auth Method |
+|----------|---------|-------------|
+| **OpenAI** | `openai` | API key |
+| **Anthropic** | `@anthropic-ai/sdk` | API key |
+| **Ollama** | `ollama` | Local (no auth) |
+| **Ollama Cloud** | `openai` SDK | API key |
+| **OpenRouter** | `openai` SDK | API key |
+| **OpenCode** | Custom protocol | API token |
+| **Zai (Zhipu AI)** | `openai` SDK | API key |
+| **QwenCloud** | `openai` SDK | API key |
+| **ClinePass** | `openai` SDK | API key |
 
-The agent supports multiple LLM providers through a unified `LLMClient` interface (`src/providers/types.ts`). Provider selection is automatic via model-string prefix detection (`src/providers/model-registry.ts`).
+All providers are abstracted behind a common `LLMClient` interface in `src/providers/types.ts`. New providers implement this interface.
 
-| Provider | Key | File | API Key Env Var | Default Model |
-|----------|-----|------|-----------------|---------------|
-| OpenAI | `openai` | `src/providers/openai.ts` | `OPENAI_API_KEY` | `gpt-4o` |
-| Anthropic | `anthropic` | `src/providers/anthropic.ts` | `ANTHROPIC_API_KEY` | `claude-sonnet-4-20250514` |
-| Ollama (Local) | `ollama` | `src/providers/ollama.ts` | — (no key) | `qwen3-coder` |
-| Ollama (Cloud) | `ollamaCloud` | `src/providers/ollama-cloud.ts` | `OLLAMA_CLOUD_API_KEY` | `gpt-oss:120b-cloud` |
-| OpenRouter | `openrouter` | `src/providers/openrouter.ts` | `OPENROUTER_API_KEY` | `openrouter/openai/gpt-4o` |
-| OpenCode | `opencode` | `src/providers/opencode.ts` | `OPENCODE_API_KEY` | `opencode/big-pickle` |
-| Z.AI (Zhipu) | `zai` | `src/providers/zai.ts` | `ZAI_API_KEY` | `glm-4.7` |
-| ClinePass | `clinepass` | `src/providers/clinepass.ts` | `CLINE_API_KEY` | `cline-pass/glm-5.2` |
-| QwenCloud | `qwencloud` | `src/providers/qwencloud.ts` | `QWENCLOUD_API_KEY` | `qw/glm-5.2` |
-
-### Provider Architecture
-
-- **Factory**: `src/providers/factory.ts` — `createProvider({model, provider, providers})` returns `LLMClient`
-- **Model Registry**: `src/providers/model-registry.ts` — `detectProvider(model)` maps model strings to provider types
-- **Capabilities**: `src/providers/capabilities.ts` — checks model features (thinking, tools, context window)
-- **Models.dev**: `src/providers/models-dev.ts` — fetches live model metadata from models.dev
-- **OpenAI Protocol**: `src/providers/openai-protocol.ts` — shared base for OpenAI-compatible providers
-
-### Provider Onboarding
-
-- `tiny-agent login` — interactive provider picker (`src/cli/handlers/login.ts`)
-- `tiny-agent login <provider>` — direct provider configuration
-- `tiny-agent login status` — show connection status
-- `tiny-agent logout <provider>` — remove API key from config
-- Config stored at `~/.tiny-agent/config.yaml` with literal key + env-var tip (ADR-014)
+## Model Registry
+- Models are registered in `src/providers/model-registry.ts`
+- Live provider lookup via `src/providers/clinepass.ts` (models.dev API)
+- Capability detection in `src/providers/capabilities.ts`
+- Device-specific models in `src/providers/models-dev.ts`
 
 ## MCP (Model Context Protocol)
+- Client: `@modelcontextprotocol/sdk` ^1.25.2
+- Manager: `src/mcp/manager.ts`
+- Supports stdio transport for local MCP servers
+- MCP servers provide dynamically registered tools
 
-External tool servers connected via the Model Context Protocol.
+## Observability (Optional)
+- **OpenTelemetry**: `@opentelemetry/api` + `@opentelemetry/sdk-trace-base`
+- **Langfuse**: Optional integration via `langfuse` package
+- Observability wrapper: `src/observability/`
 
-| Component | File | Purpose |
-|-----------|------|---------|
-| Manager | `src/mcp/manager.ts` | Server lifecycle, tool registration, globToRegex pattern matching |
-| Client | `src/mcp/client.ts` | MCP protocol client (stdio transport) |
-| Types | `src/mcp/types.ts` | `McpToolDefinition`, `McpToolCallResult`, `McpConnection` |
+## Configuration
+- User config: `~/.tiny-agent/config.yaml`
+- Config loaded via `src/config/loader.ts`
+- Schema validated with `zod`
 
-### Configuration
-
-```yaml
-mcpServers:
-  server-name:
-    command: "npx"
-    args: ["-y", "@some/mcp-server"]
-    enabled: true
-```
-
-- Servers defined in `config.yaml` under `mcpServers`
-- Tools auto-registered into the `ToolRegistry` with `mcp_` prefix
-- `disabledMcpPatterns` config option for filtering MCP tools by glob pattern
-- Server status shown via `tiny-agent status` and `/mcp` chat command
-
-## Lifecycle Hooks
-
-External commands triggered at lifecycle events (ADR-015).
-
-| Component | File | Purpose |
-|-----------|------|---------|
-| Types | `src/hooks/types.ts` | `HookConfig`, `HookEvent`, `HookRegistry` |
-| Manager | `src/hooks/manager.ts` | `buildRegistry()`, `runHooks()`, `hasHooks()` |
-| Presets | `src/hooks/presets.ts` | `PLANNOTATOR_PRESET`, `findPreset()`, `listPresetIds()` |
-| CLI Handler | `src/cli/handlers/hooks.ts` | `tiny-agent hooks list/install/enable/disable/remove` |
-
-### Hook Events
-
-| Event | Triggered After | Input |
-|-------|-----------------|-------|
-| `post-plan-generate` | Plan agent generates a plan | Plan content + task description |
-| `pre-build-execute` | Build agent starts executing | Plan content + state file path |
-| `post-build-execute` | Build agent finishes | Build results |
-
-### Plannotator Preset
-
-The built-in `plannotator` preset (`src/hooks/presets.ts`) installs two hooks:
-- `post-plan-generate` — review plan content
-- `pre-build-execute` — review build plan before execution
-
-Install: `tiny-agent hooks install plannotator`
-
-### Hook Configuration
-
-```yaml
-hooks:
-  - name: my-review-hook
-    event: post-plan-generate
-    command: ./review.sh
-    args: ["--plan"]
-    inputMode: stdin
-    enabled: true
-    timeoutMs: 0
-    applyModifications: true
-```
-
-## Web Search
-
-| Component | File | Purpose |
-|-----------|------|---------|
-| Web Search Tool | `src/tools/web-search-tool.ts` | Tool definition for LLM-initiated web search |
-| DuckDuckGo Provider | `src/tools/search-providers/duckduckgo.ts` | DuckDuckGo HTML scraping search backend |
-| Search Provider Interface | `src/tools/search-providers/provider.ts` | `SearchProvider` interface |
-| Search Tools | `src/tools/search-tools.ts` | `grep` and `glob` file search tools |
-
-## Observability / Telemetry
-
-### OpenTelemetry
-
-- **SDK**: `@opentelemetry/api` + `@opentelemetry/sdk-trace-base`
-- **Implementation**: `src/observability/telemetry.ts` — span creation, attribute setting, exporter management
-- **Spans**: `llm.request`, `retrieval`, `tool.execution`, `http.request`
-- **Console exporter**: `NoopSpanExporter` for disabled mode (no network overhead)
-
-### Langfuse (Optional)
-
-- **Package**: `langfuse` (optional dependency)
-- **Implementation**: `src/observability/langfuse.ts`
-- **Purpose**: LLM-specific observability with cost tracking
-- **Enabled when**: `config.observability.langfuseEnabled` is true
-
-### Structured Logging
-
-- **Implementation**: `src/observability/logger.ts`
-- **Events**: `request.start`, `request.end`, `retrieval`, `llm.request`
-- **Output**: JSON to stdout (for programmatic consumption) or console
-- **Redaction**: `src/observability/redact.ts` — masks API keys in logs
-
-### Cost Estimation
-
-- **Implementation**: `src/observability/cost.ts`, `src/observability/pricing.ts`
-- **Data**: `src/observability/model-pricing.json` — per-model token pricing
-- **Output**: `CostEstimate` with input/output token costs
+## Tools
+- **Bash**: Local shell execution via `src/tools/bash-tool.ts`
+- **File operations**: read, write, edit, delete, glob, grep via `src/tools/file-tools.ts` and `src/tools/search-tools.ts`
+- **Web search**: DuckDuckGo integration via `src/tools/web-search-tool.ts`
+- **SKILL.md**: Skill discovery from directories and built-in registry

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,142 +1,57 @@
 # Technology Stack
 
-## Languages & Runtime
+## Language & Runtime
+- **Language:** TypeScript 5+ (strict mode)
+- **Runtime:** Bun (v1.x) — JavaScript runtime, bundler, test runner
+- **Module system:** ESM (`"type": "module"` in package.json)
 
-| Property | Value |
-|----------|-------|
-| Language | TypeScript 5+ (strict mode) |
-| Runtime | Bun (latest) |
-| Module system | ES modules (`"type": "module"`) |
-| Target | ESNext |
-| Module resolution | NodeNext |
-| JSX | react-jsx (Ink CLI components) |
-| Package manager | Bun (bun.lock) |
-| Version | 0.6.0 |
+## Core Dependencies
+| Dependency | Purpose |
+|------------|---------|
+| `ink` ^7.1.1 | React for CLI — UI rendering |
+| `react` ^19.2.3 | UI component model |
+| `zod` ^4.0.0 | Runtime validation of configs and inputs |
+| `yaml` ^2.8.2 | Config file parsing |
+| `tiktoken` ^1.0.15 | Token counting |
+| `@tokenlens/models` ^1.3.0 | Model token limits |
+| `@opentelemetry/api` ^1.9.1 | Observability spans |
 
-## Configuration Files
-
-| File | Purpose |
-|------|---------|
-| `package.json` | Dependencies, scripts, project metadata |
-| `tsconfig.json` | TypeScript compiler options (strict, NodeNext, `@/*` path alias) |
-| `biome.json` | Linter + formatter config (tab indentation, 120 char width, double quotes) |
-| `bun.lock` | Bun lockfile (v1) |
-| `prek.toml` | Pre-commit hook configuration |
-| `cspell.json` | Spell-check configuration |
-| `renovate.json` | Dependency auto-update configuration |
-| `bump.config.ts` | Version bump configuration (bumpp) |
-
-## Key Dependencies
-
-### AI / LLM SDKs
-
-| Package | Purpose | Used in |
-|---------|---------|---------|
-| `openai` | OpenAI API client (also used for OpenRouter, OpenCode, Z.AI, ClinePass, QwenCloud) | `src/providers/openai.ts`, `src/providers/openrouter.ts`, etc. |
-| `@anthropic-ai/sdk` | Anthropic Claude API client | `src/providers/anthropic.ts` |
-| `ollama` | Ollama local + cloud API client | `src/providers/ollama.ts`, `src/providers/ollama-cloud.ts` |
-
-### CLI / UI
-
-| Package | Purpose | Used in |
-|---------|---------|---------|
-| `ink` | React for CLI terminal apps | `src/ui/` (all components) |
-| `ink-box` | Box component for Ink | `src/ui/components/` |
-| `ink-spinner` | Spinner component for Ink | `src/ui/components/Spinner.tsx` |
-| `react` | React runtime (for Ink) | `src/ui/` |
-| `react-devtools-core` | DevTools integration | Dev mode only |
-
-### Utilities
-
-| Package | Purpose | Used in |
-|---------|---------|---------|
-| `yaml` | YAML parsing/serializing for config files | `src/config/loader.ts`, `src/config/config-io.ts` |
-| `zod` | Runtime validation for configs and tool inputs | `src/config/schema.ts`, `src/tools/` |
-| `tiktoken` | Token counting for context budgeting | `src/core/tokens.ts` |
-| `@tokenlens/models` | Model token limits | `src/providers/capabilities.ts` |
-
-### Telemetry / Observability
-
-| Package | Purpose | Used in |
-|---------|---------|---------|
-| `@opentelemetry/api` | OpenTelemetry tracing API | `src/observability/telemetry.ts` |
-| `@opentelemetry/sdk-trace-base` | OpenTelemetry SDK (tracer provider, exporters) | `src/observability/telemetry.ts` |
-| `langfuse` (optional) | LLM observability platform integration | `src/observability/langfuse.ts` |
-
-### MCP
-
-| Package | Purpose | Used in |
-|---------|---------|---------|
-| `@modelcontextprotocol/sdk` | Model Context Protocol client SDK | `src/mcp/client.ts`, `src/mcp/manager.ts` |
+## Provider SDKs
+| SDK | Provider |
+|-----|----------|
+| `openai` ^7.0.0 | OpenAI, OpenRouter, Zai, QwenCloud, ClinePass |
+| `@anthropic-ai/sdk` ^0.115.0 | Anthropic Claude |
+| `ollama` ^0.6.3 | Local Ollama models |
+| `@modelcontextprotocol/sdk` ^1.25.2 | MCP servers |
 
 ## Dev Dependencies
+| Dependency | Purpose |
+|------------|---------|
+| `@biomejs/biome` ^2.3.8 | Linting + formatting |
+| `typescript` ^7.0.0 | Type checking |
+| `bumpp` ^12.0.0 | Version bumping |
+| `husky` ^9.1.7 | Pre-commit hooks |
+| `@types/bun` | Bun type definitions |
 
-| Package | Purpose |
-|---------|---------|
-| `@biomejs/biome` | Linter + formatter (replaces ESLint + Prettier) |
-| `@types/bun` | Type definitions for Bun runtime |
-| `@types/react` | Type definitions for React |
-| `typescript` | TypeScript compiler (peer dependency) |
-| `bumpp` | Version bumping for releases |
-| `husky` | Git hooks management |
+## Configuration
+| File | Purpose |
+|------|---------|
+| `tsconfig.json` | TypeScript strict mode, `verbatimModuleSyntax` |
+| `biome.json` | Linting + formatting rules (2.3.x schema) |
+| `bump.config.ts` | Version bump config (bumpp) |
+| `package.json` | Dependencies, scripts, version |
 
-## Build & Release
+## Scripts
+- `bun run dev` — Watch mode
+- `bun run build` — Compile to binary (outputs `tiny-agent`)
+- `bun test` — Run all tests
+- `bun run typecheck` — tsc --noEmit
+- `bun run lint`/`lint:fix` — Biome check
+- `bun run format`/`format:check` — Biome format
+- `bun run release:minor` — Test + typecheck + lint + bumpp minor
 
-### Scripts (from `package.json`)
-
-```bash
-bun run dev              # Watch mode (bun --watch index.ts)
-bun run build            # Compile to binary (outputs tiny-agent)
-bun run generate:skills  # Regenerate embedded skills
-bun run generate:version # Generate version constant
-bun run typecheck        # tsc --noEmit (with version generation)
-bun run lint             # biome check .
-bun run lint:fix         # biome check --write --unsafe .
-bun run format           # biome format . --write
-bun test                 # Run all tests (bun test)
-bun test:watch           # Watch mode tests
-bun run release:patch    # Patch release (test → typecheck → lint → bumpp)
-bun run release:minor    # Minor release
-bun run release:major    # Major release
-```
-
-### Build Output
-
-The build compiles to a single binary using `bun build --compile`:
-
-```
-index.ts → bun build --compile → tiny-agent (standalone binary)
-```
-
-### CI Pipeline (`.github/workflows/ci.yml`)
-
-- **Triggers**: Push to `main`, pull requests to `main`
-- **Jobs**: `lint` (ubuntu-latest), `test` (ubuntu-latest + macos-latest), `build` (conditional)
-- **Setup**: Bun latest, dependency caching via `oven-sh/setup-bun@v2`
-
-### Release Pipeline (`.github/workflows/release.yml`)
-
-- Automated releases via bumpp + GitHub Actions
-- Homebrew formula in `.github/homebrew-tiny-agent/tiny-agent.rb`
-
-## TypeScript Configuration
-
-Key compiler options from `tsconfig.json`:
-
-- `strict: true` — strict mode
-- `verbatimModuleSyntax` — requires explicit `import type` for types
-- `noUncheckedIndexedAccess` — indexed access requires validation
-- `noImplicitOverride` — override methods must use `override` keyword
-- `path alias`: `@/*` → `./src/*`
-- `module: NodeNext`, `moduleResolution: NodeNext`
-
-## Linting & Formatting (Biome)
-
-- Tab indentation (width 2)
-- 120 character line width
-- Double quotes
-- Semicolons enabled
-- ES5 trailing commas
-- Disabled rules: `noNonNullAssertion`, `noNonNullAssertedOptionalChain`, `noArrayIndexKey`, `noAssignInExpressions`
-- Auto-organize imports on save
-- `src/skills/embedded-content.ts` excluded (generated file)
+## Version History
+- v0.5.0, v0.5.1 — Foundation
+- v0.6.0 — Agent decomposition
+- v0.7.0 — Multi-agent + hooks + QwenCloud
+- v0.8.0 — Round 5 extractions (tool-status, SyntaxHighlighter, plan-converter, help-text, Login Flow Controller, stable prompt fix)

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,191 +1,97 @@
 # Directory Structure
 
-## Overview
-
 ```
-tiny-coding-agent/
-├── index.ts                 # Entry point → main()
-├── package.json             # Dependencies + scripts
-├── tsconfig.json            # TypeScript config (strict, NodeNext)
-├── biome.json               # Linter + formatter
-├── bun.lock                 # Bun lockfile
-├── src/                     # Source code (141 files, ~20k lines)
-│   ├── agents/              # Multi-agent system (plan, build, explore)
-│   ├── cli/                 # CLI interface + command handlers
-│   ├── config/              # Configuration schema + loading
-│   ├── core/                # Agent loop + extracted modules
-│   ├── hooks/               # Lifecycle hooks system
-│   ├── mcp/                 # MCP client integration
-│   ├── observability/       # Telemetry, logging, cost tracking
-│   ├── providers/           # LLM provider implementations
-│   ├── skills/              # Skill discovery + loading
-│   ├── tools/               # Built-in tools + registry
-│   ├── ui/                  # Ink React CLI components
-│   └── utils/               # Shared utilities
-├── test/                    # Test files (80 files, ~17k lines)
-├── docs/                    # Documentation + ADRs
-├── scripts/                 # Build scripts + ralph automation
-├── .github/                 # CI workflows + Homebrew formula
-└── .planning/codebase/      # This codebase map
+src/
+├── agents/           # Agent types — plan, build, explore, state management
+│   ├── agent-client.ts       # LLM client creation for agent use
+│   ├── build-agent.ts        # Build execution agent
+│   ├── codebase-explorer.ts  # Codebase exploration logic
+│   ├── explore-agent.ts      # Exploration orchestrator
+│   ├── plan-agent.ts         # Plan generation agent
+│   ├── plan-converter.ts     # Plan → BuildStep conversion
+│   ├── plan-grammar.ts       # Plan markdown parser/serializer/validator
+│   ├── state-manager.ts      # State file management
+│   ├── state.ts              # State types and file I/O
+│   └── step-executor.ts      # Per-step action execution
+│
+├── cli/              # CLI interface and command handlers
+│   ├── main.tsx               # Entry point, run/chat modes
+│   ├── chat-command-registry.ts # /help, /clear, /model etc.
+│   ├── command-dispatch.ts    # Central command routing
+│   ├── help-text.ts           # Help text content
+│   ├── prompt.ts              # User prompt DI singleton
+│   ├── shared.ts              # Shared CLI utilities
+│   ├── status-line.ts         # Status line display
+│   ├── tool-display.tsx       # Tool execution display
+│   └── handlers/              # Per-command handlers
+│       ├── agent.ts, config.ts, hooks.ts, login*.ts
+│       ├── mcp.ts, memory.ts, plan.ts, review.ts
+│       ├── skill.ts, state.ts, status.ts, trace.ts
+│       └── upgrade.ts
+│
+├── config/           # Configuration loading
+│   ├── loader.ts             # YAML config loader
+│   └── schema.ts             # Zod schema
+│
+├── core/              # Agent loop, memory, tools, providers
+│   ├── agent.ts               # Agent class — runStream, run, health
+│   ├── agent-observability.ts # Telemetry wrapper
+│   ├── agent-utils.ts         # Loop detection, stream helpers
+│   ├── context-budget.ts      # Context window management
+│   ├── conversation.ts        # Conversation persistence
+│   ├── debug-logger.ts        # Verbose logging
+│   ├── memory.ts              # MemoryStore class
+│   ├── provider-cache.ts      # LLM client cache
+│   ├── signal-handler-manager.ts # Process signal handlers
+│   ├── skill-manager.ts       # Skill discovery/loading
+│   ├── tokens.ts              # Token counting
+│   └── turn-executor.ts       # Per-iteration tool execution
+│
+├── hooks/            # Lifecycle hook system
+│   ├── index.ts, manager.ts, types.ts
+│
+├── mcp/              # Model Context Protocol
+│   ├── client.ts, manager.ts, types.ts
+│
+├── observability/    # Telemetry and logging
+│   ├── logger.ts, langfuse.ts, telemetry.ts
+│   ├── redact.ts, trace-context.ts, cost.ts
+│   └── token-usage.ts, pricing.ts
+│
+├── providers/        # LLM provider implementations
+│   ├── types.ts, factory.ts, index.ts
+│   ├── anthropic.ts, openai.ts, ollama.ts
+│   ├── clinepass.ts, zai.ts, openrouter.ts
+│   └── model-registry.ts, capabilities.ts
+│
+├── skills/           # Skill system
+│   ├── loader.ts, parser.ts, prompt.ts
+│   ├── signature.ts, types.ts, builtin-registry.ts
+│   └── builtin/  # Embedded skill files
+│
+├── tools/            # Tool system
+│   ├── registry.ts, types.ts, bash-tool.ts
+│   ├── file-tools.ts, search-tools.ts
+│   ├── web-search-tool.ts, confirmation.ts
+│   └── plugin-loader.ts
+│
+├── ui/               # Ink React components
+│   ├── App.tsx, utils.ts
+│   ├── components/   # UI components
+│   │   ├── AgentSwitcher, ChatLayout, CommandMenu
+│   │   ├── Header, HeaderBox, Message, MessageList
+│   │   ├── ModelPicker, SkillPicker, Spinner
+│   │   ├── StatusLine, StreamingText, ThinkingIndicator
+│   │   ├── ToastList, TextInput, ToolCall, ToolOutput
+│   │   ├── ToolsPanel, ContextStatus
+│   │   ├── tool-status.ts     # Unified tool display helpers
+│   │   └── SyntaxHighlighter.tsx # Diff/git syntax renderer
+│   ├── contexts/     # React contexts
+│   │   ├── ChatContext.tsx, StatusLineContext.tsx
+│   │   └── ToastContext.tsx
+│   └── hooks/        # Custom hooks
+│       └── useCommandHandler.ts
+│
+└── utils/            # Shared utilities
+    ├── xml.ts, command.ts, retry.ts, version.ts
 ```
-
-## Source Layout (`src/`)
-
-### `src/core/` — Agent Loop & Extracted Modules
-
-| File | Lines | Purpose |
-|------|-------|---------|
-| `agent.ts` | 652 | Agent class — orchestrates the LLM conversation loop |
-| `memory.ts` | 422 | MemoryStore — user-initiated memory storage + retrieval |
-| `agent-observability.ts` | 326 | AgentObservability — span/timer management wrapper |
-| `context-budget.ts` | 276 | prepareContext() — context window budgeting + memory merge |
-| `turn-executor.ts` | 236 | TurnExecutor — one LLM call + tool batch execution |
-| `agent-utils.ts` | 228 | streamLlmResponse(), streamFinalAnswer(), isLooping() |
-| `skill-manager.ts` | 158 | SkillManager — skill discovery, loading, tool restriction |
-| `provider-cache.ts` | 134 | ProviderCache — LLM client cache with eviction |
-| `debug-logger.ts` | 132 | DebugLogger — verbose logging (no-op when disabled) |
-| `conversation.ts` | — | ConversationManager — history persistence |
-| `tokens.ts` | — | Token counting utilities (tiktoken) |
-| `index.ts` | — | Re-exports |
-
-### `src/agents/` — Multi-Agent System
-
-| File | Lines | Purpose |
-|------|-------|---------|
-| `build-agent.ts` | 401 | Build executor — parses plan, executes steps |
-| `codebase-explorer.ts` | 381 | Filesystem exploration (shallow + deep modes) |
-| `plan-grammar.ts` | 437 | Plan markdown parser → phases/steps AST |
-| `state-manager.ts` | 198 | StateManager — state file lifecycle (loadOrCreate, loadOrFail, save) |
-| `explore-agent.ts` | 234 | Codebase analysis agent |
-| `plan-agent.ts` | 231 | Plan generation agent |
-| `step-executor.ts` | 217 | StepExecutor — retry/skip/abort flow |
-| `agent-client.ts` | 50 | createAgentClient() — LLM client factory for agents |
-| `state.ts` | — | State file I/O with file locking + rotation |
-| `types.ts` | — | StateFile, AgentPhase, AgentStatus types |
-
-### `src/cli/` — CLI Interface
-
-| File | Lines | Purpose |
-|------|-------|---------|
-| `main.tsx` | 405 | Entry point — main(), handleRun(), handleInteractiveChat() |
-| `tool-display.tsx` | 156 | ThinkingTagFilter, formatArgs, displayToolExecution, outputJson |
-| `command-dispatch.ts` | 265 | Command dispatch table (pre/post config) |
-| `shared.ts` | 280 | parseArgs(), createLLMClient(), setupTools(), createAgent() |
-| `prompt.ts` | — | readline prompt helpers (prompt, promptHidden) |
-| `handlers/` | — | One file per CLI command (login, logout, plan, hooks, etc.) |
-
-### `src/providers/` — LLM Provider Implementations
-
-| File | Lines | Purpose |
-|------|-------|---------|
-| `anthropic.ts` | 370 | Anthropic Claude provider |
-| `ollama.ts` | 324 | Ollama local provider |
-| `factory.ts` | — | createProvider() factory + parseModelString() |
-| `model-registry.ts` | — | detectProvider() + model capability lookup |
-| `openai.ts` | — | OpenAI provider |
-| `openrouter.ts` | — | OpenRouter provider |
-| `opencode.ts` | — | OpenCode provider |
-| `zai.ts` | — | Z.AI (Zhipu) provider |
-| `clinepass.ts` | — | ClinePass provider (live model lookup, ADR-013) |
-| `qwencloud.ts` | — | QwenCloud provider |
-| `capabilities.ts` | — | Model capability checks |
-| `openai-protocol.ts` | — | Shared OpenAI-compatible protocol |
-| `types.ts` | — | LLMClient, Message, TokenUsage interfaces |
-
-### `src/tools/` — Built-in Tools
-
-| File | Lines | Purpose |
-|------|-------|---------|
-| `file-tools.ts` | 449 | read_file, write_file, edit_file, delete_file |
-| `search-tools.ts` | 354 | grep, glob tools |
-| `bash-tool.ts` | 281 | Bash command execution |
-| `registry.ts` | 204 | ToolRegistry class |
-| `confirmation.ts` | — | User confirmation system (ADR-009) |
-| `skill-tool.ts` | — | Skill loading tool |
-| `plugin-loader.ts` | — | Dynamic plugin loading |
-| `web-search-tool.ts` | — | Web search tool |
-| `gitignore.ts` | — | .gitignore-aware file filtering |
-| `types.ts` | — | Tool, ToolResult, ToolParameters interfaces |
-
-### `src/ui/` — Ink React Components
-
-| File | Lines | Purpose |
-|------|-------|---------|
-| `hooks/useCommandHandler.ts` | 452 | Slash command dispatcher (/help, /model, /plan, etc.) |
-| `components/Message.tsx` | 382 | Message rendering (markdown, code blocks) |
-| `components/ModelPicker.tsx` | 380 | Model selection UI |
-| `contexts/ChatContext.tsx` | 303 | Chat state management |
-| `components/ChatLayout.tsx` | 249 | Main chat layout |
-| `App.tsx` | 239 | Root app component |
-| `chat-command-registry.ts` | 77 | Command registry + help text generation |
-
-### `src/config/` — Configuration
-
-| File | Lines | Purpose |
-|------|-------|---------|
-| `loader.ts` | 324 | loadConfig(), getConfigPath(), createDefaultConfig() |
-| `schema.ts` | 247 | Zod-validated Config interface + schemas |
-| `config-io.ts` | 87 | readConfigFile(), writeConfigFile() (YAML/JSON) |
-
-### `src/hooks/` — Lifecycle Hooks (ADR-015)
-
-| File | Purpose |
-|------|---------|
-| `types.ts` | HookConfig, HookEvent, HookRegistry types |
-| `manager.ts` | buildRegistry(), runHooks(), hasHooks() |
-| `presets.ts` | PLANNOTATOR_PRESET, findPreset() |
-| `index.ts` | Re-exports |
-
-### `src/observability/` — Telemetry & Logging
-
-| File | Purpose |
-|------|---------|
-| `telemetry.ts` | OpenTelemetry span management |
-| `logger.ts` | Structured JSON logging |
-| `cost.ts` | Token cost estimation |
-| `pricing.ts` | Model pricing data |
-| `redact.ts` | API key masking |
-| `langfuse.ts` | Optional Langfuse integration |
-| `token-usage.ts` | Token usage tracking |
-| `trace-context.ts` | Trace context propagation |
-
-## Test Layout (`test/`)
-
-Tests mirror the `src/` structure:
-
-```
-test/
-├── agents/          # Agent tests (build, explore, plan, state, step-executor)
-├── cli/             # CLI tests (handlers, command-dispatch, integration)
-├── config/          # Config tests (loader, config-io)
-├── core/            # Core tests (agent, memory, turn-executor, observability)
-├── e2e/             # End-to-end agent loop test
-├── hooks/           # Hooks tests (manager, presets, types)
-├── mcp/             # MCP tests (manager, errors)
-├── observability/   # Observability tests (telemetry, cost, redact, langfuse)
-├── providers/       # Provider tests (anthropic, clinepass, model-registry, ollama)
-├── security/        # Security tests (command-injection, bash-env, file-validation)
-├── skills/          # Skills tests (loader, parser, prompt, builtin-registry)
-├── tools/           # Tool tests (bash, file, search, registry, skill-tool)
-├── ui/              # UI tests (chat-command-registry, model-picker, utils)
-└── utils/           # Utility tests (command, xml)
-```
-
-## Documentation
-
-```
-docs/
-├── README.md        # Documentation index
-├── adr/             # 16 Architecture Decision Records (001-016)
-└── development-tasks.md
-```
-
-## Naming Conventions
-
-- **Files**: kebab-case (`file-tools.ts`, `agent-observability.ts`)
-- **Classes/Types**: PascalCase (`ToolRegistry`, `StateManager`, `LLMClient`)
-- **Functions/Variables**: camelCase (`loadConfig`, `createProvider`)
-- **Constants**: SCREAMING_SNAKE_CASE (`DEFAULT_STATE_FILE`, `MAX_STATE_FILE_SIZE`)
-- **Private members**: `_prefix` (`_providerCache`, `_toolRegistry`)
-- **Imports**: `.js` extension for internal modules, `node:` prefix for Node builtins
-- **Types**: explicit `import type` (enforced by `verbatimModuleSyntax`)

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,202 +1,61 @@
 # Testing
 
 ## Framework
-
-| Property | Value |
-|----------|-------|
-| Framework | `bun:test` (Bun's built-in test runner) |
-| Assertion library | `bun:test` (`expect`, `toEqual`, `toBe`, etc.) |
-| Test runner | `bun test` |
-| Watch mode | `bun test:watch` (`bun test --watch`) |
-| Coverage | Not configured (relies on test count + behavior testing) |
-
-## Test Statistics
-
-| Metric | Value |
-|--------|-------|
-| Test files | 80 |
-| Total tests | 1,288 |
-| Assertions | 2,795 `expect()` calls |
-| Pass rate | 100% (0 failures) |
-| Test lines | ~17,139 |
-| Execution time | ~5 seconds |
-
-## Test Structure
-
-Tests mirror the `src/` directory structure:
-
-```
-test/
-├── agents/              # Agent tests (8 files)
-│   ├── build-agent.test.ts
-│   ├── codebase-explorer.test.ts
-│   ├── explore-agent.test.ts
-│   ├── plan-agent.test.ts
-│   ├── plan-grammar.test.ts
-│   ├── state.test.ts
-│   └── step-executor.test.ts
-├── cli/                 # CLI tests (10 files)
-│   ├── handlers/        # One test file per CLI handler
-│   ├── chat-commands.test.ts
-│   ├── command-dispatch.test.ts
-│   ├── integration.test.ts
-│   └── main.test.tsx
-├── config/              # Config tests (2 files)
-├── core/                # Core module tests (15 files)
-│   ├── agent.test.ts
-│   ├── agent-fallback.test.ts
-│   ├── agent-observability.test.ts
-│   ├── agent-utils-stream.test.ts
-│   ├── context-budget.test.ts
-│   ├── debug-logger.test.ts
-│   ├── provider-cache.test.ts
-│   ├── turn-executor.test.ts
-│   └── ...
-├── e2e/                 # End-to-end tests (1 file)
-│   └── agent-loop.test.ts
-├── hooks/               # Hooks tests (4 files)
-├── mcp/                 # MCP tests (2 files)
-├── observability/       # Observability tests (8 files)
-├── providers/           # Provider tests (5 files)
-├── security/            # Security tests (4 files)
-│   ├── bash-env.test.ts
-│   ├── command-injection.test.ts
-│   ├── file-validation.test.ts
-│   └── security-suite.test.ts
-├── skills/              # Skills tests (4 files)
-├── tools/               # Tool tests (8 files)
-├── ui/                  # UI tests (3 files)
-└── utils/               # Utility tests (2 files)
-```
-
-## Test Patterns
-
-### Basic Test Structure
-
-```typescript
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-
-describe("MemoryStore", () => {
-  const tempFile = "/tmp/test-memory.json";
-
-  beforeEach(() => {
-    try {
-      unlinkSync(tempFile);
-    } catch {
-      /* ignore */
-    }
-  });
-
-  it("should evict oldest memories when over max limit", () => {
-    const store = new MemoryStore({ filePath: tempFile, maxMemories: 3 });
-    store.add("1");
-    store.add("2");
-    store.add("3");
-    store.add("4");
-    expect(store.count()).toBe(3);
-  });
-});
-```
-
-### Cleanup Pattern
-
-Tests that create files must clean up in `beforeEach`/`afterEach`:
-
-```typescript
-beforeEach(() => {
-  try { unlinkSync(tempFile); } catch { /* ignore */ }
-});
-
-afterEach(() => {
-  try { unlinkSync(tempFile); } catch { /* ignore */ }
-});
-```
-
-### Mocking Patterns
-
-#### Mocking LLM Clients
-
-```typescript
-const mockClient: LLMClient = {
-  chat: async () => ({ content: "mock response", usage: undefined }),
-  chatStream: async function* () { yield "mock"; },
-};
-```
-
-#### Mocking Tool Registry
-
-```typescript
-const registry = new ToolRegistry();
-registry.register({
-  name: "test_tool",
-  description: "Test tool",
-  parameters: { type: "object", properties: {} },
-  execute: async () => ({ success: true, output: "ok" }),
-});
-```
-
-#### Mocking stdin (readline prompts)
-
-```typescript
-// Mock prompt to return a specific value
-const mockPrompt = async () => "y";
-const executor = new StepExecutor(registry, { promptFn: mockPrompt });
-```
-
-#### Mocking process.exit
-
-Tests that exercise CLI handlers mock `process.exit` to prevent the test runner from exiting:
-
-```typescript
-const exitSpy = mock((code?: number) => { throw new Error(`exit:${code}`); });
-mock.module("node:process", () => ({ ...process, exit: exitSpy }));
-```
-
-### Test Categories
-
-#### Unit Tests
-
-Test individual modules in isolation:
-- `test/core/turn-executor.test.ts` — TurnExecutor with mock registry
-- `test/core/provider-cache.test.ts` — ProviderCache with mock clients
-- `test/core/debug-logger.test.ts` — DebugLogger no-op behavior
-- `test/agents/step-executor.test.ts` — StepExecutor with mock prompt
-
-#### Integration Tests
-
-Test multiple modules working together:
-- `test/cli/integration.test.ts` — CLI arg parsing + dispatch
-- `test/e2e/agent-loop.test.ts` — Full agent loop with mock LLM
-
-#### Security Tests
-
-Dedicated security test suite in `test/security/`:
-- `command-injection.test.ts` — bash tool injection prevention
-- `bash-env.test.ts` — environment variable sanitization
-- `file-validation.test.ts` — path traversal prevention
-- `security-suite.test.ts` — combined security validation
+- **Test runner:** Bun's built-in test runner (`bun test`)
+- **Assertion library:** `bun:test` — `expect`, `describe`, `it`
+- **Type checking:** `tsc --noEmit` (pre-existing `@types/bun` issue)
+- **Linting + formatting:** `biome check`
 
 ## Running Tests
-
 ```bash
-bun test                         # All tests
-bun test <file>                  # Single file (e.g., "bun test tools/file.test.ts")
-bun test <pattern>               # Pattern match (e.g., "bun test memory")
-bun test:watch                   # Watch mode for TDD
+bun test                       # All tests
+bun test <file>                # Single file
+bun test <pattern>             # Match pattern (e.g. "memory")
+bun test:watch                 # Watch mode
 ```
 
-## CI Testing
+## Test Structure
+- **Test files:** `test/` directory mirrors `src/` structure
+  - `test/core/` — Agent, memory, conversation, tokens
+  - `test/agents/` — Plan, build, explore agents
+  - `test/tools/` — File, bash, search, registry
+  - `test/providers/` — Provider implementations
+  - `test/cli/` — CLI handlers, main entry
+  - `test/ui/` — UI utilities
+  - `test/security/` — Security suite (path traversal, injection)
+  - `test/config/` — Config loader
+  - `test/observability/` — Telemetry, cost, tracing
+  - `test/skills/` — Skill loading, parsing
+- **Test count:** ~666 tests across ~80 files
+- **Current results:** ~600 pass, ~66 fail (pre-existing environment-dependent failures)
 
-Tests run on CI in `.github/workflows/ci.yml`:
-- **ubuntu-latest**: Full test suite
-- **macos-latest**: Full test suite
-- Bun latest version
-- Dependency caching via `actions/cache`
+## Test Patterns
+- **Pure function tests**: Test input/output without mocks
+- **Class tests**: Construct with test doubles, verify state transitions
+- **Async tests**: Use `await` with `async` test functions
+- **Cleanup**: `beforeEach`/`afterEach` for file system state
 
-## Testing Philosophy
+## Coverage Areas
+| Area | Test coverage |
+|------|---------------|
+| Core agent loop | Good — streaming, iterations, tool execution |
+| Memory store | Good — CRUD, eviction, persistence, signal handlers |
+| Plan grammar | Good — parse, serialize, validate, edge cases |
+| Tools (registry, file, bash) | Good — registration, execution, confirmation |
+| CLI handlers | Good — config, state, memory, plan, trace, hooks |
+| Providers | Good — OpenAI, Anthropic, Ollama, model registry |
+| Security | Good — path traversal, injection, env vars, sensitive files |
+| Observability | Good — telemetry, cost, token usage, Langfuse |
+| Skills | Good — loading, parsing, frontmatter, built-in registry |
+| UI utilities | Moderate — format, filter utilities |
+| Chat UI (Ink) | Low — mostly rendering, tested via typecheck |
 
-- **Test behavior, not implementation details** — tests should give confidence that the code works
-- **Clean up resources** — `beforeEach`/`afterEach` for temp files
-- **Mock at the seam** — mock `LLMClient`, `ToolRegistry`, `prompt` — not internals
-- **Structured results** — tests use `{ success: boolean, error?: string }` pattern matching the codebase convention
-- **No coverage thresholds** — relies on 1,288 tests across 80 files covering all modules
+## Pre-existing Failures
+The ~66 failing tests are environment-dependent and include:
+- Path traversal security tests (sandbox permissions)
+- Command injection prevention (shell environment)
+- Sensitive file access (system config)
+- Env variable filtering (shell environment)
+- Config loader env var override loop (env vars)
+- extractRecommendations (test fixture)
+- ExploreAgentOptions (option parsing)

--- a/docs/adr/019-code-mode-design.md
+++ b/docs/adr/019-code-mode-design.md
@@ -1,0 +1,370 @@
+# ADR-019: Code Mode — LLM-Written Programs for Parallel Tool Execution
+
+**Status:** Draft (design exploration — not yet implemented)
+**Date:** 2026-07-31
+**Deciders:** (pending implementation decision)
+
+## Context
+
+The current agent loop follows a strict **serial request → respond → execute → repeat** pattern:
+
+```
+LLM request (tool list + messages)
+  → LLM responds with 1-N tool calls
+  → Run tool calls sequentially (batch)
+  → Append results as messages
+  → LLM request again (with all history)
+  → ... repeat up to 20 iterations
+```
+
+This has three structural inefficiencies, identified in the ByteByteGo article (issue #86, item #4):
+
+1. **Sequential tool execution**: Even independent tool calls (e.g., `grep` + `glob` + `read_file`) run one at a time because each LLM iteration produces a set of calls that are executed, then the results are fed back for the next decision.
+
+2. **Context growth per iteration**: Each iteration adds tool call JSON + result text to the message array. After 5-10 iterations, the context is dominated by tool results rather than the actual reasoning.
+
+3. **LLM overhead per decision**: The LLM makes a round-trip for every decision point. If the task requires 8 tool calls, that's 8 LLM requests (or at best 3-4 if batching multiple calls per iteration).
+
+The ByteByteGo article describes **Code Mode** as an alternative: instead of the LLM making tool calls one iteration at a time, the LLM writes a JavaScript program that the harness executes in one shot.
+
+```
+Current:   LLM → tool call → result → LLM → tool call → result → LLM → answer
+Code Mode: LLM → [JS program with 8 tool calls] → harness executes → answer
+```
+
+This ADR explores whether Code Mode is worth implementing for this codebase, what design would work best given the current architecture, and how to phase the implementation.
+
+## Research
+
+### How OpenAI's Codex does Code Mode
+
+The ByteByteGo article describes Codex's approach at a high level: the model writes a JavaScript program using `await` for async tool calls, including `Promise.all()` for parallel execution. The harness (the host process) executes this program and returns the final result.
+
+Key characteristics:
+- **The program is ephemeral**: It runs once, produces a result, and is discarded.
+- **Tool access via async functions**: Tools are exposed as async JavaScript functions (e.g., `readFile()`, `search()`, `grep()`).
+- **Parallelism via `Promise.all()`**: The model can choose to run independent tool calls in parallel.
+- **Single LLM request**: The entire sequence of tool calls is planned in one LLM response, dramatically reducing overhead.
+
+### How this codebase currently executes tools
+
+The current flow in `runStream()` → `TurnExecutor.executeTurn()`:
+
+1. LLM responds with `assistantMessage.toolCalls` (an array of `{ name, arguments }`)
+2. `TurnExecutor.executeTurn()` calls `registry.executeBatch(calls)` which runs all calls via `Promise.all()`
+3. Results are appended as tool result messages
+4. The next LLM iteration sees the results and decides what to do next
+
+This already uses `Promise.all()` for parallel execution within a single turn. The serial bottleneck is the **LLM round-trips between turns**, not the tool execution itself.
+
+### Current architecture constraints
+
+1. **ToolRegistry executes via `executeBatch()`**: Tools are already executed in parallel within a turn. The bottleneck is the LLM iteration cycle.
+
+2. **`agent.ts` runStream() is an async generator**: It yields `AgentStreamChunk` objects as it progresses through iterations. Code Mode would need to fit within this generator model, or replace it for a Code Mode session.
+
+3. **Tool definitions include zod schemas**: Most tools have zod-validated args schemas. A Code Mode program would need to construct valid args for each tool call.
+
+4. **No JavaScript sandbox exists**: Currently, tool execution happens in-process via `ToolRegistry.execute()`. A Code Mode program would need either a sandbox (isolated execution) or the same in-process execution.
+
+## Proposed Design
+
+### Option A: Plan-Ahead Tool Batch (Recommended for v1)
+
+Instead of the LLM writing an executable JavaScript program (complex, high risk), implement a **plan-ahead pattern**: the LLM outputs a structured plan listing multiple tool calls, and the harness executes them in a single turn without intervening LLM requests.
+
+**How it works:**
+
+1. Add a system prompt instruction: "When you need multiple tool calls, output them all at once in a `tool_calls` JSON array. The system will execute them in parallel and return all results together."
+
+2. In `runStream()`, collect all tool calls from a single LLM response, execute them all, and return results to the LLM in **one** iteration — no per-call round-trip.
+
+3. The LLM processes the combined results and either outputs more tool calls or provides the final answer.
+
+**Example flow:**
+
+```
+LLM receives: user prompt + system prompt (with Code Mode instructions)
+LLM outputs: 
+  1. grep for function signature
+  2. grep for usages
+  3. read_file for both files
+  [all three tool calls in one response]
+
+Harness: executes all 3 in parallel via Promise.all()
+LLM receives: all 3 results at once
+LLM outputs: final answer (synthesized from all results)
+
+Total: 2 LLM requests instead of 4+
+```
+
+**Implementation sketch:**
+
+```typescript
+// In runStream(), replace the per-iteration loop with a plan-ahead check:
+if (assistantToolCalls.length > 0) {
+  // Execute all tool calls (already happens via executeBatch)
+  // Return all results at once
+  messages.push(...toolResultMessages);
+  
+  // Continue to next iteration — LLM receives all results together
+  continue;
+}
+```
+
+Wait — this is **already how it works**. The LLM can output multiple tool calls in one response, and they're all executed in parallel via `executeBatch()`.
+
+The real optimization in Option A is about **LLM training/prompting** — teaching the LLM to output more tool calls per iteration rather than making many small iterations. This is a prompt engineering change, not an architecture change.
+
+**Complexity:** Very Low — prompt-only change (if the model already supports batch tool calling).
+
+### Option B: Declarative Plan Format (Recommended for v1 — Extended)
+
+Instead of the LLM writing executable JavaScript, it writes a **declarative plan** in a JSON format that the harness interprets. This is the middle ground between prompting and full Code Mode.
+
+**Declarative plan format:**
+
+```json
+{
+  "plan": [
+    { "step": "search", "args": { "pattern": "function foo" } },
+    { "step": "grep", "args": { "pattern": "foo\\(", "path": "src/" } },
+    { "step": "read_file", "args": { "path": "$results[0].path" } }
+  ],
+  "parallel_groups": [
+    [0, 1],    // search and grep can run in parallel
+    [2]        // read_file depends on search result
+  ]
+}
+```
+
+**Benefits over JavaScript:**
+- No sandbox needed (JSON is safe to parse)
+- No runtime evaluation risk
+- Simpler for the LLM to generate (JSON is easier than valid JS)
+- Dependency graph is explicit and verifiable
+- The harness can validate the plan before executing
+
+**Implementation:**
+
+1. Add a `parseToolPlan()` function that converts the JSON plan into a DAG of tool calls
+2. Add a `executeToolPlan()` function that walks the DAG, executing parallel groups
+3. Modify `runStream()` to detect declarative plans vs regular tool calls
+4. Add system prompt instructions for the plan format
+
+**Example flow:**
+
+```
+Iteration 1:
+  User: "Refactor function foo to use async"
+  LLM: outputs declarative plan (search → grep → read → edit)
+  Harness: executes plan (parallel: search+grep, then read, then edit)
+  LLM receives: all results
+  LLM outputs: final answer
+
+Total: 2 LLM requests (plan + answer) instead of 5+ (search, grep, read, edit, answer)
+```
+
+**Complexity:** Medium — new parser + executor + integration with runStream.
+
+### Option C: Full JavaScript Sandbox (Long-term)
+
+Implement a sandboxed JavaScript runtime where the LLM writes and executes arbitrary programs.
+
+**Design:**
+
+1. **Sandbox**: Use `vm` module (Node.js built-in) or isolated-vm for security
+2. **API surface**: Expose tools as async functions:
+   ```javascript
+   async function readFile(path) { ... }
+   async function search(pattern) { ... }
+   async function grep(pattern, path) { ... }
+   ```
+3. **Program template**:
+   ```javascript
+   async function main() {
+     const files = await Promise.all([
+       grep("function foo", "src/"),
+       grep("foo(", "tests/"),
+     ]);
+     const content = await readFile("src/foo.ts");
+     return { files, content };
+   }
+   ```
+4. **Result handling**: The program's return value is returned to the LLM as a tool result
+5. **Timeout**: Programs have a max execution time (configurable, default 30s)
+6. **Resource limits**: Memory limit, no network access, no filesystem access beyond tool APIs
+
+**Implementation phases:**
+
+1. **Phase 1 — Simple executor**: Run the JS program in a `vm.Script` with a limited context
+2. **Phase 2 — Tool API bindings**: Expose tools as async functions in the sandbox
+3. **Phase 3 — Result handling**: Parse the program's return value and inject it into the conversation
+4. **Phase 4 — Dual mode**: Let the LLM choose between Code Mode (for multi-step tasks) and regular mode (for simple tasks)
+
+**Complexity:** Very High — sandbox + API bindings + executor + safety measures.
+
+## Trade-offs
+
+| Aspect | Current (tool calls) | Option A (prompt-only) | Option B (declarative plan) | Option C (JS sandbox) |
+|--------|---------------------|----------------------|----------------------------|----------------------|
+| LLM requests per task | N (iterations) | N (same, but LLM batches more) | ~2 (plan + answer) | 1-2 (program + answer) |
+| Tool execution | Per-iteration batch | Per-iteration batch | DAG-walked, parallel groups | Program-controlled, fully parallel |
+| LLM training needs | None | Strong (model must batch well) | Moderate (plan format) | Low (JS is common training data) |
+| Implementation effort | None | Very Low | Medium | Very High |
+| Sandbox safety | N/A (in-process) | N/A | N/A | Critical (vm + limits) |
+| Backward compatibility | — | ✅ Full | ⚠️ Needs dual-mode parser | ❌ New interaction pattern |
+| Error handling | Per-call, simple | Same as current | Plan validation + per-step | Program-level try/catch |
+| Test surface change | — | None | New (plan parser + executor) | Massive (sandbox + APIs + programs) |
+
+## Recommendation
+
+**Implement Option B (Declarative Plan Format) as the initial Code Mode implementation.**
+
+Rationale:
+
+1. **No sandbox risk** — JSON parsing is safe; no `vm` or isolated-vm dependency needed.
+2. **Parallelism gains** — The DAG walker executes independent steps in parallel, reducing wall-clock time.
+3. **Measurable improvement** — A 5-step task today takes ~5 LLM iterations. With declarative plans, it takes ~2 (plan + answer). This is a 60% reduction in LLM calls.
+4. **Backward compatible** — Regular tool calls still work. The declarative plan is detected via a special field in the LLM response, so existing behavior is unchanged.
+5. **Phased approach** — Option B can be split into phases:
+   - **Phase 1**: Parse + execute declarative plans (no dependency tracking yet)
+   - **Phase 2**: Add dependency DAG and parallel group execution
+   - **Phase 3**: Train/improve prompt to make LLM use the format reliably
+
+**Defer Option C** until the codebase has:
+- A proven need (e.g., 10+ MCP servers, 50+ tool requests per task)
+- Proven safety patterns from the community (e.g., Codex's implementation details)
+- A dedicated security review of the sandbox boundary
+
+## Implementation Plan — Phase 1
+
+### Add `executePlan()` to TurnExecutor
+
+```typescript
+// turn-executor.ts
+interface PlanStep {
+  step: string;      // tool name
+  args: Record<string, unknown>;
+  deps?: number[];   // indices of steps this step depends on
+}
+
+interface DeclarativePlan {
+  plan: PlanStep[];
+  parallel_groups?: number[][];
+}
+
+async executePlan(plan: DeclarativePlan): Promise<TurnResult> {
+  const results = new Map<number, ToolResult>();
+  
+  if (plan.parallel_groups) {
+    // DAG-based execution: run each parallel group sequentially,
+    // steps within a group in parallel
+    for (const group of plan.parallel_groups) {
+      const stepResults = await Promise.all(
+        group.map(async (idx) => {
+          const step = plan.plan[idx];
+          const args = resolveDependencies(step.args, results);
+          return { idx, result: await this._registry.execute(step.step, args) };
+        })
+      );
+      for (const { idx, result } of stepResults) {
+        results.set(idx, result);
+      }
+    }
+  } else {
+    // All steps in parallel (no dependency info)
+    const allResults = await Promise.all(
+      plan.plan.map(async (step, idx) => {
+        return { idx, result: await this._registry.execute(step.step, step.args) };
+      })
+    );
+    for (const { idx, result } of allResults) {
+      results.set(idx, result);
+    }
+  }
+  
+  // Build result messages and display objects
+  return buildTurnResult(plan.plan, results);
+}
+```
+
+### Detect declarative plans in `runStream()`
+
+```typescript
+// In runStream(), after parsing LLM response
+if (assistantToolCalls.length === 0 && responseHasPlan(responseContent)) {
+  const plan = parseToolPlan(responseContent);
+  const turnResult = await this._turnExecutor.executePlan(plan);
+  // ... yield display objects, append messages
+} else {
+  const turnResult = await this._turnExecutor.executeTurn(assistantToolCalls);
+  // ... existing flow
+}
+```
+
+### System prompt augmentation
+
+Add instructions for the declarative plan format when Code Mode is enabled:
+
+```typescript
+const codeModeInstruction = `
+When you need to make multiple tool calls, you can output a declarative plan 
+instead of individual tool calls. A plan is a JSON object with a "plan" array:
+
+{
+  "plan": [
+    { "step": "tool_name", "args": { ... } },
+    { "step": "tool_name", "args": { ... } }
+  ],
+  "parallel_groups": [[0, 1], [2]]
+}
+
+Steps within the same parallel_group run simultaneously.
+Steps in different groups run sequentially (group 0, then group 1, etc.).
+Use this for multi-step tasks to reduce round-trips.
+`;
+```
+
+### MCP tool categorization enhancement
+
+Code Mode pairs naturally with tool categorization (PR #96). A declarative plan can include categorized tools because they're all registered in the ToolRegistry — just filtered by the heuristic. If a plan references a tool that was filtered out, `executePlan()` should try to register it on demand and retry.
+
+## Consequences
+
+### Positive
+
+- **Fewer LLM round-trips**: A multi-step plan executes in 1 iteration instead of N
+- **Parallelism gains**: Independent steps run concurrently via `Promise.all()`
+- **Deterministic execution**: The plan is explicit and verifiable before execution
+- **Backward compatible**: Regular tool calls continue to work; plan detection is additive
+- **Phased rollout**: Can start with simple plans (no dependency tracking) and add complexity later
+
+### Negative
+
+- **LLM reliability**: The LLM must generate valid JSON plans consistently. Schema validation and retry logic will be needed.
+- **Plan validation overhead**: Invalid plans (missing tools, bad args) need graceful fallback to regular mode.
+- **Dependency resolution**: `$results[0].path` references requires a lightweight expression evaluator.
+- **Debugging complexity**: A failing plan is harder to debug than a failing single tool call — the error could be in the plan format, dependency resolution, or tool execution.
+
+### Risks
+
+- **LLM ignores Code Mode**: If the model doesn't use the plan format reliably, the feature provides no benefit. Mitigation: make Code Mode opt-in (per-request), and measure adoption via observability.
+- **Plan format limits flexibility**: A declarative plan can only express tool calls, not conditional logic (`if result.error`). Mitigation: Phase 1 handles only linear plans; conditional plans are Phase 2.
+- **Sandbox temptation**: Once plans work, there will be pressure to add more expressiveness (conditionals, loops). This slides toward Option C (JS sandbox) by increments. Mitigation: define explicit boundaries for what plans can express; if a feature requires a JS sandbox, it's deferred to Option C.
+
+## Related Decisions
+
+- **ADR-005: Tool System Design** — the `Tool` interface and `ToolRegistry.execute()` used by `executePlan()`.
+- **ADR-011: Multi-Agent System** — the state file and PlanGrammar. Declarative plans would be a separate concern from the build/explore agent state.
+- **ADR-016: Agent Decomposition** — `TurnExecutor` is the natural home for `executePlan()`. The module already handles tool execution + error recovery; adding plan execution is an extension of its existing responsibility.
+- **ADR-018: Deferred Tool Discovery** — tool categorization (PR #96) complements Code Mode: categorized tools are available in plans, and the plan format lets the LLM explicitly request tools it needs.
+- **Issue #86, item #4 (Code Mode)** — the originating issue item.
+
+## Future Considerations
+
+- A **visual plan debugger** (showing the DAG, executed steps, timings) would help diagnose plan failures.
+- **Plan templates** for common workflows (e.g., "read file → edit file → read file to verify") could be pre-defined and suggested to the LLM.
+- **Observability metrics**: `plans_created`, `plans_succeeded`, `plans_failed`, `avg_steps_per_plan` — to validate the feature's impact on LLM round-trip reduction.
+- If Option C (JS sandbox) is later implemented, the plan format could serve as a compilation target: the LLM writes JavaScript, which is compiled to a declarative plan for safe execution.
+- **Plan caching**: If the same plan structure appears repeatedly (e.g., "find definition → read file"), it could be cached and replayed without an LLM call.


### PR DESCRIPTION
## What

ADR-019: Code Mode design document exploring LLM-written programs for parallel tool execution.

## Why

Issue #86, item #4 from ByteByteGo optimization patterns. The current agent loop makes N LLM requests for N tool calls. Code Mode reduces this to ~2 requests per task.

## Key Recommendation

Implement **Option B (Declarative Plan Format)** — the LLM outputs a JSON plan with tool calls and dependency groups, and the harness executes it as a DAG. This provides ~60% reduction in LLM round-trips without requiring a JavaScript sandbox.

## Related

- Complements tool categorization (PR #96) — categorized tools are available in plans
- Natural extension for TurnExecutor (ADR-016 decomposition)