### PR TITLE
refactor(tools): extract shared search helpers into search-utils.ts

### DIFF
--- a/src/tools/search-tools.ts
+++ b/src/tools/search-tools.ts
@@ -1,10 +1,16 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { findGitignorePatterns, isIgnored } from "./gitignore.js";
+import {
+	formatNotFound,
+	formatPermissionDenied,
+	formatResults,
+	MAX_LINE_LENGTH,
+	MAX_RESULTS,
+	matchesGlob,
+	shouldDescendIntoDir,
+} from "./search-utils.js";
 import type { Tool, ToolResult } from "./types.js";
-
-const MAX_RESULTS = 100;
-const MAX_LINE_LENGTH = 200;
 
 export const grepTool: Tool = {
 	name: "grep",
@@ -55,12 +61,9 @@ export const grepTool: Tool = {
 				return { success: true, output: "No matches found." };
 			}
 
-			const truncated = results.length > MAX_RESULTS;
-			const output = results.slice(0, MAX_RESULTS).join("\n");
-
 			return {
 				success: true,
-				output: truncated ? `${output}\n\n... (${results.length - MAX_RESULTS} more results truncated)` : output,
+				output: formatResults(results),
 			};
 		} catch (err) {
 			if (err instanceof SyntaxError) {
@@ -68,10 +71,10 @@ export const grepTool: Tool = {
 			}
 			const error = err as NodeJS.ErrnoException;
 			if (error.code === "ENOENT") {
-				return { success: false, error: `Path not found: ${searchPath}` };
+				return { success: false, error: formatNotFound(searchPath) };
 			}
 			if (error.code === "EACCES") {
-				return { success: false, error: `Permission denied: ${searchPath}` };
+				return { success: false, error: formatPermissionDenied(searchPath) };
 			}
 			return { success: false, error: `Search failed: ${error.message}` };
 		}
@@ -200,16 +203,6 @@ async function searchInFile(filePath: string, regex: RegExp, results: string[]):
 		}
 	}
 }
-
-function matchesGlob(filename: string, pattern: string): boolean {
-	const normalizedPath = filename.split(path.sep).join("/");
-
-	const regexPattern = pattern.replace(/\./g, "\\.").replace(/\*\*/g, ".*").replace(/\*/g, "[^/]*").replace(/\?/g, ".");
-
-	const regex = new RegExp(`^${regexPattern}$`, "i");
-	return regex.test(normalizedPath);
-}
-
 export const globTool: Tool = {
 	name: "glob",
 	description: "Find files by glob pattern (e.g., **/*.ts). Returns matching file paths.",
@@ -241,20 +234,17 @@ export const globTool: Tool = {
 				return { success: true, output: "No matching files found." };
 			}
 
-			const truncated = results.length > MAX_RESULTS;
-			const output = results.slice(0, MAX_RESULTS).join("\n");
-
 			return {
 				success: true,
-				output: truncated ? `${output}\n\n... (${results.length - MAX_RESULTS} more results truncated)` : output,
+				output: formatResults(results),
 			};
 		} catch (err) {
 			const error = err as NodeJS.ErrnoException;
 			if (error.code === "ENOENT") {
-				return { success: false, error: `Path not found: ${searchPath}` };
+				return { success: false, error: formatNotFound(searchPath) };
 			}
 			if (error.code === "EACCES") {
-				return { success: false, error: `Permission denied: ${searchPath}` };
+				return { success: false, error: formatPermissionDenied(searchPath) };
 			}
 			return { success: false, error: `Glob search failed: ${error.message}` };
 		}
@@ -336,19 +326,4 @@ async function globFiles(basePath: string, pattern: string, relativePath: string
 		}
 	}
 }
-
-function shouldDescendIntoDir(pattern: string, dirPath: string): boolean {
-	const patternParts = pattern.split("/").filter((p) => p !== "**");
-	const dirParts = dirPath.split(path.sep);
-
-	for (let i = 0; i < dirParts.length && i < patternParts.length; i++) {
-		const patternPart = patternParts[i];
-		const dirPart = dirParts[i];
-		if (patternPart && dirPart && !matchesGlob(dirPart, patternPart)) {
-			return false;
-		}
-	}
-	return true;
-}
-
 export const searchTools: Tool[] = [grepTool, globTool];

--- a/src/tools/search-utils.ts
+++ b/src/tools/search-utils.ts
@@ -1,0 +1,73 @@
+/**
+ * search-utils.ts — shared formatting and utility helpers for search tools.
+ *
+ * Extracted from search-tools.ts (Round 7 Candidate #5) so the glob-matching
+ * and result-truncation logic can be reused without duplication between the
+ * grep and glob tools.
+ */
+
+import * as path from "node:path";
+
+/** Maximum results returned by any search tool. */
+export const MAX_RESULTS = 100;
+
+/** Maximum line length before truncating output lines. */
+export const MAX_LINE_LENGTH = 200;
+
+/**
+ * Format search results with truncation when they exceed the limit.
+ */
+export function formatResults(results: string[], maxResults: number = MAX_RESULTS): string {
+	if (results.length === 0) {
+		return "No matching files found.";
+	}
+
+	const truncated = results.length > maxResults;
+	const output = results.slice(0, maxResults).join("\n");
+
+	return truncated ? `${output}\n\n... (${results.length - maxResults} more results truncated)` : output;
+}
+
+/**
+ * Build a standard not-found error result for search tools.
+ */
+export function formatNotFound(path?: string): string {
+	return `Path not found: ${path ?? "(unknown)"}`;
+}
+
+/**
+ * Build a standard permission-denied error result for search tools.
+ */
+export function formatPermissionDenied(path?: string): string {
+	return `Permission denied: ${path ?? "(unknown)"}`;
+}
+
+/**
+ * Check whether a filename matches a glob pattern.
+ */
+export function matchesGlob(filename: string, pattern: string): boolean {
+	const normalizedPath = filename.split(path.sep).join("/");
+
+	const regexPattern = pattern.replace(/\./g, "\\.").replace(/\*\*/g, ".*").replace(/\*/g, "[^/]*").replace(/\?/g, ".");
+
+	const regex = new RegExp(`^${regexPattern}$`, "i");
+	return regex.test(normalizedPath);
+}
+
+/**
+ * Check whether the directory path could match a pattern.
+ * Used to prune descending into non-matching directories.
+ */
+export function shouldDescendIntoDir(pattern: string, dirPath: string): boolean {
+	const patternParts = pattern.split("/").filter((p) => p !== "**");
+	const dirParts = dirPath.split(path.sep);
+
+	for (let i = 0; i < dirParts.length && i < patternParts.length; i++) {
+		const patternPart = patternParts[i];
+		const dirPart = dirParts[i];
+		if (patternPart && dirPart && !matchesGlob(dirPart, patternPart)) {
+			return false;
+		}
+	}
+	return true;
+}


### PR DESCRIPTION
Implements Round 7 Candidate #5.

Creates src/tools/search-utils.ts with 5 shared helpers used by both
grep and glob tools:
- formatResults() — result truncation logic (was duplicated across both execute() methods)
- formatNotFound() / formatPermissionDenied() — standardized error messages
- matchesGlob() — glob pattern matching with path.sep normalization
- shouldDescendIntoDir() — directory traversal pruning

search-tools.ts now imports from search-utils.js instead of inlining.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>