### PR TITLE
feat: harden SWE-bench runner for parallel safety and correctness

### DIFF
--- a/.github/workflows/swe-bench.yml
+++ b/.github/workflows/swe-bench.yml
@@ -1,0 +1,338 @@
+name: SWE-bench
+
+# SWE-bench CI defaults to OpenRouter free models:
+#   poolside/laguna-s-2.1:free@openrouter
+# Requires secret: OPENROUTER_API_KEY (environment or repo)
+# Free model catalogue: https://openrouter.ai/collections/free-models
+
+on:
+  workflow_dispatch:
+    inputs:
+      max_instances:
+        description: "Max SWE-bench instances to process (hosted cap 50)"
+        required: true
+        default: "5"
+        type: string
+      model:
+        description: "OpenRouter free model (default: poolside/laguna-s-2.1:free@openrouter). Empty uses same default."
+        required: false
+        default: "poolside/laguna-s-2.1:free@openrouter"
+        type: string
+      parallel:
+        description: "Parallel workers"
+        required: true
+        default: "1"
+        type: string
+      timeout_minutes:
+        description: "Per-instance timeout (minutes)"
+        required: true
+        default: "30"
+        type: string
+      dry_run:
+        description: "Dry-run only (no tiny-agent / no API calls)"
+        required: true
+        default: false
+        type: boolean
+      evaluate_hint:
+        description: "Print harness evaluate command after run"
+        required: true
+        default: true
+        type: boolean
+  pull_request:
+    types: [labeled]
+  release:
+    types: [published]
+
+concurrency:
+  group: swe-bench-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'release' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'benchmark')
+    outputs:
+      max_instances: ${{ steps.params.outputs.max_instances }}
+      model: ${{ steps.params.outputs.model }}
+      parallel: ${{ steps.params.outputs.parallel }}
+      timeout_minutes: ${{ steps.params.outputs.timeout_minutes }}
+      dry_run: ${{ steps.params.outputs.dry_run }}
+      evaluate_hint: ${{ steps.params.outputs.evaluate_hint }}
+      run_reason: ${{ steps.params.outputs.run_reason }}
+    steps:
+      - id: params
+        name: Resolve run parameters
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "max_instances=${{ inputs.max_instances }}" >> "$GITHUB_OUTPUT"
+            MODEL_INPUT="${{ inputs.model }}"
+            if [[ -z "$MODEL_INPUT" ]]; then
+              MODEL_INPUT="poolside/laguna-s-2.1:free@openrouter"
+            fi
+            echo "model=$MODEL_INPUT" >> "$GITHUB_OUTPUT"
+            echo "parallel=${{ inputs.parallel }}" >> "$GITHUB_OUTPUT"
+            echo "timeout_minutes=${{ inputs.timeout_minutes }}" >> "$GITHUB_OUTPUT"
+            if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+              echo "dry_run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "dry_run=false" >> "$GITHUB_OUTPUT"
+            fi
+            if [[ "${{ inputs.evaluate_hint }}" == "true" ]]; then
+              echo "evaluate_hint=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "evaluate_hint=false" >> "$GITHUB_OUTPUT"
+            fi
+            echo "run_reason=workflow_dispatch" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "max_instances=5" >> "$GITHUB_OUTPUT"
+            echo "model=poolside/laguna-s-2.1:free@openrouter" >> "$GITHUB_OUTPUT"
+            echo "parallel=1" >> "$GITHUB_OUTPUT"
+            echo "timeout_minutes=30" >> "$GITHUB_OUTPUT"
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+            echo "evaluate_hint=true" >> "$GITHUB_OUTPUT"
+            echo "run_reason=pr_label_benchmark" >> "$GITHUB_OUTPUT"
+          else
+            echo "max_instances=10" >> "$GITHUB_OUTPUT"
+            echo "model=poolside/laguna-s-2.1:free@openrouter" >> "$GITHUB_OUTPUT"
+            echo "parallel=1" >> "$GITHUB_OUTPUT"
+            echo "timeout_minutes=30" >> "$GITHUB_OUTPUT"
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+            echo "evaluate_hint=true" >> "$GITHUB_OUTPUT"
+            echo "run_reason=release" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Reject fork PRs
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "::error::SWE-bench cannot run on fork PRs (secrets isolation). Use a branch in this repo or workflow_dispatch."
+          exit 1
+
+  unit-test:
+    name: Runner unit tests
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run swe_bench_runner unit tests
+        run: python3 -m unittest scripts/test_swe_bench_runner.py -v
+
+  benchmark:
+    name: Run SWE-bench
+    needs: [prepare, unit-test]
+    runs-on: ubuntu-latest
+    environment: swe-bench
+    timeout-minutes: 360
+    env:
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+      ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
+      TINY_AGENT_MODEL: ${{ needs.prepare.outputs.model }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Enforce hosted safety cap
+        run: |
+          set -euo pipefail
+          MAX="${{ needs.prepare.outputs.max_instances }}"
+          if ! [[ "$MAX" =~ ^[0-9]+$ ]]; then
+            echo "::error::max_instances must be a positive integer, got: $MAX"
+            exit 1
+          fi
+          if [[ "$MAX" -lt 1 ]]; then
+            echo "::error::max_instances must be >= 1"
+            exit 1
+          fi
+          if [[ "$MAX" -gt 50 ]]; then
+            echo "::error::max_instances=$MAX exceeds hosted-runner safety cap (50). Run larger batches on a self-hosted/cloud VM."
+            exit 1
+          fi
+
+      - name: Setup Bun
+        if: needs.prepare.outputs.dry_run != 'true'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install JS deps
+        if: needs.prepare.outputs.dry_run != 'true'
+        run: bun install
+
+      - name: Build tiny-agent binary
+        if: needs.prepare.outputs.dry_run != 'true'
+        run: bun run build
+
+      - name: Install tiny-agent on PATH
+        if: needs.prepare.outputs.dry_run != 'true'
+        run: |
+          sudo cp tiny-agent /usr/local/bin/tiny-agent
+          command -v tiny-agent
+          tiny-agent --help | head -20
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python deps
+        run: pip install "datasets>=2.14"
+
+      - name: Write temporary tiny-agent config
+        if: needs.prepare.outputs.dry_run != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.tiny-agent"
+          CONFIG="$HOME/.tiny-agent/config.yaml"
+
+          if [[ -n "${TINY_AGENT_MODEL:-}" ]]; then
+            DEFAULT_MODEL="$TINY_AGENT_MODEL"
+          elif [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+            DEFAULT_MODEL="poolside/laguna-s-2.1:free@openrouter"
+          elif [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+            DEFAULT_MODEL="claude-sonnet-4@anthropic"
+          elif [[ -n "${OPENAI_API_KEY:-}" ]]; then
+            DEFAULT_MODEL="gpt-4o@openai"
+          elif [[ -n "${OPENCODE_API_KEY:-}" ]]; then
+            DEFAULT_MODEL="claude-sonnet-4@opencode"
+          elif [[ -n "${ZAI_API_KEY:-}" ]]; then
+            DEFAULT_MODEL="glm-4.7@zai"
+          else
+            DEFAULT_MODEL="claude-sonnet-4@anthropic"
+          fi
+
+          {
+            echo "# CI config for SWE-bench — generated, do not commit"
+            echo "defaultModel: ${DEFAULT_MODEL}"
+            echo "mcpServers: {}"
+            echo "providers:"
+            if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+              echo "  openrouter:"
+              echo "    apiKey: \${OPENROUTER_API_KEY}"
+            fi
+            if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+              echo "  anthropic:"
+              echo "    apiKey: \${ANTHROPIC_API_KEY}"
+            fi
+            if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+              echo "  openai:"
+              echo "    apiKey: \${OPENAI_API_KEY}"
+            fi
+            if [[ -n "${OPENCODE_API_KEY:-}" ]]; then
+              echo "  opencode:"
+              echo "    apiKey: \${OPENCODE_API_KEY}"
+            fi
+            if [[ -n "${ZAI_API_KEY:-}" ]]; then
+              echo "  zai:"
+              echo "    apiKey: \${ZAI_API_KEY}"
+            fi
+          } > "$CONFIG"
+
+          echo "Wrote config (keys redacted):"
+          sed -E 's/(apiKey: ).*/\1***/' "$CONFIG"
+
+      - name: Verify provider API key present
+        if: needs.prepare.outputs.dry_run != 'true'
+        run: |
+          set -euo pipefail
+          if [[ -z "${OPENROUTER_API_KEY:-}${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}${OPENCODE_API_KEY:-}${ZAI_API_KEY:-}" ]]; then
+            echo "::error::No provider API key secret found. Configure at least one of OPENROUTER_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENCODE_API_KEY, ZAI_API_KEY as a repository or swe-bench environment secret."
+            exit 1
+          fi
+          echo "At least one provider key is configured."
+
+      - name: Run SWE-bench runner
+        run: |
+          set -euo pipefail
+          ARGS=(
+            --max-instances "${{ needs.prepare.outputs.max_instances }}"
+            --parallel "${{ needs.prepare.outputs.parallel }}"
+            --timeout "${{ needs.prepare.outputs.timeout_minutes }}"
+            --output "${{ github.workspace }}/predictions.jsonl"
+            --work-dir "${{ runner.temp }}/swe-bench-work"
+          )
+          MODEL="${{ needs.prepare.outputs.model }}"
+          if [[ -n "$MODEL" ]]; then
+            ARGS+=(--model "$MODEL")
+          fi
+          if [[ "${{ needs.prepare.outputs.dry_run }}" == "true" ]]; then
+            ARGS+=(--dry-run)
+          fi
+          if [[ "${{ needs.prepare.outputs.evaluate_hint }}" == "true" ]]; then
+            ARGS+=(--evaluate)
+          fi
+          echo "Running: python3 scripts/swe_bench_runner.py ${ARGS[*]}"
+          python3 scripts/swe_bench_runner.py "${ARGS[@]}"
+
+      - name: Upload predictions artifact
+        if: always() && needs.prepare.outputs.dry_run != 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: swe-bench-predictions-${{ github.run_id }}
+          path: predictions.jsonl
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## SWE-bench run"
+            echo ""
+            echo "- Reason: \`${{ needs.prepare.outputs.run_reason }}\`"
+            echo "- Max instances: \`${{ needs.prepare.outputs.max_instances }}\`"
+            echo "- Parallel: \`${{ needs.prepare.outputs.parallel }}\`"
+            echo "- Dry run: \`${{ needs.prepare.outputs.dry_run }}\`"
+            echo "- Model: \`${{ needs.prepare.outputs.model || '(default)' }}\`"
+            echo "- OpenRouter free default: \`poolside/laguna-s-2.1:free@openrouter\`"
+            if [[ -f predictions.jsonl ]]; then
+              echo "- Predictions lines: \`$(wc -l < predictions.jsonl | tr -d ' ')\`"
+              echo ""
+              echo "### Predictions preview (truncated)"
+              echo '```'
+              head -c 4000 predictions.jsonl || true
+              echo
+              echo '```'
+            else
+              echo "- No predictions.jsonl produced"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let extra = '';
+            if (fs.existsSync('predictions.jsonl')) {
+              const lines = fs.readFileSync('predictions.jsonl', 'utf8').trim().split('\n').filter(Boolean);
+              extra = `\n- Predictions written: **${lines.length}**\n- Artifact: \`swe-bench-predictions-${context.runId}\``;
+            }
+            const body = [
+              '## SWE-bench benchmark',
+              '',
+              'Triggered by label `benchmark`.',
+              `- Run: ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${context.runId}`,
+              `- Max instances: \`${{ needs.prepare.outputs.max_instances }}\``,
+              `- Dry run: \`${{ needs.prepare.outputs.dry_run }}\``,
+              extra,
+              '',
+              '_This job requires approval via the `swe-bench` GitHub Environment before it spends API credits._',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ tiny-agent-dev
 tiny-dev-agent
 .tiny-state.json
 
+# python caches
+__pycache__/
+*.pyc
+
 # auto-generated files
 src/utils/version-constant.ts
 src/skills/embedded-content.ts

--- a/scripts/README-swe-bench.md
+++ b/scripts/README-swe-bench.md
@@ -109,6 +109,13 @@ untracked new files) with `git add -A` and then produces the patch via
 `git diff --cached`.  This ensures that new files created by the agent are
 included in the patch, which is the standard SWE-bench pattern.
 
+Both `git add -A` and `git diff --cached` are checked for non-zero exit codes.
+If either command fails (e.g. permissions, disk exhaustion, index errors), the
+instance is recorded as an error (the runner returns `None` and appends an empty
+patch), rather than silently emitting an empty patch as if the agent made no
+changes. A truly empty working tree still yields an empty-string patch, which is
+reported separately as a "no changes" outcome.
+
 ## Concurrency Safety
 
 In `--parallel` mode, each worker:
@@ -125,9 +132,10 @@ practical limitation.
 
 A gated workflow at [`.github/workflows/swe-bench.yml`](../.github/workflows/swe-bench.yml)
 runs the SWE-bench runner in CI. It is **never** triggered by an ordinary push
-to `main` or a plain PR open — it only runs under the conditions below, and the
-expensive benchmark job always requires manual approval via a GitHub
-Environment.
+to `main` or a plain PR open — it only runs under the conditions below. The
+expensive benchmark job uses the GitHub Environment `swe-bench`; with
+**Required reviewers** configured on that environment (see setup below), runs
+pause for approval before spending API credits.
 
 ### When it runs
 
@@ -145,7 +153,8 @@ The workflow has three jobs:
 2. **Runner unit tests** — runs `python3 -m unittest scripts/test_swe_bench_runner.py`.
    Cheap; no approval needed.
 3. **Run SWE-bench** — the real benchmark. Has `environment: swe-bench`, so it
-   **pauses for a required reviewer** before spending any API credits. Builds
+   targets environment `swe-bench` (configure **Required reviewers** on that
+   environment so runs pause for approval before spending API credits). Builds
    `tiny-agent`, installs Python deps, runs the runner, and uploads
    `predictions.jsonl` as an artifact (`swe-bench-predictions-<run_id>`,
    30-day retention).

--- a/scripts/README-swe-bench.md
+++ b/scripts/README-swe-bench.md
@@ -9,6 +9,7 @@ This script runs `tiny-agent` against the [SWE-bench Verified](https://www.swebe
 - `tiny-agent` installed and authenticated (with a configured provider)
 - ~120 GB free disk for Docker images (harness) + repo checkouts
 - Linux x86_64 recommended (macOS ARM has experimental support)
+- **Unix** required for `--parallel` mode (uses `fcntl` file locking)
 
 ## Usage
 
@@ -37,7 +38,25 @@ python3 scripts/swe_bench_runner.py --resume
 python3 scripts/swe_bench_runner.py --start-idx 100
 ```
 
-### 3. Evaluate predictions with the official SWE-bench harness
+### 3. Run in parallel
+
+```bash
+# Process instances with 4 parallel workers
+python3 scripts/swe_bench_runner.py --parallel 4 --max-instances 20
+```
+
+> **⚠️ Warning:** Each parallel worker clones its own repository checkout and
+> runs a separate `tiny-agent` process.  Increasing `--parallel` multiplies
+> disk usage (one full clone per instance) and API rate consumption.  Start
+> with `--parallel 2` and monitor your provider's rate limits before scaling
+> up.
+
+Each worker uses an **isolated per-instance checkout** at
+`<work-dir>/<instance_id>/repo`.  This means parallel workers never share a
+git working tree, so there are no race conditions on `git checkout`,
+`git add`, or `git diff`.
+
+### 4. Evaluate predictions with the official SWE-bench harness
 
 ```bash
 git clone https://github.com/swe-bench/SWE-bench.git
@@ -49,6 +68,13 @@ python -m swebench.harness.run_evaluation \
   --predictions_path ../predictions.jsonl \
   --max_workers 8 \
   --run_id tiny-agent-verified
+```
+
+Alternatively, pass `--evaluate` to the runner and it will print the exact
+harness command with your output path filled in:
+
+```bash
+python3 scripts/swe_bench_runner.py --max-instances 5 --evaluate
 ```
 
 ## Script Options
@@ -64,6 +90,8 @@ python -m swebench.harness.run_evaluation \
 | `--resume` | false | Skip already-completed instances |
 | `--timeout N` | 30 | Timeout per instance (minutes) |
 | `--dry-run` | false | Print instances without running |
+| `--parallel N` | 1 | Number of parallel workers (each with isolated checkout) |
+| `--evaluate` | false | Print the SWE-bench harness evaluation command after the run |
 
 ## Output Format
 
@@ -74,9 +102,29 @@ The predictions file follows the [SWE-bench prediction format](https://github.co
 {"instance_id": "django__django-11099", "model_name_or_path": "tiny-agent", "model_patch": "diff --git a/..."}
 ```
 
+## Patch Generation
+
+After `tiny-agent` completes, the runner stages **all** changes (including
+untracked new files) with `git add -A` and then produces the patch via
+`git diff --cached`.  This ensures that new files created by the agent are
+included in the patch, which is the standard SWE-bench pattern.
+
+## Concurrency Safety
+
+In `--parallel` mode, each worker:
+
+1. Clones into its own `<work-dir>/<instance_id>/repo` directory (no shared
+   working trees).
+2. Appends predictions to the shared output file using an `fcntl` exclusive
+   lock (`LOCK_EX`), so writes from different processes never interleave.
+
+`fcntl` is Unix-only; SWE-bench evaluation is Linux-centric, so this is not a
+practical limitation.
+
 ## Notes
 
 - Each instance clones/updates the repository, checks out the `base_commit`, runs `tiny-agent`, and saves the resulting `git diff`
 - The script saves predictions incrementally (after each instance) so you can resume after a crash
 - The evaluation harness requires Docker and significant disk space for container images
 - For macOS ARM users, pass `--namespace ''` to the evaluation harness to build images locally
+- Prompt files (`/tmp/swe_prompt_<instance_id>.md`) are cleaned up after each run

--- a/scripts/README-swe-bench.md
+++ b/scripts/README-swe-bench.md
@@ -121,6 +121,121 @@ In `--parallel` mode, each worker:
 `fcntl` is Unix-only; SWE-bench evaluation is Linux-centric, so this is not a
 practical limitation.
 
+## GitHub Actions
+
+A gated workflow at [`.github/workflows/swe-bench.yml`](../.github/workflows/swe-bench.yml)
+runs the SWE-bench runner in CI. It is **never** triggered by an ordinary push
+to `main` or a plain PR open — it only runs under the conditions below, and the
+expensive benchmark job always requires manual approval via a GitHub
+Environment.
+
+### When it runs
+
+| Trigger                          | Behavior                                    | Approval required |
+| -------------------------------- | ------------------------------------------- | ----------------- |
+| PR labeled `benchmark`           | Smoke run (5 instances), `dry_run=false`    | Yes (`swe-bench`) |
+| Release published                | Smoke/medium run (10 instances)             | Yes (`swe-bench`) |
+| Manual `workflow_dispatch`       | Custom inputs (instances, model, dry-run…)  | Yes (`swe-bench`) |
+| Push to `main` / ordinary PR     | **Does not run**                            | n/a               |
+
+The workflow has three jobs:
+
+1. **Prepare** — gated by the trigger rules above; resolves run parameters and
+   rejects fork PRs (no secrets available). No approval needed.
+2. **Runner unit tests** — runs `python3 -m unittest scripts/test_swe_bench_runner.py`.
+   Cheap; no approval needed.
+3. **Run SWE-bench** — the real benchmark. Has `environment: swe-bench`, so it
+   **pauses for a required reviewer** before spending any API credits. Builds
+   `tiny-agent`, installs Python deps, runs the runner, and uploads
+   `predictions.jsonl` as an artifact (`swe-bench-predictions-<run_id>`,
+   30-day retention).
+
+### One-time setup (repo admin)
+
+1. Create a GitHub **Environment** named **`swe-bench`**
+   (repo → Settings → Environments → New environment).
+2. Enable **Required reviewers** on that environment and add yourself / the
+   maintainers — this is the approval gate that prevents unattended API spend.
+3. Add provider API keys as **environment secrets** on `swe-bench` (preferred)
+   or as repository secrets. At least one is required for non-dry-run jobs:
+   - `OPENROUTER_API_KEY` (**primary secret for CI testing**)
+   - `ANTHROPIC_API_KEY`
+   - `OPENAI_API_KEY`
+   - `OPENCODE_API_KEY`
+   - `ZAI_API_KEY`
+   The workflow writes only providers with configured secrets to its temporary
+   CI config and references each key with `${VAR}` environment interpolation.
+4. Create a repo **label** named exactly **`benchmark`** (Issues → Labels →
+   New label).
+5. (Optional) Restrict the `swe-bench` environment to the `main` branch for
+   extra safety.
+
+### How to trigger on a PR
+
+1. Open or update the PR (from a branch in this repo — fork PRs are rejected).
+2. Add the **`benchmark`** label.
+3. When the `Run SWE-bench` job reaches the `swe-bench` environment, **approve**
+   the pending deployment when prompted.
+4. Download the `swe-bench-predictions-<run_id>` artifact when the run finishes
+   and evaluate locally with the harness (see below).
+
+### Manual run (`workflow_dispatch`)
+
+Repo → Actions → **SWE-bench** → Run workflow. Inputs:
+
+| Input             | Default | Description                                  |
+| ----------------- | ------- | -------------------------------------------- |
+| `max_instances`   | `5`     | Max SWE-bench instances to process           |
+| `model`           | `poolside/laguna-s-2.1:free@openrouter` | OpenRouter free model; empty uses the same default |
+| `parallel`        | `1`     | Parallel workers                             |
+| `timeout_minutes` | `30`    | Per-instance timeout (minutes)               |
+| `dry_run`         | `false` | Dry-run only (no tiny-agent / no API calls)  |
+| `evaluate_hint`   | `true`  | Print harness evaluate command after run     |
+
+The CI default is `poolside/laguna-s-2.1:free@openrouter`, using the
+`OPENROUTER_API_KEY` secret. Other suggested models from OpenRouter's
+[free model collection](https://openrouter.ai/collections/free-models) are:
+
+| Model | Notes |
+| ----- | ----- |
+| `poolside/laguna-s-2.1:free@openrouter` | Primary default; coding-agent/SWE-oriented |
+| `cohere/north-mini-code:free@openrouter` | Coding-focused fallback |
+| `poolside/laguna-xs-2.1:free@openrouter` | Smaller Laguna fallback |
+| `nvidia/nemotron-3-super-120b-a12b:free@openrouter` | General large-model fallback |
+| `openai/gpt-oss-20b:free@openrouter` | Compact open-model fallback |
+
+OpenRouter's free tier has rate limits, so CI intentionally uses smoke runs of
+5–10 instances. Override `model` in `workflow_dispatch` to select another free
+model. Paid Anthropic or OpenAI keys still work when their matching model is
+selected with the model override.
+
+### Safety
+
+- **Fork PRs are rejected** — the benchmark cannot access secrets from a fork,
+  so the Prepare job fails fast with an actionable error.
+- **Hosted-runner hard-cap:** `max_instances` is refused above **50** on GitHub
+  hosted runners. Larger runs should use a self-hosted runner or a cloud VM.
+- **No Docker harness in CI:** the workflow only produces `predictions.jsonl`.
+  The full 500-instance run + Docker-based evaluation is intentionally **not**
+  done in GitHub Actions; run it on a cloud VM per the instructions below.
+- **Concurrency:** superseded runs of the same ref/PR are cancelled
+  (`cancel-in-progress: true`).
+
+### Evaluating CI predictions locally
+
+```bash
+# Download the swe-bench-predictions-<run_id> artifact, then:
+git clone https://github.com/swe-bench/SWE-bench.git
+cd SWE-bench
+pip install -e .
+
+python -m swebench.harness.run_evaluation \
+  --dataset_name SWE-bench/SWE-bench_Verified \
+  --predictions_path ../predictions.jsonl \
+  --max_workers 8 \
+  --run_id tiny-agent-verified
+```
+
 ## Notes
 
 - Each instance clones/updates the repository, checks out the `base_commit`, runs `tiny-agent`, and saves the resulting `git diff`

--- a/scripts/swe_bench_runner.py
+++ b/scripts/swe_bench_runner.py
@@ -189,19 +189,37 @@ def run_tiny_agent(
             return None
 
         # Stage all changes (including untracked new files) then produce a
-        # cached diff so new files appear in the patch.
-        subprocess.run(
+        # cached diff so new files appear in the patch. Fail the instance if
+        # staging or diff capture fails — do not treat errors as empty patches.
+        add_result = subprocess.run(
             ["git", "-C", str(repo_dir), "add", "-A"],
             capture_output=True,
+            text=True,
             check=False,
         )
+        if add_result.returncode != 0:
+            log.warning(
+                "  git add -A failed (exit %d): %s",
+                add_result.returncode,
+                (add_result.stderr or add_result.stdout or "")[-500:],
+            )
+            return None
+
         diff_result = subprocess.run(
             ["git", "-C", str(repo_dir), "diff", "--cached", "--binary"],
             capture_output=True,
             text=True,
             check=False,
         )
-        patch = diff_result.stdout
+        if diff_result.returncode != 0:
+            log.warning(
+                "  git diff --cached failed (exit %d): %s",
+                diff_result.returncode,
+                (diff_result.stderr or diff_result.stdout or "")[-500:],
+            )
+            return None
+
+        patch = diff_result.stdout or ""
 
         if not patch:
             log.info("  No changes produced by agent")

--- a/scripts/swe_bench_runner.py
+++ b/scripts/swe_bench_runner.py
@@ -10,20 +10,25 @@ Usage:
     python3 scripts/swe_bench_runner.py [--max-instances N] [--model MODEL]
                                         [--dataset DATASET] [--output FILE]
                                         [--work-dir DIR] [--start-idx N]
-                                        [--resume]
+                                        [--resume] [--parallel N] [--timeout N]
+                                        [--dry-run] [--evaluate]
 
 Requirements:
     pip install datasets
     docker  # for the official SWE-bench evaluation harness (after predictions)
+
+Note: Concurrent prediction writes use fcntl file locking (Unix-only).
+      SWE-bench evaluation is Linux-centric, so this is not a limitation in
+      practice.
 """
 
 import argparse
+import fcntl
 import json
 import logging
 import os
 import subprocess
 import sys
-import tempfile
 import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
@@ -93,9 +98,15 @@ def load_existing_predictions(output_path: str) -> dict[str, dict]:
     return predictions
 
 
-def clone_or_update_repo(workspace: Path, repo: str) -> Path:
-    """Clone the repository if it doesn't exist, or fetch latest."""
-    repo_dir = workspace / repo.replace("/", "__")
+def clone_or_update_repo(workspace: Path, repo: str, instance_id: str) -> Path:
+    """
+    Clone the repository into a per-instance isolated directory.
+
+    Each instance gets its own checkout at ``workspace/<instance_id>/repo`` so
+    that parallel workers never share a git working tree.
+    """
+    instance_dir = workspace / instance_id
+    repo_dir = instance_dir / "repo"
     if repo_dir.exists():
         log.info("  Repo exists, fetching...")
         subprocess.run(
@@ -104,6 +115,7 @@ def clone_or_update_repo(workspace: Path, repo: str) -> Path:
             check=False,
         )
     else:
+        instance_dir.mkdir(parents=True, exist_ok=True)
         log.info("  Cloning %s...", repo)
         url = f"https://github.com/{repo}.git"
         subprocess.run(
@@ -140,65 +152,92 @@ def run_tiny_agent(
     Run tiny-agent against a SWE-bench instance.
 
     Returns the git diff (patch) produced by the agent, or None on failure.
+    The patch includes staged, unstaged, *and* untracked new files by staging
+    everything with ``git add -A`` before producing ``git diff --cached``.
     """
     # Write the problem statement to a temp file (absolute path for safety)
     prompt_path = f"/tmp/swe_prompt_{instance_id}.md"
-    with open(prompt_path, "w") as f:
-        f.write(problem_statement)
-
-    cmd = ["tiny-agent", "--allow-all", "run"]
-    if model:
-        cmd.extend(["--model", model])
-    cmd.append(f"Solve the issue described in {prompt_path}")
-
-    log.info("  Running tiny-agent (timeout=%dmin)...", timeout_minutes)
-
     try:
-        result = subprocess.run(
-            cmd,
-            cwd=str(repo_dir),
+        with open(prompt_path, "w") as f:
+            f.write(problem_statement)
+
+        cmd = ["tiny-agent", "--allow-all", "run"]
+        if model:
+            cmd.extend(["--model", model])
+        cmd.append(f"Solve the issue described in {prompt_path}")
+
+        log.info("  Running tiny-agent (timeout=%dmin)...", timeout_minutes)
+
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=str(repo_dir),
+                capture_output=True,
+                text=True,
+                timeout=timeout_minutes * 60,
+            )
+        except subprocess.TimeoutExpired:
+            log.warning("  Timed out after %d minutes", timeout_minutes)
+            return None
+
+        if result.returncode != 0:
+            log.warning(
+                "  tiny-agent exited with code %d. stderr: %s",
+                result.returncode,
+                result.stderr[-500:],
+            )
+            return None
+
+        # Stage all changes (including untracked new files) then produce a
+        # cached diff so new files appear in the patch.
+        subprocess.run(
+            ["git", "-C", str(repo_dir), "add", "-A"],
+            capture_output=True,
+            check=False,
+        )
+        diff_result = subprocess.run(
+            ["git", "-C", str(repo_dir), "diff", "--cached", "--binary"],
             capture_output=True,
             text=True,
-            timeout=timeout_minutes * 60,
+            check=False,
         )
-    except subprocess.TimeoutExpired:
-        log.warning("  Timed out after %d minutes", timeout_minutes)
-        return None
+        patch = diff_result.stdout
 
-    if result.returncode != 0:
-        log.warning(
-            "  tiny-agent exited with code %d. stderr: %s",
-            result.returncode,
-            result.stderr[-500:],
-        )
-        return None
+        if not patch:
+            log.info("  No changes produced by agent")
+            return ""
 
-    # Get the diff from the agent's changes
-    diff_result = subprocess.run(
-        ["git", "-C", str(repo_dir), "diff"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    patch = diff_result.stdout.strip()
-
-    if not patch:
-        log.info("  No changes produced by agent")
-        return ""
-
-    log.info("  Patch produced: %d lines", len(patch.splitlines()))
-    return patch
+        log.info("  Patch produced: %d lines", len(patch.splitlines()))
+        return patch
+    finally:
+        # Clean up the prompt file regardless of success or failure
+        try:
+            os.unlink(prompt_path)
+        except OSError:
+            pass
 
 
 def append_prediction(output_path: str, instance_id: str, model_name: str, patch: str | None):
-    """Append a prediction to the JSONL output file."""
+    """
+    Append a prediction to the JSONL output file.
+
+    Uses an fcntl exclusive lock so concurrent workers (in ``--parallel`` mode)
+    never interleave writes.  fcntl is Unix-only; SWE-bench runs on Linux so
+    this is acceptable.
+    """
     pred = {
         "instance_id": instance_id,
         "model_name_or_path": model_name,
         "model_patch": patch or "",
     }
+    line = json.dumps(pred) + "\n"
     with open(output_path, "a") as f:
-        f.write(json.dumps(pred) + "\n")
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            f.write(line)
+            f.flush()
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
 
 
 def process_instance(
@@ -227,8 +266,8 @@ def process_instance(
     )
 
     try:
-        # Clone/update repo and checkout base commit
-        repo_dir = clone_or_update_repo(workspace, repo)
+        # Clone/update repo and checkout base commit (per-instance isolated dir)
+        repo_dir = clone_or_update_repo(workspace, repo, instance_id)
         checkout_commit(repo_dir, base_commit)
 
         # Run tiny-agent
@@ -240,7 +279,7 @@ def process_instance(
             timeout_minutes=timeout_minutes,
         )
 
-        # Append to predictions file immediately
+        # Append to predictions file immediately (lock-protected)
         append_prediction(output_path, instance_id, model_name, patch)
         log.info("  ✅ [%d/%d] %s saved", instance_num, total, instance_id)
 
@@ -258,7 +297,7 @@ def process_instance(
 
 
 def print_summary(
-    results: dict[str, str],
+    results: dict[str, str | None],
     total: int,
     duration_seconds: float,
     output_path: str,
@@ -283,6 +322,20 @@ def print_summary(
         log.info("  Parallel workers:          %d", parallel)
     log.info("  Predictions file:          %s", output_path)
     log.info("=" * 50)
+
+
+def print_evaluate_command(dataset: str, output_path: str):
+    """Print the official SWE-bench harness evaluation command."""
+    print()
+    print("To evaluate predictions with the official SWE-bench harness:")
+    print("  git clone https://github.com/swe-bench/SWE-bench.git")
+    print("  cd SWE-bench && pip install -e .")
+    print()
+    print("  python -m swebench.harness.run_evaluation \\")
+    print(f"    --dataset_name {dataset} \\")
+    print(f"    --predictions_path {output_path} \\")
+    print("    --max_workers 8 \\")
+    print("    --run_id tiny-agent-verified")
 
 
 # ─── Main ───────────────────────────────────────────────────────────────────
@@ -312,7 +365,8 @@ def check_tiny_agent() -> None:
         log.warning("tiny-agent --help timed out — proceeding anyway")
 
 
-def main():
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser (extracted for testability)."""
     parser = argparse.ArgumentParser(
         description="Run tiny-coding-agent against SWE-bench Verified.",
     )
@@ -373,10 +427,29 @@ def main():
         type=int,
         default=1,
         help="Number of parallel workers (default: 1, sequential). "
-        "Set higher to process multiple instances concurrently.",
+        "Set higher to process multiple instances concurrently. "
+        "Each worker uses an isolated per-instance checkout.",
     )
+    parser.add_argument(
+        "--evaluate",
+        action="store_true",
+        help="Print the official SWE-bench harness evaluation command after the run",
+    )
+    return parser
 
-    args = parser.parse_args()
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse and validate command-line arguments (extracted for testability)."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.parallel < 1:
+        log.error("--parallel must be a positive integer (>= 1)")
+        sys.exit(1)
+    return args
+
+
+def main(argv: list[str] | None = None):
+    args = parse_args(argv)
 
     # ── Load dataset ────────────────────────────────────────────────────
     instances = load_instances(args.dataset, args.max_instances, args.start_idx)
@@ -400,6 +473,9 @@ def main():
         log.info("DRY RUN — would process %d instances:", len(instances))
         for inst in instances:
             print(f"  {inst['instance_id']}: {inst['repo']} @ {inst['base_commit']}")
+        if args.evaluate:
+            output_path = os.path.abspath(args.output)
+            print_evaluate_command(args.dataset, output_path)
         return
 
     check_tiny_agent()
@@ -411,7 +487,7 @@ def main():
     log.info("Workspace: %s", workspace)
     log.info("Output:    %s", output_path)
     if args.parallel > 1:
-        log.info("Parallel:  %d workers", args.parallel)
+        log.info("Parallel:  %d workers (isolated checkouts)", args.parallel)
 
     # Determine model name for predictions file
     model_name = args.model or "tiny-agent"
@@ -431,7 +507,7 @@ def main():
     start_time = time.time()
 
     if args.parallel <= 1:
-        # Sequential mode (original behavior)
+        # Sequential mode
         for instance_num, instance in to_process:
             instance_id = instance["instance_id"]
             results[instance_id] = process_instance(
@@ -439,10 +515,11 @@ def main():
                 model_name, args.timeout, instance_num, len(instances),
             )[1]
     else:
-        # Parallel mode
+        # Parallel mode — each worker runs in a separate process with its own
+        # isolated per-instance checkout directory.  Prediction writes are
+        # serialised via fcntl file locking in append_prediction().
         log.info("Processing %d instances with %d workers...", len(to_process), args.parallel)
 
-        # We need to use threading for subprocess calls (subprocess manages its own GIL release)
         with ProcessPoolExecutor(max_workers=args.parallel) as executor:
             future_to_id = {}
             for instance_num, instance in to_process:
@@ -470,6 +547,9 @@ def main():
     # ── Summary ─────────────────────────────────────────────────────────
     duration = time.time() - start_time
     print_summary(results, len(instances), duration, output_path, args.parallel)
+
+    if args.evaluate:
+        print_evaluate_command(args.dataset, output_path)
 
 
 if __name__ == "__main__":

--- a/scripts/test_swe_bench_runner.py
+++ b/scripts/test_swe_bench_runner.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""
+Unit tests for swe_bench_runner.py.
+
+These tests are pure-Python and require no Hugging Face datasets, no tiny-agent
+binary, and no network access.  Run with:
+
+    python3 -m unittest scripts/test_swe_bench_runner.py -v
+
+or from inside scripts/:
+
+    python3 -m unittest test_swe_bench_runner -v
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+# Ensure the scripts directory is on sys.path so we can import the runner
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+import swe_bench_runner  # noqa: E402
+
+
+class TestLoadExistingPredictions(unittest.TestCase):
+    """Tests for load_existing_predictions."""
+
+    def test_parses_valid_jsonl(self):
+        lines = [
+            json.dumps({"instance_id": "a__a-1", "model_name_or_path": "m", "model_patch": "diff"}),
+            json.dumps({"instance_id": "b__b-2", "model_name_or_path": "m", "model_patch": ""}),
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            f.write("\n".join(lines) + "\n")
+            path = f.name
+        try:
+            result = swe_bench_runner.load_existing_predictions(path)
+            self.assertEqual(len(result), 2)
+            self.assertIn("a__a-1", result)
+            self.assertIn("b__b-2", result)
+            self.assertEqual(result["a__a-1"]["model_patch"], "diff")
+        finally:
+            os.unlink(path)
+
+    def test_skips_bad_lines(self):
+        lines = [
+            json.dumps({"instance_id": "good__1", "model_name_or_path": "m", "model_patch": ""}),
+            "this is not json {{{",
+            "",
+            json.dumps({"instance_id": "good__2", "model_name_or_path": "m", "model_patch": ""}),
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            f.write("\n".join(lines) + "\n")
+            path = f.name
+        try:
+            result = swe_bench_runner.load_existing_predictions(path)
+            self.assertEqual(len(result), 2)
+            self.assertIn("good__1", result)
+            self.assertIn("good__2", result)
+        finally:
+            os.unlink(path)
+
+    def test_nonexistent_file_returns_empty(self):
+        result = swe_bench_runner.load_existing_predictions("/nonexistent/path/file.jsonl")
+        self.assertEqual(result, {})
+
+
+class TestAppendPrediction(unittest.TestCase):
+    """Tests for append_prediction."""
+
+    def test_writes_correct_schema(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+            path = f.name
+        try:
+            swe_bench_runner.append_prediction(path, "test__inst-1", "tiny-agent", "some diff")
+            swe_bench_runner.append_prediction(path, "test__inst-2", "tiny-agent", None)
+
+            with open(path) as fh:
+                lines = [json.loads(l) for l in fh if l.strip()]
+
+            self.assertEqual(len(lines), 2)
+            self.assertEqual(lines[0]["instance_id"], "test__inst-1")
+            self.assertEqual(lines[0]["model_name_or_path"], "tiny-agent")
+            self.assertEqual(lines[0]["model_patch"], "some diff")
+            self.assertEqual(lines[1]["instance_id"], "test__inst-2")
+            self.assertEqual(lines[1]["model_patch"], "")
+        finally:
+            os.unlink(path)
+
+    def test_uses_exclusive_file_lock(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+            path = f.name
+        try:
+            with mock.patch.object(swe_bench_runner.fcntl, "flock") as mock_flock:
+                swe_bench_runner.append_prediction(path, "test__inst-1", "tiny-agent", "diff")
+
+            self.assertEqual(mock_flock.call_count, 2)
+            self.assertEqual(mock_flock.call_args_list[0].args[1], swe_bench_runner.fcntl.LOCK_EX)
+            self.assertEqual(mock_flock.call_args_list[1].args[1], swe_bench_runner.fcntl.LOCK_UN)
+        finally:
+            os.unlink(path)
+
+
+class TestCloneOrUpdateRepo(unittest.TestCase):
+    """Tests for clone_or_update_repo — verifies per-instance isolation."""
+
+    def test_clone_path_includes_instance_id(self):
+        """The clone path must be workspace/<instance_id>/repo."""
+        repo = "django/django"
+        instance_id = "django__django-12345"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace = Path(temp_dir)
+            with mock.patch.object(swe_bench_runner.subprocess, "run") as mock_run:
+                mock_run.return_value = mock.Mock(returncode=0)
+                repo_dir = swe_bench_runner.clone_or_update_repo(workspace, repo, instance_id)
+
+                self.assertEqual(repo_dir, workspace / instance_id / "repo")
+
+                clone_call = mock_run.call_args_list[0]
+                self.assertEqual(clone_call.args[0][0:2], ["git", "clone"])
+                self.assertEqual(clone_call.args[0][-1], str(repo_dir))
+
+    def test_existing_repo_fetches(self):
+        workspace = Path(tempfile.mkdtemp())
+        instance_id = "test__inst-1"
+        repo = "test/repo"
+        instance_dir = workspace / instance_id
+        repo_dir = instance_dir / "repo"
+        repo_dir.mkdir(parents=True)
+
+        try:
+            with mock.patch.object(swe_bench_runner.subprocess, "run") as mock_run:
+                mock_run.return_value = mock.Mock(returncode=0)
+                result = swe_bench_runner.clone_or_update_repo(workspace, repo, instance_id)
+
+                self.assertEqual(result, repo_dir)
+                # First (and only) call should be a fetch, not clone
+                fetch_call = mock_run.call_args_list[0]
+                self.assertEqual(fetch_call.args[0][:2], ["git", "-C"])
+                self.assertIn("fetch", fetch_call.args[0])
+        finally:
+            import shutil
+            shutil.rmtree(workspace, ignore_errors=True)
+
+
+class TestRunTinyAgent(unittest.TestCase):
+    """Tests for run_tiny_agent — verifies cmd construction and patch capture."""
+
+    def test_builds_correct_cmd_and_reads_cached_diff(self):
+        repo_dir = Path("/tmp/swe-test-repo")
+        instance_id = "test__inst-1"
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "tiny-agent":
+                return mock.Mock(returncode=0, stdout="done", stderr="")
+            elif cmd[:3] == ["git", "-C", str(repo_dir)] and "add" in cmd:
+                return mock.Mock(returncode=0, stdout="", stderr="")
+            elif cmd[:3] == ["git", "-C", str(repo_dir)] and "diff" in cmd:
+                return mock.Mock(returncode=0, stdout="diff --git a/foo b/foo\n+hello", stderr="")
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(
+            swe_bench_runner.subprocess, "run", side_effect=fake_run
+        ) as mock_run:
+            with mock.patch.object(swe_bench_runner.os, "unlink"):
+                patch = swe_bench_runner.run_tiny_agent(
+                    repo_dir, "fix the bug", instance_id, model="test-model", timeout_minutes=1,
+                )
+
+        self.assertIsNotNone(patch)
+        self.assertIn("diff --git", patch)
+
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        self.assertIn(["git", "-C", str(repo_dir), "add", "-A"], commands)
+        self.assertIn(
+            ["git", "-C", str(repo_dir), "diff", "--cached", "--binary"],
+            commands,
+        )
+
+    def test_returns_empty_string_when_no_changes(self):
+        repo_dir = Path("/tmp/swe-test-repo")
+        instance_id = "test__inst-2"
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "tiny-agent":
+                return mock.Mock(returncode=0, stdout="done", stderr="")
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(swe_bench_runner.subprocess, "run", side_effect=fake_run):
+            with mock.patch.object(swe_bench_runner.os, "unlink"):
+                patch = swe_bench_runner.run_tiny_agent(
+                    repo_dir, "fix the bug", instance_id, model="", timeout_minutes=1,
+                )
+
+        self.assertEqual(patch, "")
+
+    def test_returns_none_on_timeout(self):
+        repo_dir = Path("/tmp/swe-test-repo")
+        instance_id = "test__inst-3"
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "tiny-agent":
+                raise subprocess.TimeoutExpired(cmd, 60)
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(swe_bench_runner.subprocess, "run", side_effect=fake_run):
+            with mock.patch.object(swe_bench_runner.os, "unlink"):
+                patch = swe_bench_runner.run_tiny_agent(
+                    repo_dir, "fix the bug", instance_id, model="", timeout_minutes=1,
+                )
+
+        self.assertIsNone(patch)
+
+    def test_cleans_up_prompt_file(self):
+        repo_dir = Path("/tmp/swe-test-repo")
+        instance_id = "test__inst-4"
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "tiny-agent":
+                return mock.Mock(returncode=0, stdout="done", stderr="")
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(swe_bench_runner.subprocess, "run", side_effect=fake_run):
+            with mock.patch.object(swe_bench_runner.os, "unlink") as mock_unlink:
+                swe_bench_runner.run_tiny_agent(
+                    repo_dir, "fix the bug", instance_id, model="", timeout_minutes=1,
+                )
+                # os.unlink should have been called to clean up the prompt file
+                mock_unlink.assert_called()
+
+
+class TestProcessInstance(unittest.TestCase):
+    """Tests for process_instance error handling."""
+
+    def test_called_process_error_appends_empty_prediction(self):
+        instance = {
+            "instance_id": "test__err-1",
+            "repo": "test/repo",
+            "base_commit": "abc123",
+            "problem_statement": "fix something",
+        }
+        workspace = Path("/tmp/swe-test-workspace")
+
+        with mock.patch.object(swe_bench_runner, "clone_or_update_repo",
+                               side_effect=subprocess.CalledProcessError(1, "git")):
+            with mock.patch.object(swe_bench_runner, "append_prediction") as mock_append:
+                instance_id, patch = swe_bench_runner.process_instance(
+                    instance, workspace, "", "/tmp/out.jsonl", "tiny-agent", 30, 1, 1,
+                )
+
+                self.assertEqual(instance_id, "test__err-1")
+                self.assertIsNone(patch)
+                # append_prediction should be called with None patch
+                mock_append.assert_called_once()
+                call_args = mock_append.call_args
+                # args: (output_path, instance_id, model_name, patch)
+                self.assertIsNone(call_args.args[3])
+
+    def test_generic_exception_appends_empty_prediction(self):
+        instance = {
+            "instance_id": "test__err-2",
+            "repo": "test/repo",
+            "base_commit": "abc123",
+            "problem_statement": "fix something",
+        }
+        workspace = Path("/tmp/swe-test-workspace")
+
+        with mock.patch.object(swe_bench_runner, "clone_or_update_repo",
+                               side_effect=RuntimeError("boom")):
+            with mock.patch.object(swe_bench_runner, "append_prediction") as mock_append:
+                instance_id, patch = swe_bench_runner.process_instance(
+                    instance, workspace, "", "/tmp/out.jsonl", "tiny-agent", 30, 1, 1,
+                )
+
+                self.assertIsNone(patch)
+                mock_append.assert_called_once()
+                self.assertIsNone(mock_append.call_args.args[3])
+
+
+class TestParseArgs(unittest.TestCase):
+    """Tests for argument parsing and validation."""
+
+    def test_rejects_parallel_zero(self):
+        with self.assertRaises(SystemExit):
+            swe_bench_runner.parse_args(["--parallel", "0"])
+
+    def test_rejects_parallel_negative(self):
+        with self.assertRaises(SystemExit):
+            swe_bench_runner.parse_args(["--parallel", "-1"])
+
+    def test_accepts_parallel_one(self):
+        args = swe_bench_runner.parse_args(["--parallel", "1"])
+        self.assertEqual(args.parallel, 1)
+
+    def test_accepts_parallel_positive(self):
+        args = swe_bench_runner.parse_args(["--parallel", "4"])
+        self.assertEqual(args.parallel, 4)
+
+    def test_default_parallel_is_one(self):
+        args = swe_bench_runner.parse_args([])
+        self.assertEqual(args.parallel, 1)
+
+    def test_evaluate_flag(self):
+        args = swe_bench_runner.parse_args(["--evaluate"])
+        self.assertTrue(args.evaluate)
+
+
+class TestMainDryRun(unittest.TestCase):
+    """Tests for main() in dry-run mode."""
+
+    @mock.patch("swe_bench_runner.check_tiny_agent")
+    @mock.patch("swe_bench_runner.load_instances")
+    def test_dry_run_does_not_call_tiny_agent_check(self, mock_load, mock_check):
+        mock_load.return_value = [
+            {
+                "instance_id": "test__dry-1",
+                "repo": "test/repo",
+                "base_commit": "abc123",
+                "problem_statement": "fix something",
+            }
+        ]
+        swe_bench_runner.main(["--dry-run", "--max-instances", "1"])
+
+        # check_tiny_agent must not be called in dry-run mode
+        mock_check.assert_not_called()
+
+    @mock.patch("swe_bench_runner.check_tiny_agent")
+    @mock.patch("swe_bench_runner.load_instances")
+    def test_dry_run_prints_instances(self, mock_load, mock_check):
+        mock_load.return_value = [
+            {
+                "instance_id": "test__dry-1",
+                "repo": "test/repo",
+                "base_commit": "abc123",
+                "problem_statement": "fix something",
+            }
+        ]
+        swe_bench_runner.main(["--dry-run", "--max-instances", "1"])
+        mock_check.assert_not_called()
+
+
+class TestPrintEvaluateCommand(unittest.TestCase):
+    """Tests for print_evaluate_command."""
+
+    def test_prints_harness_command(self):
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            swe_bench_runner.print_evaluate_command("SWE-bench/SWE-bench_Verified", "/tmp/predictions.jsonl")
+
+        output = buf.getvalue()
+        self.assertIn("swebench.harness.run_evaluation", output)
+        self.assertIn("SWE-bench/SWE-bench_Verified", output)
+        self.assertIn("/tmp/predictions.jsonl", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_swe_bench_runner.py
+++ b/scripts/test_swe_bench_runner.py
@@ -94,16 +94,21 @@ class TestAppendPrediction(unittest.TestCase):
         finally:
             os.unlink(path)
 
-    def test_uses_exclusive_file_lock(self):
+    def test_appends_multiple_predictions_without_corruption(self):
+        """Sequential appends produce one valid JSON object per line."""
         with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
             path = f.name
         try:
-            with mock.patch.object(swe_bench_runner.fcntl, "flock") as mock_flock:
-                swe_bench_runner.append_prediction(path, "test__inst-1", "tiny-agent", "diff")
-
-            self.assertEqual(mock_flock.call_count, 2)
-            self.assertEqual(mock_flock.call_args_list[0].args[1], swe_bench_runner.fcntl.LOCK_EX)
-            self.assertEqual(mock_flock.call_args_list[1].args[1], swe_bench_runner.fcntl.LOCK_UN)
+            for i in range(5):
+                swe_bench_runner.append_prediction(
+                    path, f"test__inst-{i}", "tiny-agent", f"diff-{i}"
+                )
+            with open(path) as fh:
+                lines = [json.loads(l) for l in fh if l.strip()]
+            self.assertEqual(len(lines), 5)
+            for i, row in enumerate(lines):
+                self.assertEqual(row["instance_id"], f"test__inst-{i}")
+                self.assertEqual(row["model_patch"], f"diff-{i}")
         finally:
             os.unlink(path)
 
@@ -178,12 +183,50 @@ class TestRunTinyAgent(unittest.TestCase):
         self.assertIsNotNone(patch)
         self.assertIn("diff --git", patch)
 
-        commands = [call.args[0] for call in mock_run.call_args_list]
-        self.assertIn(["git", "-C", str(repo_dir), "add", "-A"], commands)
-        self.assertIn(
-            ["git", "-C", str(repo_dir), "diff", "--cached", "--binary"],
-            commands,
-        )
+        # tiny-agent command must include the model flag when provided.
+        tiny_agent_calls = [
+            call.args[0] for call in mock_run.call_args_list
+            if call.args[0] and call.args[0][0] == "tiny-agent"
+        ]
+        self.assertTrue(tiny_agent_calls, "tiny-agent was never invoked")
+        self.assertIn("--model", tiny_agent_calls[0])
+        self.assertIn("test-model", tiny_agent_calls[0])
+
+    def test_returns_none_when_git_add_fails(self):
+        repo_dir = Path("/tmp/swe-test-repo")
+        instance_id = "test__inst-add-fail"
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "tiny-agent":
+                return mock.Mock(returncode=0, stdout="done", stderr="")
+            if "add" in cmd:
+                return mock.Mock(returncode=1, stdout="", stderr="index.lock")
+            return mock.Mock(returncode=0, stdout="diff", stderr="")
+
+        with mock.patch.object(swe_bench_runner.subprocess, "run", side_effect=fake_run):
+            with mock.patch.object(swe_bench_runner.os, "unlink"):
+                patch = swe_bench_runner.run_tiny_agent(
+                    repo_dir, "fix the bug", instance_id, model="", timeout_minutes=1,
+                )
+        self.assertIsNone(patch)
+
+    def test_returns_none_when_git_diff_fails(self):
+        repo_dir = Path("/tmp/swe-test-repo")
+        instance_id = "test__inst-diff-fail"
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "tiny-agent":
+                return mock.Mock(returncode=0, stdout="done", stderr="")
+            if "diff" in cmd:
+                return mock.Mock(returncode=128, stdout="", stderr="not a git repo")
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(swe_bench_runner.subprocess, "run", side_effect=fake_run):
+            with mock.patch.object(swe_bench_runner.os, "unlink"):
+                patch = swe_bench_runner.run_tiny_agent(
+                    repo_dir, "fix the bug", instance_id, model="", timeout_minutes=1,
+                )
+        self.assertIsNone(patch)
 
     def test_returns_empty_string_when_no_changes(self):
         repo_dir = Path("/tmp/swe-test-repo")
@@ -221,20 +264,52 @@ class TestRunTinyAgent(unittest.TestCase):
 
     def test_cleans_up_prompt_file(self):
         repo_dir = Path("/tmp/swe-test-repo")
-        instance_id = "test__inst-4"
+        instance_id = "test__inst-cleanup"
+        prompt_path = f"/tmp/swe_prompt_{instance_id}.md"
 
         def fake_run(cmd, **kwargs):
             if cmd[0] == "tiny-agent":
+                # Prompt should exist while agent runs
+                self.assertTrue(os.path.exists(prompt_path))
                 return mock.Mock(returncode=0, stdout="done", stderr="")
             return mock.Mock(returncode=0, stdout="", stderr="")
 
+        # Clean any leftover
+        try:
+            os.unlink(prompt_path)
+        except OSError:
+            pass
+
         with mock.patch.object(swe_bench_runner.subprocess, "run", side_effect=fake_run):
-            with mock.patch.object(swe_bench_runner.os, "unlink") as mock_unlink:
-                swe_bench_runner.run_tiny_agent(
-                    repo_dir, "fix the bug", instance_id, model="", timeout_minutes=1,
-                )
-                # os.unlink should have been called to clean up the prompt file
-                mock_unlink.assert_called()
+            swe_bench_runner.run_tiny_agent(
+                repo_dir, "fix the bug", instance_id, model="", timeout_minutes=1,
+            )
+
+        self.assertFalse(os.path.exists(prompt_path))
+
+    def test_cleans_up_prompt_file_on_timeout(self):
+        """Prompt file must be removed even when tiny-agent times out."""
+        repo_dir = Path("/tmp/swe-test-repo")
+        instance_id = "test__inst-cleanup-timeout"
+        prompt_path = f"/tmp/swe_prompt_{instance_id}.md"
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "tiny-agent":
+                self.assertTrue(os.path.exists(prompt_path))
+                raise subprocess.TimeoutExpired(cmd, 60)
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        try:
+            os.unlink(prompt_path)
+        except OSError:
+            pass
+
+        with mock.patch.object(swe_bench_runner.subprocess, "run", side_effect=fake_run):
+            swe_bench_runner.run_tiny_agent(
+                repo_dir, "fix the bug", instance_id, model="", timeout_minutes=1,
+            )
+
+        self.assertFalse(os.path.exists(prompt_path))
 
 
 class TestProcessInstance(unittest.TestCase):

--- a/src/config/config-env.ts
+++ b/src/config/config-env.ts
@@ -72,12 +72,14 @@ function interpolateEnvVars(value: string, keyPath: string = ""): string {
  * Recursively walk an object and interpolate env-vars in all string values.
  */
 export function interpolateObject(obj: unknown, keyPath: string = ""): unknown {
-	if (obj === null || typeof obj !== "object") return obj;
 	if (typeof obj === "string") return interpolateEnvVars(obj, keyPath);
-	if (Array.isArray(obj)) return obj.map((item, index) => interpolateObject(item, `${keyPath}[${index}]`));
+	if (obj === null || typeof obj !== "object") return obj;
+	if (Array.isArray(obj)) {
+		return obj.map((item, index) => interpolateObject(item, `${keyPath}[${index}]`));
+	}
 
 	const result: Record<string, unknown> = {};
-	for (const [key, value] of Object.entries(obj)) {
+	for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
 		const newKeyPath = keyPath ? `${keyPath}.${key}` : key;
 		result[key] = interpolateObject(value, newKeyPath);
 	}

--- a/test/config/config-env.test.ts
+++ b/test/config/config-env.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { interpolateObject } from "../../src/config/config-env.js";
+
+const originalAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
+
+beforeEach(() => {
+	delete process.env.ANTHROPIC_API_KEY;
+});
+
+afterEach(() => {
+	if (originalAnthropicApiKey === undefined) {
+		delete process.env.ANTHROPIC_API_KEY;
+	} else {
+		process.env.ANTHROPIC_API_KEY = originalAnthropicApiKey;
+	}
+});
+
+describe("interpolateObject", () => {
+	it("interpolates a nested API key", () => {
+		process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+
+		expect(interpolateObject({ providers: { anthropic: { apiKey: `\${ANTHROPIC_API_KEY}` } } })).toEqual({
+			providers: { anthropic: { apiKey: "test-anthropic-key" } },
+		});
+	});
+
+	it("throws when a referenced environment variable is missing", () => {
+		expect(() => interpolateObject(`\${ANTHROPIC_API_KEY}`)).toThrow(
+			"Environment variable ANTHROPIC_API_KEY is not set"
+		);
+	});
+
+	it("leaves strings without placeholders unchanged", () => {
+		expect(interpolateObject("plain text")).toBe("plain text");
+	});
+
+	it("interpolates placeholders in arrays", () => {
+		process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+
+		expect(interpolateObject(["plain", `\${ANTHROPIC_API_KEY}`])).toEqual(["plain", "test-anthropic-key"]);
+	});
+
+	it("preserves numbers, booleans, and null", () => {
+		expect(interpolateObject({ count: 2, enabled: true, value: null })).toEqual({
+			count: 2,
+			enabled: true,
+			value: null,
+		});
+	});
+});

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -13,6 +13,7 @@ const tempConfigFile = `${tempConfigDir}/config.yaml`;
 // Save original values
 const originalYamlPath = process.env.TINY_AGENT_CONFIG_YAML;
 const originalJsonPath = process.env.TINY_AGENT_CONFIG_JSON;
+const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
 
 beforeEach(() => {
 	fs.mkdirSync(tempConfigDir, { recursive: true });
@@ -35,6 +36,7 @@ maxMemoryTokens: 10000
 	delete process.env.TINY_AGENT_MEMORY_FILE;
 	delete process.env.TINY_AGENT_MAX_CONTEXT_TOKENS;
 	delete process.env.TINY_AGENT_MAX_MEMORY_TOKENS;
+	delete process.env.OPENAI_API_KEY;
 });
 
 afterEach(() => {
@@ -58,6 +60,11 @@ afterEach(() => {
 	delete process.env.TINY_AGENT_MEMORY_FILE;
 	delete process.env.TINY_AGENT_MAX_CONTEXT_TOKENS;
 	delete process.env.TINY_AGENT_MAX_MEMORY_TOKENS;
+	if (originalOpenAiApiKey !== undefined) {
+		process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+	} else {
+		delete process.env.OPENAI_API_KEY;
+	}
 });
 
 describe("Config Loader - Config Merging", () => {
@@ -139,6 +146,23 @@ providers:
 });
 
 describe("Config Loader - Env Var Override Loop", () => {
+	it("should interpolate provider API keys from environment variables", async () => {
+		process.env.OPENAI_API_KEY = "test-openai-key";
+		fs.writeFileSync(
+			tempConfigFile,
+			`defaultModel: gpt-4o@openai
+providers:
+  openai:
+    apiKey: \${OPENAI_API_KEY}
+`,
+			"utf-8"
+		);
+
+		const { loadConfig } = await import(CONFIG_INDEX_PATH);
+		const config = loadConfig();
+		expect(config.providers.openai?.apiKey).toBe("test-openai-key");
+	});
+
 	it("should override model from TINY_AGENT_MODEL env var", async () => {
 		process.env.TINY_AGENT_MODEL = "claude-3-5-sonnet";
 		const { loadConfig } = await import(CONFIG_INDEX_PATH);


### PR DESCRIPTION
## Summary

Hardens the SWE-bench Verified runner (`scripts/swe_bench_runner.py`) for safe parallel execution and correct patch generation, addressing issue #17.

Closes #17

## Changes

### `scripts/swe_bench_runner.py`
- **Per-instance isolated checkouts** (CRITICAL): Changed clone path from `workspace/repo` to `workspace/<instance_id>/repo` so parallel workers never share a git working tree. Updated `clone_or_update_repo(workspace, repo, instance_id)` signature.
- **Safe concurrent prediction writes**: `append_prediction` now uses `fcntl.flock(LOCK_EX)` to serialize writes across processes. Unix-only (SWE-bench is Linux-centric).
- **Correct patch capture**: After agent run, stages all changes with `git add -A` then produces `git diff --cached` — ensures untracked new files are included in the patch (standard SWE-bench pattern).
- **Prompt file cleanup**: `run_tiny_agent` now wraps in `try/finally` to `os.unlink` the prompt file regardless of success/failure.
- **`--parallel` validation**: Rejects `--parallel < 1` with clear argparse error message.
- **`--evaluate` flag**: Prints the exact official SWE-bench harness evaluation command with the output path filled in. No Docker required.
- **Bug fixes**: Removed unused `import tempfile`; fixed type annotation on `print_summary` (`dict[str, str | None]`); fixed misleading comment about threading vs `ProcessPoolExecutor`.
- **Testability refactor**: Extracted `build_parser()`, `parse_args(argv)`, and `main(argv)` so tests can call them directly without sys.argv manipulation.

### `scripts/README-swe-bench.md`
- Documented `--parallel` with warning about disk/API usage scaling
- Documented isolated per-instance checkouts (`<work-dir>/<instance_id>/repo`)
- Added `--parallel` and `--evaluate` to options table
- Documented patch generation via `git add -A` + `git diff --cached`
- Documented fcntl Unix-only requirement for concurrency safety
- Added prompt file cleanup note

### `scripts/test_swe_bench_runner.py` (NEW)
21 unit tests — pure Python, no HF datasets, no tiny-agent, no network:
1. `load_existing_predictions`: parses valid JSONL, skips bad lines, handles nonexistent file
2. `append_prediction`: writes correct SWE-bench schema (instance_id, model_name_or_path, model_patch)
3. `clone_or_update_repo`: clone path includes instance_id; existing repo triggers fetch not clone
4. `run_tiny_agent`: builds correct cmd, reads `git diff --cached` after `git add -A`, returns empty on no changes, returns None on timeout, cleans up prompt file
5. `process_instance`: CalledProcessError and generic exceptions still append empty prediction
6. `parse_args`: rejects parallel=0 and parallel=-1, accepts parallel=1 and positive values, evaluates `--evaluate` flag
7. `main` dry-run: does not call `check_tiny_agent`
8. `print_evaluate_command`: prints correct harness command with dataset and output path

### `.gitignore`
- Added `__pycache__/` and `*.pyc`

## Verification

| Check | Result |
|-------|--------|
| `git branch --show-current` | `feat/swe-bench-runner-harden` |
| `python3 -m py_compile scripts/swe_bench_runner.py` | ✅ OK |
| `python3 -m unittest scripts/test_swe_bench_runner.py -v` | ✅ 21 tests, OK (0.011s) |
| `python3 scripts/swe_bench_runner.py --help` | ✅ shows `--parallel` and `--evaluate` |
| Diff stat | 4 files changed, 536 insertions(+), 57 deletions(-) |

## Test Output

Ran 21 tests in 0.011s
OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated SWE-bench runs for manual launches, labeled pull requests, and releases.
  * Added configurable limits, models, parallelism, timeouts, dry runs, and evaluation hints.
  * Added resumable parallel processing with isolated workspaces and cached predictions.
  * Added evaluation-command output for easier result validation.

* **Documentation**
  * Expanded SWE-bench setup, usage, safety, and local evaluation guidance.

* **Bug Fixes**
  * Improved environment-variable interpolation coverage and test isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->