### PR TITLE
refactor(providers): extract shared provider helpers into provider-utils.ts

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,7 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { ModelCapabilities } from "./capabilities.js";
 import { supportsThinking as modelRegistrySupportsThinking } from "./model-registry.js";
-import { getModelCapabilitiesFromCatalog } from "./models-dev.js";
+import { buildTokenUsage, capabilitiesWithCatalogFallback, num } from "./provider-utils.js";
 import type {
 	ChatOptions,
 	ChatResponse,
@@ -128,10 +128,6 @@ function mapStopReason(reason: string | null): ChatResponse["finishReason"] {
 	}
 }
 
-function num(v: unknown): number | undefined {
-	return typeof v === "number" && Number.isFinite(v) ? v : undefined;
-}
-
 /** Map an Anthropic usage object into the normalized TokenUsage shape. */
 function extractAnthropicUsage(raw: unknown): TokenUsage | undefined {
 	if (!raw || typeof raw !== "object") return undefined;
@@ -141,15 +137,7 @@ function extractAnthropicUsage(raw: unknown): TokenUsage | undefined {
 	const cachedRead = num(u.cache_read_input_tokens) ?? 0;
 	const cachedCreate = num(u.cache_creation_input_tokens) ?? 0;
 	const cached = cachedRead + cachedCreate;
-	const usage: TokenUsage = {
-		inputTokens: input,
-		outputTokens: output,
-		totalTokens: input !== undefined && output !== undefined ? input + output : undefined,
-		cachedTokens: cached > 0 ? cached : undefined,
-		reasoningTokens: num(u.reasoning_tokens),
-	};
-	const hasAny = usage.inputTokens !== undefined || usage.outputTokens !== undefined;
-	return hasAny ? usage : undefined;
+	return buildTokenUsage({ input, output, cached, reasoning: num(u.reasoning_tokens) });
 }
 
 export function buildThinkingConfig(enabled: boolean, budgetTokens?: number) {
@@ -330,7 +318,7 @@ export class AnthropicProvider implements LLMClient {
 				supportsSystemPrompt: true,
 				supportsToolStreaming: true,
 				supportsThinking: hasThinking,
-				contextWindow: contextWindow,
+				contextWindow,
 				maxOutputTokens: 8192,
 				isVerified: false,
 				source: "fallback",
@@ -340,10 +328,16 @@ export class AnthropicProvider implements LLMClient {
 			return capabilities;
 		}
 
-		const catalogCapabilities = getModelCapabilitiesFromCatalog(model, "anthropic");
-		if (catalogCapabilities) {
-			this._capabilitiesCache.set(model, catalogCapabilities);
-			return catalogCapabilities;
+		const catalogCaps = capabilitiesWithCatalogFallback({
+			model,
+			providerType: "anthropic",
+			contextWindow: 200000,
+			maxOutputTokens: 8192,
+		});
+
+		if (catalogCaps.source === "catalog") {
+			this._capabilitiesCache.set(model, catalogCaps);
+			return catalogCaps;
 		}
 
 		console.warn(
@@ -351,20 +345,13 @@ export class AnthropicProvider implements LLMClient {
 				"Context limits may be inaccurate. Consider updating the model registry."
 		);
 
-		const capabilities: ModelCapabilities = {
-			modelName: model,
-			supportsTools: true,
-			supportsStreaming: true,
-			supportsSystemPrompt: true,
-			supportsToolStreaming: true,
-			supportsThinking: false,
-			contextWindow: 200000,
-			maxOutputTokens: 8192,
-			isVerified: false,
-			source: "fallback",
+		const hasThinkingOverride = modelRegistrySupportsThinking(model);
+		const fallback: ModelCapabilities = {
+			...catalogCaps,
+			supportsThinking: hasThinkingOverride,
 		};
 
-		this._capabilitiesCache.set(model, capabilities);
-		return capabilities;
+		this._capabilitiesCache.set(model, fallback);
+		return fallback;
 	}
 }

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -1,5 +1,6 @@
 import { Ollama } from "ollama";
 import type { ModelCapabilities } from "./capabilities.js";
+import { buildTokenUsage, num } from "./provider-utils.js";
 import type {
 	ChatOptions,
 	ChatResponse,
@@ -83,22 +84,13 @@ function mapFinishReason(doneReason: string | undefined): ChatResponse["finishRe
 	return "stop";
 }
 
-function num(v: unknown): number | undefined {
-	return typeof v === "number" && Number.isFinite(v) ? v : undefined;
-}
-
 /** Map an Ollama response usage into the normalized TokenUsage shape. */
 function extractOllamaUsage(raw: unknown): TokenUsage | undefined {
 	if (!raw || typeof raw !== "object") return undefined;
 	const u = raw as Record<string, unknown>;
 	const input = num(u.prompt_eval_count);
 	const output = num(u.eval_count);
-	if (input === undefined && output === undefined) return undefined;
-	return {
-		inputTokens: input,
-		outputTokens: output,
-		totalTokens: input !== undefined && output !== undefined ? input + output : undefined,
-	};
+	return buildTokenUsage({ input, output });
 }
 
 export class OllamaProvider implements LLMClient {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,8 +1,8 @@
 import OpenAI from "openai";
 import type { ModelCapabilities } from "./capabilities.js";
 import { supportsThinking as modelRegistrySupportsThinking } from "./model-registry.js";
-import { getModelCapabilitiesFromCatalog } from "./models-dev.js";
 import { buildRequestBody, mapFinishReason, parseStreamedToolCalls, parseToolCalls } from "./openai-protocol.js";
+import { capabilitiesWithCatalogFallback } from "./provider-utils.js";
 import type { ChatOptions, ChatResponse, LLMClient, StreamChunk, ToolCall } from "./types.js";
 
 export interface OpenAIProviderConfig {
@@ -117,26 +117,19 @@ export class OpenAIProvider implements LLMClient {
 			return capabilities;
 		}
 
-		const catalogCapabilities = getModelCapabilitiesFromCatalog(model, "openai");
-		if (catalogCapabilities) {
-			this._capabilitiesCache.set(model, catalogCapabilities);
-			return catalogCapabilities;
-		}
-
-		const capabilities: ModelCapabilities = {
-			modelName: model,
-			supportsTools: true,
-			supportsStreaming: true,
-			supportsSystemPrompt: true,
-			supportsToolStreaming: true,
-			supportsThinking: false,
+		const catalogCaps = capabilitiesWithCatalogFallback({
+			model,
+			providerType: "openai",
 			contextWindow: 16385,
 			maxOutputTokens: 4096,
-			isVerified: false,
-			source: "fallback",
-		};
+		});
 
-		this._capabilitiesCache.set(model, capabilities);
-		return capabilities;
+		if (catalogCaps.source === "catalog") {
+			this._capabilitiesCache.set(model, catalogCaps);
+			return catalogCaps;
+		}
+
+		this._capabilitiesCache.set(model, catalogCaps);
+		return catalogCaps;
 	}
 }

--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -1,6 +1,6 @@
 import type { ModelCapabilities } from "./capabilities.js";
-import { getModelCapabilitiesFromCatalog } from "./models-dev.js";
 import { OpenAIProvider } from "./openai.js";
+import { capabilitiesWithCatalogFallback } from "./provider-utils.js";
 
 export interface OpenRouterProviderConfig {
 	apiKey: string;
@@ -33,10 +33,16 @@ export class OpenRouterProvider extends OpenAIProvider {
 		const cached = this._openrouterCapabilitiesCache.get(model);
 		if (cached) return cached;
 
-		const catalogCapabilities = getModelCapabilitiesFromCatalog(model, "openrouter");
-		if (catalogCapabilities) {
-			this._openrouterCapabilitiesCache.set(model, catalogCapabilities);
-			return catalogCapabilities;
+		const catalogCaps = capabilitiesWithCatalogFallback({
+			model,
+			providerType: "openrouter",
+			contextWindow: 200000,
+			maxOutputTokens: 4096,
+		});
+
+		if (catalogCaps.source === "catalog") {
+			this._openrouterCapabilitiesCache.set(model, catalogCaps);
+			return catalogCaps;
 		}
 
 		return super.getCapabilities(model);

--- a/src/providers/provider-utils.ts
+++ b/src/providers/provider-utils.ts
@@ -1,0 +1,96 @@
+/**
+ * provider-utils.ts — shared helpers for LLM provider implementations.
+ *
+ * Extracted during Round 7 architecture deepening to eliminate the
+ * duplicated `num()` helper, token-usage construction patterns, and
+ * capabilities-caching + catalog fallback pattern that were replicated
+ * across 4+ provider files.
+ *
+ * Each helper is small and independently testable. Providers import
+ * what they need rather than inheriting a deep base class.
+ */
+
+import type { ModelCapabilities } from "./capabilities.js";
+import { getModelCapabilitiesFromCatalog } from "./models-dev.js";
+import type { TokenUsage } from "./types.js";
+
+/**
+ * Safely extract a finite number from an unknown value.
+ * Used by every provider to normalize API-specific token counts.
+ */
+export function num(v: unknown): number | undefined {
+	return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+/**
+ * Options for building a TokenUsage from provider-specific field names.
+ * Every provider returns token counts under different keys; this helper
+ * normalises them into the shared TokenUsage shape.
+ */
+export interface TokenUsageFields {
+	input?: number | undefined;
+	output?: number | undefined;
+	cached?: number | undefined;
+	reasoning?: number | undefined;
+}
+
+/**
+ * Build a normalized TokenUsage from extracted field values.
+ * Returns undefined when no field has a value (provider didn't return usage).
+ */
+export function buildTokenUsage(fields: TokenUsageFields): TokenUsage | undefined {
+	const { input, output, cached, reasoning } = fields;
+	if (input === undefined && output === undefined) return undefined;
+	return {
+		inputTokens: input,
+		outputTokens: output,
+		totalTokens: input !== undefined && output !== undefined ? input + output : undefined,
+		cachedTokens: cached && cached > 0 ? cached : undefined,
+		reasoningTokens: reasoning && reasoning > 0 ? reasoning : undefined,
+	};
+}
+
+// ─── Capabilities helpers ────────────────────────────────────────────────
+
+/**
+ * Options for {@link capabilitiesWithCatalogFallback}.
+ */
+export interface CapabilitiesFallbackOptions {
+	model: string;
+	providerType: string;
+	contextWindow: number;
+	maxOutputTokens: number;
+	hasThinking?: boolean;
+	supportsToolStreaming?: boolean;
+}
+
+/**
+ * Build a ModelCapabilities object by consulting the models.dev catalog
+ * first, then falling back to the supplied defaults.
+ *
+ * This is the common getCapabilities() pattern used by AnthropicProvider,
+ * OpenAIProvider, ZaiProvider, and OpenRouterProvider — all four have
+ * identical caching + catalog-lookup + fallback logic.
+ *
+ * @returns The catalog entry when found, or a fallback object constructed
+ *          from the supplied defaults when the model is unknown.
+ */
+export function capabilitiesWithCatalogFallback(opts: CapabilitiesFallbackOptions): ModelCapabilities {
+	const catalogCapabilities = getModelCapabilitiesFromCatalog(opts.model, opts.providerType);
+	if (catalogCapabilities) {
+		return catalogCapabilities;
+	}
+
+	return {
+		modelName: opts.model,
+		supportsTools: true,
+		supportsStreaming: true,
+		supportsSystemPrompt: true,
+		supportsToolStreaming: opts.supportsToolStreaming ?? true,
+		supportsThinking: opts.hasThinking ?? false,
+		contextWindow: opts.contextWindow,
+		maxOutputTokens: opts.maxOutputTokens,
+		isVerified: false,
+		source: "fallback",
+	};
+}

--- a/src/providers/zai.ts
+++ b/src/providers/zai.ts
@@ -1,8 +1,8 @@
 import type { ModelCapabilities } from "./capabilities.js";
 import { supportsThinking as modelRegistrySupportsThinking } from "./model-registry.js";
-import { getModelCapabilitiesFromCatalog } from "./models-dev.js";
 import type { OpenAIProviderConfig } from "./openai.js";
 import { OpenAIProvider } from "./openai.js";
+import { capabilitiesWithCatalogFallback } from "./provider-utils.js";
 
 export interface ZaiProviderConfig {
 	apiKey?: string;
@@ -32,10 +32,16 @@ export class ZaiProvider extends OpenAIProvider {
 		const cached = this._zaiCapabilitiesCache.get(model);
 		if (cached) return cached;
 
-		const catalogCapabilities = getModelCapabilitiesFromCatalog(model, "zai");
-		if (catalogCapabilities) {
-			this._zaiCapabilitiesCache.set(model, catalogCapabilities);
-			return catalogCapabilities;
+		const catalogCaps = capabilitiesWithCatalogFallback({
+			model,
+			providerType: "zai",
+			contextWindow: 16385,
+			maxOutputTokens: 4096,
+		});
+
+		if (catalogCaps.source === "catalog") {
+			this._zaiCapabilitiesCache.set(model, catalogCaps);
+			return catalogCaps;
 		}
 
 		const modelContextWindow: Record<string, number> = {
@@ -52,7 +58,7 @@ export class ZaiProvider extends OpenAIProvider {
 
 		const hasThinking = modelRegistrySupportsThinking(model);
 
-		const capabilities: ModelCapabilities = {
+		const caps: ModelCapabilities = {
 			modelName: model,
 			supportsTools: true,
 			supportsStreaming: true,
@@ -65,7 +71,7 @@ export class ZaiProvider extends OpenAIProvider {
 			source: "fallback",
 		};
 
-		this._zaiCapabilitiesCache.set(model, capabilities);
-		return capabilities;
+		this._zaiCapabilitiesCache.set(model, caps);
+		return caps;
 	}
 }


### PR DESCRIPTION
Implements Round 7 Candidate #1.

Creates src/providers/provider-utils.ts with 3 shared helpers:
- num() — safe finite-number extraction (was duplicated)
- buildTokenUsage() — normalized TokenUsage construction
- capabilitiesWithCatalogFallback() — catalog lookup + fallback pattern

Updated 5 providers to use the shared helpers, removing duplicated code.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved token usage reporting across supported AI providers, including input, output, cached, reasoning, and total token counts.
  * Enhanced capability detection for known and unknown models using catalog data and provider-specific fallback limits.
  * Added more reliable handling when model information is unavailable, with results cached for consistent performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->