### PR TITLE
refactor(tools): extract path-validation helpers from file-tools.ts into file-utils.ts

### DIFF
--- a/src/tools/file-tools.ts
+++ b/src/tools/file-tools.ts
@@ -1,19 +1,11 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { z } from "zod";
+import { handleDirError, handleFileError, isSensitiveFile, validateEditString, validatePath } from "./file-utils.js";
 import { findGitignorePatterns, isIgnored } from "./gitignore.js";
 import type { Tool, ToolResult } from "./types.js";
 
-export function handleFileError(filePath: string, err: unknown, context: string): ToolResult {
-	const error = err as NodeJS.ErrnoException;
-	if (error.code === "ENOENT") {
-		return { success: false, error: `File not found: ${filePath}` };
-	}
-	if (error.code === "EACCES") {
-		return { success: false, error: `Permission denied: ${filePath}` };
-	}
-	return { success: false, error: `${context}: ${error.message}` };
-}
+export { handleDirError, handleFileError, isSensitiveFile, validateEditString, validatePath };
 
 const readFileArgsSchema = z.object({
 	path: z.string(),
@@ -41,108 +33,6 @@ const listDirectoryArgsSchema = z.object({
 	path: z.string(),
 	recursive: z.boolean().optional(),
 });
-
-const SENSITIVE_PATTERNS = [
-	/\.env$/,
-	/\.env\.(?!example|sample|template|default)([a-zA-Z0-9_-]+)$/,
-	/\.aws\/credentials$/,
-	/\.aws\/config$/,
-	/\.ssh\//,
-	/\.npmrc$/,
-	/\.git-credentials$/,
-	/\.gitconfig$/,
-	/\/etc\/passwd$/,
-	/\/etc\/shadow$/,
-	/\.pki\//,
-	/\.gnupg\//,
-];
-
-function isSensitiveFile(filePath: string): boolean {
-	const basename = path.basename(filePath);
-	return SENSITIVE_PATTERNS.some((pattern) => pattern.test(filePath) || pattern.test(basename));
-}
-
-interface PathValidationResult {
-	valid: boolean;
-	error?: string;
-}
-
-function isSensitiveSystemPath(resolved: string): string | undefined {
-	const sensitivePaths = ["/etc/", "/usr/", "/bin/", "/sbin/", "/sys/", "/proc/", "/dev/", "/root/"];
-	for (const sensitive of sensitivePaths) {
-		if (resolved.startsWith(sensitive)) {
-			return sensitive;
-		}
-	}
-	return undefined;
-}
-
-function isSensitiveHomePath(resolved: string): string | undefined {
-	const homeDir = process.env.HOME ?? "";
-	const homeSensitivePaths = [
-		path.join(homeDir, ".ssh"),
-		path.join(homeDir, ".aws"),
-		path.join(homeDir, ".gnupg"),
-		path.join(homeDir, ".pki"),
-	];
-	for (const sensitive of homeSensitivePaths) {
-		if (resolved.startsWith(sensitive)) {
-			return sensitive;
-		}
-	}
-	return undefined;
-}
-
-async function validatePath(filePath: string, checkSymlink: boolean = false): Promise<PathValidationResult> {
-	const normalized = path.normalize(filePath);
-	if (normalized.includes("..")) {
-		return { valid: false, error: 'Path cannot contain ".." for security reasons' };
-	}
-
-	const resolved = path.resolve(filePath);
-
-	const systemPath = isSensitiveSystemPath(resolved);
-	if (systemPath) {
-		return { valid: false, error: `Cannot write to system path: ${systemPath}` };
-	}
-
-	const homePath = isSensitiveHomePath(resolved);
-	if (homePath) {
-		return {
-			valid: false,
-			error: `Cannot write to sensitive directory: ${path.basename(homePath)}`,
-		};
-	}
-
-	if (checkSymlink) {
-		try {
-			const stats = await fs.lstat(resolved);
-			if (stats.isSymbolicLink()) {
-				const linkTarget = await fs.readlink(resolved);
-				const target = path.resolve(path.dirname(resolved), linkTarget);
-				const targetSystem = isSensitiveSystemPath(target);
-				const targetHome = isSensitiveHomePath(target);
-				if (targetSystem || targetHome || target.includes("..")) {
-					return { valid: false, error: "Symlink points to restricted location" };
-				}
-			}
-		} catch {
-			// File doesn't exist yet, skip symlink check
-		}
-	}
-
-	return { valid: true };
-}
-
-function validateEditString(str: string): PathValidationResult {
-	const pathTraversalPattern = /\.\.[\\/]/;
-	if (pathTraversalPattern.test(str)) {
-		return { valid: false, error: "Edit strings must not contain path traversal sequences" };
-	}
-	return { valid: true };
-}
-
-export { isSensitiveFile, validateEditString, validatePath };
 
 export const readFileTool: Tool = {
 	name: "read_file",
@@ -370,20 +260,6 @@ export const listDirectoryTool: Tool = {
 		}
 	},
 };
-
-export function handleDirError(dirPath: string, err: unknown): ToolResult {
-	const error = err as NodeJS.ErrnoException;
-	if (error.code === "ENOENT") {
-		return { success: false, error: `Directory not found: ${dirPath}` };
-	}
-	if (error.code === "EACCES") {
-		return { success: false, error: `Permission denied: ${dirPath}` };
-	}
-	if (error.code === "ENOTDIR") {
-		return { success: false, error: `Not a directory: ${dirPath}` };
-	}
-	return { success: false, error: `Failed to list directory: ${error.message}` };
-}
 
 async function listDir(dirPath: string, recursive: boolean, prefix = ""): Promise<string[]> {
 	const entries = await fs.readdir(dirPath, { withFileTypes: true });

--- a/src/tools/file-utils.ts
+++ b/src/tools/file-utils.ts
@@ -1,0 +1,128 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { ToolResult } from "./types.js";
+
+const SENSITIVE_PATTERNS = [
+	/\.env$/,
+	/\.env\.(?!example|sample|template|default)([a-zA-Z0-9_-]+)$/,
+	/\.aws\/credentials$/,
+	/\.aws\/config$/,
+	/\.ssh\//,
+	/\.npmrc$/,
+	/\.git-credentials$/,
+	/\.gitconfig$/,
+	/\/etc\/passwd$/,
+	/\/etc\/shadow$/,
+	/\.pki\//,
+	/\.gnupg\//,
+];
+
+export function isSensitiveFile(filePath: string): boolean {
+	const basename = path.basename(filePath);
+	return SENSITIVE_PATTERNS.some((pattern) => pattern.test(filePath) || pattern.test(basename));
+}
+
+export function handleFileError(filePath: string, err: unknown, context: string): ToolResult {
+	const error = err as NodeJS.ErrnoException;
+	if (error.code === "ENOENT") {
+		return { success: false, error: `File not found: ${filePath}` };
+	}
+	if (error.code === "EACCES") {
+		return { success: false, error: `Permission denied: ${filePath}` };
+	}
+	return { success: false, error: `${context}: ${error.message}` };
+}
+
+export function handleDirError(dirPath: string, err: unknown): ToolResult {
+	const error = err as NodeJS.ErrnoException;
+	if (error.code === "ENOENT") {
+		return { success: false, error: `Directory not found: ${dirPath}` };
+	}
+	if (error.code === "EACCES") {
+		return { success: false, error: `Permission denied: ${dirPath}` };
+	}
+	if (error.code === "ENOTDIR") {
+		return { success: false, error: `Not a directory: ${dirPath}` };
+	}
+	return { success: false, error: `Failed to list directory: ${error.message}` };
+}
+
+interface PathValidationResult {
+	valid: boolean;
+	error?: string;
+}
+
+function isSensitiveSystemPath(resolved: string): string | undefined {
+	const sensitivePaths = ["/etc/", "/usr/", "/bin/", "/sbin/", "/sys/", "/proc/", "/dev/", "/root/"];
+	for (const sensitive of sensitivePaths) {
+		if (resolved.startsWith(sensitive)) {
+			return sensitive;
+		}
+	}
+	return undefined;
+}
+
+function isSensitiveHomePath(resolved: string): string | undefined {
+	const homeDir = process.env.HOME ?? "";
+	const homeSensitivePaths = [
+		path.join(homeDir, ".ssh"),
+		path.join(homeDir, ".aws"),
+		path.join(homeDir, ".gnupg"),
+		path.join(homeDir, ".pki"),
+	];
+	for (const sensitive of homeSensitivePaths) {
+		if (resolved.startsWith(sensitive)) {
+			return sensitive;
+		}
+	}
+	return undefined;
+}
+
+export async function validatePath(filePath: string, checkSymlink: boolean = false): Promise<PathValidationResult> {
+	const normalized = path.normalize(filePath);
+	if (normalized.includes("..")) {
+		return { valid: false, error: 'Path cannot contain ".." for security reasons' };
+	}
+
+	const resolved = path.resolve(filePath);
+
+	const systemPath = isSensitiveSystemPath(resolved);
+	if (systemPath) {
+		return { valid: false, error: `Cannot write to system path: ${systemPath}` };
+	}
+
+	const homePath = isSensitiveHomePath(resolved);
+	if (homePath) {
+		return {
+			valid: false,
+			error: `Cannot write to sensitive directory: ${path.basename(homePath)}`,
+		};
+	}
+
+	if (checkSymlink) {
+		try {
+			const stats = await fs.lstat(resolved);
+			if (stats.isSymbolicLink()) {
+				const linkTarget = await fs.readlink(resolved);
+				const target = path.resolve(path.dirname(resolved), linkTarget);
+				const targetSystem = isSensitiveSystemPath(target);
+				const targetHome = isSensitiveHomePath(target);
+				if (targetSystem || targetHome || target.includes("..")) {
+					return { valid: false, error: "Symlink points to restricted location" };
+				}
+			}
+		} catch {
+			// File doesn't exist yet, skip symlink check
+		}
+	}
+
+	return { valid: true };
+}
+
+export function validateEditString(str: string): PathValidationResult {
+	const pathTraversalPattern = /\.\.[\\/]/;
+	if (pathTraversalPattern.test(str)) {
+		return { valid: false, error: "Edit strings must not contain path traversal sequences" };
+	}
+	return { valid: true };
+}


### PR DESCRIPTION
## What

Extract path-validation helpers (handleFileError, handleDirError, isSensitiveFile, validatePath, validateEditString) from file-tools.ts (449 lines) into file-utils.ts (~120 lines).

## Why

Path-validation logic is independent of the tool definitions. Extracting it improves separation of concerns and makes both files easier to test.

## How

- file-utils.ts (new, ~120 lines): extracted helpers + SENSITIVE_PATTERNS + PathValidationResult interface
- file-tools.ts (modified, 449→~320 lines): removed extracted code, imports + re-exports from file-utils.ts for backward compat
- All 5 exported helpers re-exported from file-tools.ts; tests continue to work via re-export chain